### PR TITLE
feat(number-field) - add number field 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@hey-api/client-fetch": "^0.8.1",
+        "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/themes": "^3.2.0",
+        "react-currency-input-field": "^3.10.0",
         "type-fest": "^4.35.0"
       },
       "devDependencies": {
@@ -3626,6 +3628,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-currency-input-field": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-currency-input-field/-/react-currency-input-field-3.10.0.tgz",
+      "integrity": "sha512-GRmZogHh1e1LrmgXg/fKHSuRLYUnj/c/AumfvfuDMA0UX1mDR6u2NR0fzDemRdq4tNHNLucJeJ2OKCr3ehqyDA==",
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@hey-api/client-fetch": "^0.8.1",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/themes": "^3.2.0",
+    "react-currency-input-field": "^3.10.0",
     "type-fest": "^4.35.0"
   },
   "devDependencies": {

--- a/src/flows/Demo.tsx
+++ b/src/flows/Demo.tsx
@@ -3,8 +3,8 @@ import { Select } from '../ui/Select';
 import { Theme } from '@radix-ui/themes';
 import { SelectCountries } from '../ui/SelectCountries';
 import { SVGSprite } from '../ui/SVGSprite';
-import '@radix-ui/themes/styles.css';
 import { CurrencyInput } from '../ui/CurrencyInput';
+import '@radix-ui/themes/styles.css';
 
 export const Demo = () => {
   const [value, setValue] = useState('dragon');

--- a/src/flows/Demo.tsx
+++ b/src/flows/Demo.tsx
@@ -4,10 +4,12 @@ import { Theme } from '@radix-ui/themes';
 import { SelectCountries } from '../ui/SelectCountries';
 import { SVGSprite } from '../ui/SVGSprite';
 import '@radix-ui/themes/styles.css';
+import { CurrencyInput } from '../ui/CurrencyInput';
 
 export const Demo = () => {
   const [value, setValue] = useState('dragon');
   const [selectedCountry, setSelectedCountry] = useState('');
+  const [annualSalary, setAnnualSalary] = useState('');
   const options = [
     { label: 'Dragon', value: 'dragon' },
     { label: 'Phoenix', value: 'phoenix' },
@@ -19,6 +21,10 @@ export const Demo = () => {
     { label: 'Canada', value: 'ca' },
     { label: 'Mexico', value: 'mx' },
   ];
+
+  const onChangeSalary = (value?: string) => {
+    setAnnualSalary(value || '');
+  };
 
   return (
     <Theme>
@@ -39,6 +45,15 @@ export const Demo = () => {
         placeholder="Select your country..."
         name="spirit-animal"
         label="Select your country"
+      />
+
+      <CurrencyInput
+        value={annualSalary}
+        label="Employee's annual salary"
+        name="salary"
+        locale={'US-en'}
+        inputMode={'decimal'}
+        onChange={onChangeSalary}
       />
     </Theme>
   );

--- a/src/ui/CurrencyInput.css
+++ b/src/ui/CurrencyInput.css
@@ -1,0 +1,17 @@
+@import './css/primitives.css';
+
+.rmt-CurrencyInput {
+  box-sizing: border-box;
+  display: flex;
+  padding: var(--rmt-input-padding);
+  border: 1px solid var(--rmt-input-border-color);
+  border-radius: var(--rmt-border-radius-md);
+  font-size: var(--rmt-font-size-md);
+  color: var(--rmt-text-color);
+  min-height: var(--rmt-input-min-height);
+}
+
+.rmt-CurrencyInput:hover {
+  border-color: var(--rmt-primary-color);
+  box-shadow: var(--rmt-primary-color) 0px 0px 0px 1px;
+}

--- a/src/ui/CurrencyInput.tsx
+++ b/src/ui/CurrencyInput.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactCurrencyInput from 'react-currency-input-field';
+import type { CurrencyInputProps as ReactCurrencyInputProps } from 'react-currency-input-field';
+import { FormGroup, FormGroupProps } from './FormGroup';
+
+type CurrencyInputProps = Omit<FormGroupProps, 'children'> & {
+  locale: string;
+  placeholder?: string;
+  inputMode: 'decimal' | 'numeric';
+  value: string;
+  onChange: ReactCurrencyInputProps['onValueChange'];
+};
+
+export const CurrencyInput = ({
+  label,
+  name,
+  id,
+  description,
+  locale,
+  placeholder,
+  onChange,
+  inputMode,
+  value,
+  ...props
+}: CurrencyInputProps) => {
+  return (
+    <FormGroup label={label} name={name} id={id} description={description}>
+      <ReactCurrencyInput
+        {...props}
+        intlConfig={{ locale }}
+        placeholder={(label as string) || placeholder}
+        onValueChange={onChange}
+        // NOTE: iOS selects the decimal separator for the `decimal` keyboard based on system language.
+        // Since we use `en-US` locale this can prevent users from being able to enter floating-point numbers.
+        inputMode={inputMode}
+        // NOTE: This component uses `Intl.NumberFormat` under the hood which causes
+        // rounding errors for very, very large numbers in the UI.
+        maxLength={15}
+        lang={locale}
+        decimalSeparator="."
+        groupSeparator=","
+        value={value}
+      />
+    </FormGroup>
+  );
+};

--- a/src/ui/CurrencyInput.tsx
+++ b/src/ui/CurrencyInput.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactCurrencyInput from 'react-currency-input-field';
 import type { CurrencyInputProps as ReactCurrencyInputProps } from 'react-currency-input-field';
 import { FormGroup, FormGroupProps } from './FormGroup';
+import './CurrencyInput.css';
 
 type CurrencyInputProps = Omit<FormGroupProps, 'children'> & {
   locale: string;
@@ -40,6 +41,7 @@ export const CurrencyInput = ({
         decimalSeparator="."
         groupSeparator=","
         value={value}
+        className="rmt-CurrencyInput"
       />
     </FormGroup>
   );

--- a/src/ui/Select.css
+++ b/src/ui/Select.css
@@ -1,8 +1,6 @@
 @import './css/primitives.css';
 
 :root {
-  --rmt-select-trigger-padding: 8px 16px;
-  --rmt-select-trigger-min-height: 44px;
   --rmt-select-arrow-size: 1rem;
   --rmt-select-content-padding: 0;
   --rmt-select-item-active: #e3e9ef;
@@ -17,11 +15,12 @@
 .rmt-SelectTrigger {
   display: flex;
   width: 100%;
-  font-size: var(--rmt-font-size-md);
+  font-size: var(--rmt-font-size-sm);
   color: var(--rmt-text-color);
   border-radius: var(--rmt-border-radius-md);
-  padding: var(--rmt-select-trigger-padding);
-  min-height: var(--rmt-select-trigger-min-height);
+  border: 1px solid var(--rmt-input-border-color);
+  padding: var(--rmt-input-padding);
+  min-height: var(--rmt-input-min-height);
 }
 
 .rmt-SelectTrigger:hover {

--- a/src/ui/css/primitives.css
+++ b/src/ui/css/primitives.css
@@ -4,4 +4,10 @@
   --rmt-font-size-md: 1rem;
   --rmt-primary-color: #0061ff;
   --rmt-text-color: #0f1419;
+
+  /* Forms */
+
+  --rmt-input-padding: 8px 16px;
+  --rmt-input-border-color: #9aa6b2;
+  --rmt-input-min-height: 44px;
 }


### PR DESCRIPTION
## Overview

I built a CurrencyInput that we can use that let us format for example the input introduced

## Implementation decisions

I added the react-currency-input-field to format the input, the input it's a normal input where you can give classes, it will be easily customizable

## How to use


I run a viteapp linking the dependency

```
 "react": "^18.0.0",
 "react-dom": "^18.0.0",
 "@remoteoss/remote-flows": "file:../remote-flows"
```

in the App.tsx

```
import { Demo } from '@remoteoss/remote-flows/flows/Demo'

import './App.css'

function App() {

  return (
    <>
      <Demo />
    </>
  )
}

export default App


````

In the App.css, had problems with the css, I was changing lines and didn't work, to make it work I find that the relative import did the trick

```
@import "../node_modules/@remoteoss/remote-flows/dist/flows/Demo.css";
```


The only thing different that I have set up in the vitejs app is

```
import { defineConfig } from 'vite'
import react from '@vitejs/plugin-react-swc'
import path from 'path';

// https://vite.dev/config/
export default defineConfig({
  plugins: [react()],
  resolve: {
    alias: {
      react: path.resolve('./node_modules/react'),
    },
  },
})
```

I am aliasing react to avoid having an error about two react copies


## Demo
![image](https://github.com/user-attachments/assets/0bf2486f-f645-44be-908f-3aedf9fc42c0)




