### PR TITLE
feat(cost-calculator) - implement endpoints with react-query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@remoteoss/remote-flows": "file:../remote-flows",
         "@tailwindcss/cli": "^4.0.9",
         "@tailwindcss/postcss": "^4.0.9",
+        "@tanstack/react-query": "^5.67.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "0.477.0",
@@ -2132,6 +2133,30 @@
         "lightningcss": "^1.29.1",
         "postcss": "^8.4.41",
         "tailwindcss": "4.0.9"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.2.tgz",
+      "integrity": "sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.2.tgz",
+      "integrity": "sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==",
+      "dependencies": {
+        "@tanstack/query-core": "5.67.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "@remoteoss/json-schema-form": "0.11.10-beta.0",
-        "@remoteoss/remote-flows": "file:../remote-flows",
         "@tailwindcss/cli": "^4.0.9",
         "@tailwindcss/postcss": "^4.0.9",
         "@tanstack/react-query": "^5.67.2",
@@ -1639,10 +1638,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@remoteoss/remote-flows": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.34.8",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@remoteoss/remote-flows": "file:../remote-flows",
     "@tailwindcss/cli": "^4.0.9",
     "@tailwindcss/postcss": "^4.0.9",
+    "@tanstack/react-query": "^5.67.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "0.477.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@remoteoss/json-schema-form": "0.11.10-beta.0",
-    "@remoteoss/remote-flows": "file:../remote-flows",
     "@tailwindcss/cli": "^4.0.9",
     "@tailwindcss/postcss": "^4.0.9",
     "@tanstack/react-query": "^5.67.2",

--- a/src/RemoteFlowsProvider.tsx
+++ b/src/RemoteFlowsProvider.tsx
@@ -43,8 +43,10 @@ export function RemoteFlows({
   );
 
   return (
-    <RemoteFlowContext.Provider value={{ client: remoteApiClient.current }}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </RemoteFlowContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      <RemoteFlowContext.Provider value={{ client: remoteApiClient.current }}>
+        {children}
+      </RemoteFlowContext.Provider>
+    </QueryClientProvider>
   );
 }

--- a/src/RemoteFlowsProvider.tsx
+++ b/src/RemoteFlowsProvider.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 import { Client, createClient } from '@hey-api/client-fetch';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { RemoteFlowsSDKProps } from './types';
 import { client } from './client/client.gen';
@@ -9,6 +10,8 @@ import { BaseTokenResponse } from './client';
 const RemoteFlowContext = createContext<{ client: Client | null }>({
   client: null,
 });
+
+const queryClient = new QueryClient();
 
 export const useClient = () => useContext(RemoteFlowContext);
 
@@ -41,7 +44,7 @@ export function RemoteFlows({
 
   return (
     <RemoteFlowContext.Provider value={{ client: remoteApiClient.current }}>
-      {children}
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </RemoteFlowContext.Provider>
   );
 }

--- a/src/flows/CostCalculator.tsx
+++ b/src/flows/CostCalculator.tsx
@@ -165,7 +165,6 @@ export function CostCalculator({ onSubmit }: Props) {
 
   useEffect(() => {
     if (selectedCountry) {
-      console.log({ selectedCountry });
       if (
         selectedCountry?.childRegions.length === 0 &&
         selectedCountry.hasAdditionalFields

--- a/src/flows/CostCalculator.tsx
+++ b/src/flows/CostCalculator.tsx
@@ -45,7 +45,6 @@ export function CostCalculator({ onSubmit }: Props) {
     validationSchema,
     handleJSONSchemaValidation,
   );
-  const [regionSlug, setRegionSlug] = useState<string | null>(null);
   const form = useForm<FormValues>({
     resolver: resolver,
     defaultValues: {
@@ -57,12 +56,13 @@ export function CostCalculator({ onSubmit }: Props) {
     mode: 'onBlur',
   });
   const selectedCountryForm = form.watch('country');
-  const selectedRegion = form.watch('region');
+  console.log({ region: form.watch('region') });
+  const [regionSlug, setRegionSlug] = useState<string | null>(null);
 
   const { data: currencies = [] } = useCompanyCurrencies();
   const { data: countries = [] } = useCalculatorCountries();
   const { data: jsonSchemaRegionFields } =
-    useCalculatorLoadRegionFieldsSchemaForm(regionSlug);
+    useCalculatorLoadRegionFieldsSchemaForm(form.watch('region') || regionSlug);
   const mutation = useCalculatorEstimation();
 
   const selectedCountry = useMemo(() => {
@@ -96,12 +96,6 @@ export function CostCalculator({ onSubmit }: Props) {
       }
     }
   }, [selectedCountry, countries]);
-
-  useEffect(() => {
-    if (selectedRegion) {
-      setRegionSlug(selectedRegion);
-    }
-  }, [selectedRegion]);
 
   const handleSubmit = (values: FormValues) => {
     const regionSlug = values.region

--- a/src/flows/CostCalculator.tsx
+++ b/src/flows/CostCalculator.tsx
@@ -124,7 +124,7 @@ type FormValues = InferType<typeof validationSchema> & {
 };
 
 type Props = {
-  onSubmit: (data: CostCalculatorEstimateResponse | undefined) => void;
+  onSubmit: (data: CostCalculatorEstimateResponse) => void;
 };
 
 export function CostCalculator({ onSubmit }: Props) {
@@ -223,7 +223,9 @@ export function CostCalculator({ onSubmit }: Props) {
 
     mutation.mutate(payload, {
       onSuccess: (data) => {
-        onSubmit(data.data);
+        if (data?.data) {
+          onSubmit(data.data);
+        }
       },
       onError: (error) => {
         console.error(error);

--- a/src/flows/CostCalculator.tsx
+++ b/src/flows/CostCalculator.tsx
@@ -11,7 +11,6 @@ import {
 import type {
   CostCalculatorEstimateResponse,
   EmploymentTermType,
-  GetIndexCountryResponse,
   MinimalRegion,
 } from '../client';
 import { useForm } from 'react-hook-form';
@@ -54,6 +53,24 @@ const useCalculatorCountries = () => {
   });
 };
 
+const useCompanyCurrencies = () => {
+  const { client } = useClient();
+
+  return useQuery({
+    queryKey: ['company-currencies'],
+    queryFn: () => {
+      return getIndexCompanyCurrency({
+        client: client as Client,
+        headers: {
+          Authorization: ``,
+        },
+      });
+    },
+    enabled: !!client,
+    select: (data) => data.data?.data?.company_currencies,
+  });
+};
+
 const validationSchema = object({
   country: string().required('Country is required'),
   currency: string().required('Currency is required'),
@@ -92,8 +109,7 @@ export function CostCalculator({ onSubmit }: Props) {
   const selectedRegion = form.watch('region');
 
   const [regions, setRegions] = useState<MinimalRegion[]>([]);
-
-  const [currencies, setCurrencies] = React.useState<any>([]);
+  const { data: currencies = [] } = useCompanyCurrencies();
   const { data: countries = [] } = useCalculatorCountries();
 
   const optionsRegions = regions.map((region) => ({
@@ -152,25 +168,6 @@ export function CostCalculator({ onSubmit }: Props) {
       loadJsonForm(selectedRegion);
     }
   }, [selectedRegion]);
-
-  useEffect(() => {
-    if (client) {
-      getIndexCompanyCurrency({
-        client: client,
-        headers: {
-          Authorization: ``,
-        },
-      })
-        .then((res) => {
-          if (res.data?.data) {
-            setCurrencies(res.data?.data.company_currencies);
-          }
-        })
-        .catch((err) => {
-          console.error(err);
-        });
-    }
-  }, []);
 
   const findSlugInCountry = (countryCode: string) => {
     const country = countries?.find((c) => c.value === countryCode);

--- a/src/flows/hooks.ts
+++ b/src/flows/hooks.ts
@@ -1,0 +1,97 @@
+import {
+  CostCalculatorEstimateParams,
+  getIndexCompanyCurrency,
+  getIndexCountry,
+  getShowRegionField,
+  postCreateEstimation,
+} from '@/src/client';
+import { useClient } from '@/src/RemoteFlowsProvider';
+import { Client } from '@hey-api/client-fetch';
+import { createHeadlessForm } from '@remoteoss/json-schema-form';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+export const useCalculatorCountries = () => {
+  const { client } = useClient();
+
+  return useQuery({
+    queryKey: ['cost-calculator-countries'],
+    queryFn: () => {
+      return getIndexCountry({
+        client: client as Client,
+        headers: {
+          Authorization: ``,
+        },
+      });
+    },
+    enabled: !!client,
+    select: (data) =>
+      data.data?.data.map((country) => ({
+        value: country.code,
+        label: country.name,
+        childRegions: country.child_regions,
+        hasAdditionalFields: country.has_additional_fields,
+        regionSlug: country.region_slug,
+      })),
+  });
+};
+
+export const useCalculatorLoadRegionFieldsSchemaForm = (
+  regionSlug: string | null,
+) => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['cost-calculator-region-fields', regionSlug],
+    queryFn: () => {
+      return getShowRegionField({
+        client: client as Client,
+        headers: {
+          Authorization: ``,
+        },
+        path: { slug: regionSlug as string },
+      });
+    },
+    enabled: !!client && !!regionSlug,
+    select: (data) =>
+      createHeadlessForm(data?.data?.data?.schema || {}, {
+        strictInputType: false,
+      }),
+  });
+};
+
+export const useCompanyCurrencies = () => {
+  const { client } = useClient();
+
+  return useQuery({
+    queryKey: ['company-currencies'],
+    queryFn: () => {
+      return getIndexCompanyCurrency({
+        client: client as Client,
+        headers: {
+          Authorization: ``,
+        },
+      });
+    },
+    enabled: !!client,
+    select: (data) =>
+      data.data?.data?.company_currencies.map((currency) => ({
+        value: currency.slug,
+        label: currency.code,
+      })),
+  });
+};
+
+export const useCalculatorEstimation = () => {
+  const { client } = useClient();
+
+  return useMutation({
+    mutationFn: (payload: CostCalculatorEstimateParams) => {
+      return postCreateEstimation({
+        client: client as Client,
+        headers: {
+          Authorization: ``,
+        },
+        body: payload,
+      });
+    },
+  });
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import './styles/global.css';
 
-// @TODO: Only for testing purposes. It should be removed when CostCalculator is ready
-export { SelectField } from '@/src/components/form/fields/SelectField';
 export { RemoteFlows } from '@/src/RemoteFlowsProvider';
 export { ThemeProvider } from '@/src/theme';
+export * from './client/types.gen';


### PR DESCRIPTION
## Overview

Implemented the cost calculator flow using react-query. I implemented the thing with ReactQueryProvider inserted in the RemoteFlows provider.

Haven't tested yet what happens with multiple providers in the page, but according to ChatGPT it should work


## How to test

in the App.tsx

```
import { useState } from "react";
import { RemoteFlows } from "@remoteoss/remote-flows";
import { CostCalculator } from "@remoteoss/remote-flows/flows/CostCalculator";
import "./App.css";

const ACCESS_TOKENS = {
  PARTNER: "<PARTNER_TOKEN>",
  NEW_COMPANY: "<COMPANY_TOKEN>",
};

function App() {
  const [estimations, setEstimations] = useState(null);
  return (
    <RemoteFlows
      auth={() =>
        Promise.resolve({
          expires_in: 3600,
          access_token: ACCESS_TOKENS.PARTNER,
        })
      }
    >
      <CostCalculator onSubmit={(response) => setEstimations(response)} />
      {estimations && <pre>{JSON.stringify(estimations, null, 2)}</pre>}
    </RemoteFlows>
  );
}

export default App;



````

In the App.css

```
@import "@remoteoss/remote-flows/index.css";
```


My vite.config.ts

```
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react-swc";
import path from "path";

// https://vite.dev/config/
export default defineConfig({
  plugins: [react()],
  resolve: {
    alias: {
      react: path.resolve("./node_modules/react"),
    },
  },
  server: {
    proxy: {
      "/api": {
        target: "https://gateway.niceremote.com",
        changeOrigin: true,
        rewrite: (path) => path.replace(/^\/api/, ""),
      },
    },
  },
});

```

I am aliasing react to avoid having an error about two react copies
