### PR TITLE
feat(disclaimer) - add disclaimer to the cost calculator

### DIFF
--- a/example/src/App.css
+++ b/example/src/App.css
@@ -1,1 +1,48 @@
 @import '@remoteoss/remote-flows/index.css';
+
+.cost-calculator-disclaimer-drawer-body {
+  padding: 16px;
+
+  h3 {
+    font-family: Arial, sans-serif;
+    font-size: 1.5em;
+    font-weight: bold;
+    color: #004d99;
+    border-bottom: 2px solid #e0e0e0;
+    padding-bottom: 10px;
+    margin-bottom: 15px;
+  }
+
+  /* Style for all p tags */
+  p {
+    font-family: Arial, sans-serif;
+    font-size: 1em;
+    line-height: 1.6;
+    margin-bottom: 15px;
+    color: #555;
+  }
+
+  /* Style for all strong tags */
+  strong {
+    font-weight: bold;
+  }
+
+  /* Style for all a tags */
+  a {
+    color: #0073e6;
+    text-decoration: none;
+  }
+
+  /* Hover effect for links */
+  a:hover {
+    text-decoration: underline;
+  }
+
+  /* Style for any paragraph after the last h3 (for the 'Note' section) */
+  h3 + p {
+    background-color: #f9f9f9;
+    padding: 15px;
+    border-left: 4px solid #ffcc00;
+    font-style: italic;
+  }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -54,6 +54,11 @@ function CostCalculatorForm() {
           currencySlug: 'eur-acf7d6b5-654a-449f-873f-aca61a280eba',
           salary: '50000',
         }}
+        params={{
+          disclaimer: {
+            label: 'Remote Disclaimer',
+          },
+        }}
         onSubmit={(payload) => setPayload(payload)}
         onError={(error) => console.error({ error })}
         onSuccess={(response) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hey-api/client-fetch": "^0.8.1",
         "@hookform/resolvers": "^4.1.3",
+        "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-radio-group": "^1.2.3",
         "@radix-ui/react-select": "^2.1.6",
@@ -31,6 +32,7 @@
         "tailwindcss": "^4.0.9",
         "tailwindcss-animate": "^1.0.7",
         "type-fest": "^4.35.0",
+        "vaul": "^1.1.2",
         "yup": "^0.32.0",
         "zod": "^3.24.2"
       },
@@ -1438,6 +1440,41 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -6079,6 +6116,18 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/victory-vendor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-radio-group": "^1.2.3",
+        "@radix-ui/react-scroll-area": "^1.2.3",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
@@ -1740,6 +1741,36 @@
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.3.tgz",
+      "integrity": "sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@hey-api/client-fetch": "^0.8.1",
     "@hookform/resolvers": "^4.1.3",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-select": "^2.1.6",
@@ -67,6 +68,7 @@
     "tailwindcss": "^4.0.9",
     "tailwindcss-animate": "^1.0.7",
     "type-fest": "^4.35.0",
+    "vaul": "^1.1.2",
     "yup": "^0.32.0",
     "zod": "^3.24.2"
   },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-radio-group": "^1.2.3",
+    "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "tailwindcss-animate": "^1.0.7",
     "type-fest": "^4.35.0",
     "vaul": "^1.1.2",
-    "yup": "^0.32.0",
-    "zod": "^3.24.2"
+    "yup": "^0.32.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary-foreground underline-offset-4 hover:underline button-link',
+        link: 'text-link-button-primary underline-offset-4 hover:underline button-link',
       },
       size: {
         default: 'h-9 px-4 py-7 has-[>svg]:px-3',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,13 +18,14 @@ const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+        link: 'text-primary-foreground underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-9 px-4 py-7 has-[>svg]:px-3',
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',
+        link: 'px-0',
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary-foreground underline-offset-4 hover:underline',
+        link: 'text-primary-foreground underline-offset-4 hover:underline button-link',
       },
       size: {
         default: 'h-9 px-4 py-7 has-[>svg]:px-3',

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/src/lib/utils';
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = 'Drawer';
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/80', className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = 'DrawerContent';
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = 'DrawerHeader';
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = 'DrawerFooter';
+
+const DrawerTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+
+import { cn } from '@/src/lib/utils';
+
+const ScrollArea = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn('relative overflow-hidden', className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none transition-colors',
+      orientation === 'vertical' &&
+        'h-full w-2.5 border-l border-l-transparent p-[1px]',
+      orientation === 'horizontal' &&
+        'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -60,6 +60,11 @@ type CostCalculatorProps = Partial<{
      */
     salary: string;
   }>;
+  params: Partial<{
+    disclaimer: {
+      label: string;
+    };
+  }>;
   /**
    * Callback function to handle the form submission. When the submit button is clicked, the payload is sent back to you.
    * @param data - The payload sent to the /cost-calculator/estimation endpoint.
@@ -88,6 +93,7 @@ export function CostCalculator({
     currencySlug: '',
     salary: '',
   },
+  params,
   onSubmit,
   onError,
   onSuccess,
@@ -144,7 +150,6 @@ export function CostCalculator({
 
   return (
     <>
-      <Disclaimer />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
           <JSONSchemaFormFields fields={fields} />
@@ -156,6 +161,9 @@ export function CostCalculator({
           </Button>
         </form>
       </Form>
+      <div className="cost-calculator-disclaimer-wrapper">
+        <Disclaimer label={params?.disclaimer?.label} />
+      </div>
     </>
   );
 }

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -13,6 +13,7 @@ import { useValidationFormResolver } from '@/src/components/form/yupValidationRe
 import { Button } from '@/src/components/ui/button';
 import { useCostCalculator } from '@/src/flows/CostCalculator/hooks';
 import { convertToCents } from '@/src/lib/utils';
+import { Disclaimer } from '@/src/flows/CostCalculator/Disclaimer';
 
 type FormValues = {
   currency: string;
@@ -143,6 +144,7 @@ export function CostCalculator({
 
   return (
     <>
+      <Disclaimer />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
           <JSONSchemaFormFields fields={fields} />

--- a/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
+++ b/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import clsx from 'clsx';
 import {
   Drawer,
   DrawerClose,
@@ -9,17 +8,22 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '@/src/components/ui/drawer';
+import { ScrollArea } from '@/src/components/ui/scroll-area';
 import { X } from 'lucide-react';
 import { Button } from '@/src/components/ui/button';
 import { useCostCalculatorDisclaimer } from '@/src/flows/CostCalculator/hooks';
 
-export const Disclaimer = () => {
+type DisclaimerProps = {
+  label?: string;
+};
+
+export const Disclaimer = ({ label = 'Disclaimer' }: DisclaimerProps) => {
   const { data: disclaimer } = useCostCalculatorDisclaimer();
   return (
     <Drawer>
       <DrawerTrigger asChild>
         <Button variant="link" size="link">
-          Disclaimer
+          {label}
         </Button>
       </DrawerTrigger>
       <DrawerContent>
@@ -42,10 +46,12 @@ export const Disclaimer = () => {
             </Button>
           </DrawerDescription>
         </DrawerHeader>
-        <div
-          className={clsx('p-4 cost-calculator-disclaimer-drawer-body')}
-          dangerouslySetInnerHTML={{ __html: disclaimer?.data.body ?? '' }}
-        ></div>
+        <ScrollArea className="px-4 pb-4 overflow-y-auto max-h-[calc(80vh-120px)] cost-calculator-disclaimer-drawer-scroll-area">
+          <div
+            className={'cost-calculator-disclaimer-drawer-body'}
+            dangerouslySetInnerHTML={{ __html: disclaimer?.data.body ?? '' }}
+          ></div>
+        </ScrollArea>
       </DrawerContent>
     </Drawer>
   );

--- a/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
+++ b/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/src/components/ui/drawer';
+import { X } from 'lucide-react';
+import { Button } from '@/src/components/ui/button';
+import { useCostCalculatorDisclaimer } from '@/src/flows/CostCalculator/hooks';
+
+type DisclaimerProps = {
+  disclaimerDrawerClass?: string;
+};
+
+export const Disclaimer = ({ disclaimerDrawerClass }: DisclaimerProps) => {
+  const { data: disclaimer } = useCostCalculatorDisclaimer();
+  return (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button variant="link" size="link">
+          Disclaimer
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DrawerClose>
+          <DrawerTitle>{disclaimer?.data.title}</DrawerTitle>
+          <DrawerDescription>
+            For more details read our{' '}
+            <Button variant="link" size="link" asChild>
+              <a
+                href={disclaimer?.data.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Disclaimer
+              </a>
+            </Button>
+          </DrawerDescription>
+        </DrawerHeader>
+        <div
+          className={clsx(
+            'p-4 cost-calculator-disclaimer-drawer-body',
+            disclaimerDrawerClass,
+          )}
+          dangerouslySetInnerHTML={{ __html: disclaimer?.data.body ?? '' }}
+        ></div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
+++ b/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
@@ -13,11 +13,7 @@ import { X } from 'lucide-react';
 import { Button } from '@/src/components/ui/button';
 import { useCostCalculatorDisclaimer } from '@/src/flows/CostCalculator/hooks';
 
-type DisclaimerProps = {
-  disclaimerDrawerClass?: string;
-};
-
-export const Disclaimer = ({ disclaimerDrawerClass }: DisclaimerProps) => {
+export const Disclaimer = () => {
   const { data: disclaimer } = useCostCalculatorDisclaimer();
   return (
     <Drawer>
@@ -47,10 +43,7 @@ export const Disclaimer = ({ disclaimerDrawerClass }: DisclaimerProps) => {
           </DrawerDescription>
         </DrawerHeader>
         <div
-          className={clsx(
-            'p-4 cost-calculator-disclaimer-drawer-body',
-            disclaimerDrawerClass,
-          )}
+          className={clsx('p-4 cost-calculator-disclaimer-drawer-body')}
           dangerouslySetInnerHTML={{ __html: disclaimer?.data.body ?? '' }}
         ></div>
       </DrawerContent>

--- a/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
+++ b/src/flows/CostCalculator/Disclaimer/Disclaimer.tsx
@@ -48,7 +48,7 @@ export const Disclaimer = ({ label = 'Disclaimer' }: DisclaimerProps) => {
         </DrawerHeader>
         <ScrollArea className="px-4 pb-4 overflow-y-auto max-h-[calc(80vh-120px)] cost-calculator-disclaimer-drawer-scroll-area">
           <div
-            className={'cost-calculator-disclaimer-drawer-body'}
+            className="cost-calculator-disclaimer-drawer-body"
             dangerouslySetInnerHTML={{ __html: disclaimer?.data.body ?? '' }}
           ></div>
         </ScrollArea>

--- a/src/flows/CostCalculator/Disclaimer/index.ts
+++ b/src/flows/CostCalculator/Disclaimer/index.ts
@@ -1,0 +1,1 @@
+export * from './Disclaimer';

--- a/src/flows/CostCalculator/hooks.ts
+++ b/src/flows/CostCalculator/hooks.ts
@@ -271,3 +271,28 @@ export const useCostCalculator = (): BaseHookReturn<
     onSubmit,
   };
 };
+
+/**
+ * Custom hook to fetch disclaimer information.
+ *
+ * This hooks returns the disclaimer html content.
+ *
+ * @returns {object} - The query object containing the disclaimer data.
+ */
+export const useCostCalculatorDisclaimer = () => {
+  const disclaimerData = {
+    data: {
+      id: 4668194326797,
+      title: 'Disclaimer information on Cost of Employment calculations',
+      body: '<h3 id="h_01HHJFVR5Q4F8A52F06EVG289R">Remote disclaimer</h3>\n<p>The estimate provides a transparent detailed breakdown for in-country statutory social contributions, statutory benefits, and other benefits that may be required. Estimates do not take into account additional costs that may be incurred for relocation, visa, right-to-work requirements, or other activities. </p>\n<p><strong>See also:</strong> <a href="https://support.remote.com/hc/en-us/articles/22329255813133">What other type of costs does the Cost Calculator not include?</a></p>\n<h3 id="h_01HHJFVYRAAGDKJ36EZS8W6P5N">EOR services</h3>\n<p>Our EOR services allow you to retain ownership of your employees\' IP and inventions. Compliance, taxes, and payroll are handled by our local teams for a seamless end-to-end experience.</p>\n<h3 id="h_01HHJFW4FQPGPK14FSM4XCY5MR">Pricing and payroll</h3>\n<p>When it comes to payroll, legal and operational complexities are reduced to a single invoice for all of your Remote employees across every country you hire in – no hidden costs and no long-term commitments needed. Just a simple pricing structure that includes a fixed hiring fee for each EOR employee.</p>\n<h3 id="01JMCR2YZ0GVTCXNPY88TADWQ1">Currency conversions</h3>\n<p>When the employee currency differs from the billing currency, we use market rates to convert. The rate figures on this quote are a rough estimate. When the employee currency differs from the billing currency, we use market rates to convert. The rate figures on this quote are a rough estimated.</p>\n<h3 id="h_01HHJFWD1TFB5DQ6B4WD5F1GY6">Employee off-boarding related costs</h3>\n<p>The estimate here does not include any costs related to off-boarding of employees. Whilst we do not charge any processing fees when you want to off-board an employee, any other costs such as severance pay, covering remaining vacation days and etc will be charged back to you.<br><strong>See also: </strong><a href="https://support.remote.com/hc/en-us/articles/22329371247885">Are the costs of employee off-boarding included in the Cost Calculator?</a></p>\n<p>Please note the ‘employee net income estimate’ section (if available for the country) is intended for informational purposes only and should not be used as a substitute for professional financial advice.</p>\n<p>Additionally, tax laws and rates can vary by location and are subject to change, which may not be immediately reflected in the calculator.</p>\n<p>For a detailed and accurate assessment of your take-home pay, please consult with a qualified tax professional or financial advisor.</p>\n<p><strong>See also</strong>: <a href="https://support.remote.com/hc/en-us/articles/25196498469773">How to use the ‘employee net income estimate’ section in the Cost Calculator?</a></p>\n<p><!-- notionvc: 04d0e276-e0d7-4793-93ee-d4ad14600217 --></p>\n<h3 id="h_01HHJFWTHJ58YAZ87M3E090H4J">Note</h3>\n<p>This estimate is for guidance only and may not constitute accurate financial advice. Information contained in this document is subject to changes in laws in different jurisdictions, which can change without notice. This document is the property of Remote, is confidential, cannot be reproduced without permission, and cannot be disclosed to any third parties.</p>\n<p><!-- notionvc: 09e777b4-c10c-438e-bb95-ce1f3fb86c9a --></p>',
+      html_url:
+        'https://support.remote.com/hc/en-us/articles/4668194326797-Disclaimer-information-on-Cost-of-Employment-calculations',
+    },
+  };
+  return useQuery({
+    queryKey: ['cost-calculator-disclaimer'],
+    queryFn: () => {
+      return Promise.resolve(disclaimerData);
+    },
+  });
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,14 @@
+/* eslint-disable react-refresh/only-export-components */
 import './styles/global.css';
 
 export {
   CostCalculator,
   CostCalculatorResults,
 } from '@/src/flows/CostCalculator';
-// eslint-disable-next-line react-refresh/only-export-components
-export { useCostCalculatorEstimationPdf } from '@/src/flows/CostCalculator/hooks';
+export {
+  useCostCalculatorEstimationPdf,
+  useCostCalculatorDisclaimer,
+} from '@/src/flows/CostCalculator/hooks';
 export { RemoteFlows } from '@/src/RemoteFlowsProvider';
 export { ThemeProvider } from '@/src/theme';
-// eslint-disable-next-line react-refresh/only-export-components
 export * from './client/types.gen';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,6 +25,7 @@
   --radius: var(--borderRadius, 0.625rem);
   --focused: var(--borderRadius, #0061ff);
   --fontBase: var(--fontSizeBase, 1rem);
+  --link-button: var(--foreground, #4b5865);
 }
 
 @theme inline {
@@ -51,6 +52,7 @@
   --color-focused: var(--focused);
   --color-badge: var(--badge);
   --color-badge-foreground: var(--badge-foreground);
+  --color-link-button-primary: var(--link-button);
   --color-radio: var(--radio);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);


### PR DESCRIPTION
## Overview

Implemented a disclaimer component that is rendered inside the cost calculator, we also offer a hook, that way partners can rely on the data and be more opinionated about the styles.

## Implementation details
In the example folder, I added some css on how one can style the drawer.

Add new dependencies from shadcn to load drawers.


## How to use
In the root folder run, nothing changed here

```
 npm run dev
```

after that 

create a .env file inside /example

```
CLIENT_ID=<CLIENT_ID>
CLIENT_SECRET=<CLIENT_ID>
REMOTE_GATEWAY=<STAGING_GATEWAY>
```


```

cd example
npm run dev
```

Open localhost:3001 and the app should work

![image](https://github.com/user-attachments/assets/9dfc611e-ca9f-4f6f-8000-f0606421c936)


