### PR TITLE
fix(json-schema) - bring back validation from json-schema #17

### DIFF
--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -22,6 +22,7 @@ import {
   useCostCalculatorCountries,
   useCostCalculatorEstimation,
 } from '@/src/flows/CostCalculator/hooks';
+import { json } from 'stream/consumers';
 
 const validationSchema = object({
   country: string().required('Country is required'),
@@ -126,6 +127,9 @@ export function CostCalculator({
   const { data: countries = [] } = useCostCalculatorCountries();
   const { data: jsonSchemaRegionFields } =
     useCalculatorLoadRegionFieldsSchemaForm(form.control);
+
+  handleJSONSchemaValidation.current =
+    jsonSchemaRegionFields?.handleValidation ?? null;
 
   const costCalculatorEstimationMutation = useCostCalculatorEstimation();
 

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -22,7 +22,6 @@ import {
   useCostCalculatorCountries,
   useCostCalculatorEstimation,
 } from '@/src/flows/CostCalculator/hooks';
-import { json } from 'stream/consumers';
 
 const validationSchema = object({
   country: string().required('Country is required'),


### PR DESCRIPTION
We removed the useEffect and forgot to assign the ref after we retrieve data from the region/:slug/fields schema