### PR TITLE
docs(cost-calculator) - throw errors correctly

### DIFF
--- a/src/flows/CostCalculator/hooks.ts
+++ b/src/flows/CostCalculator/hooks.ts
@@ -11,7 +11,7 @@ import {
 import type { BaseHookReturn, Field } from '@/src/flows/CostCalculator/types';
 import { useClient } from '@/src/RemoteFlowsProvider';
 import { Client } from '@hey-api/client-fetch';
-import { createHeadlessForm } from '@remoteoss/json-schema-form';
+import { $TSFixMe, createHeadlessForm } from '@remoteoss/json-schema-form';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { AnyObjectSchema, object, string } from 'yup';
@@ -185,6 +185,13 @@ export const useCostCalculator = (): BaseHookReturn<
     values: CostCalculatorEstimateParams,
   ): Promise<CostCalculatorEstimateResponse | null> {
     const response = await costCalculatorEstimationMutation.mutateAsync(values);
+    if (
+      response.error &&
+      response.response.status >= 400 &&
+      response.response.status < 600
+    ) {
+      throw new Error((response.error as $TSFixMe).message);
+    }
     if (response.data) {
       return response.data;
     }

--- a/src/flows/CostCalculator/tests/CostCalculator.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculator.test.tsx
@@ -91,21 +91,20 @@ describe('CostCalculator', () => {
     });
   });
 
-  // test('calls onSuccess when estimation succeeds', async () => {
-  //   render(<CostCalculator {...defaultProps} />, { wrapper });
+  test('calls onError when estimation fails', async () => {
+    server.use(
+      http.post('*/v1/cost-calculator/estimation', () => {
+        return new HttpResponse('Not found', { status: 404 });
+      }),
+    );
+    render(<CostCalculator {...defaultProps} />, { wrapper });
 
-  //   fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
-  //   await waitFor(() => {
-  //     expect(mockOnSuccess).toHaveBeenCalledWith({
-  //       data: {
-  //         employments: [],
-  //       },
-  //     });
-  //   });
-  // });
-
-  test('calls onError when estimation fails', async () => {});
+    await waitFor(() => {
+      expect(mockOnError).toHaveBeenCalled();
+    });
+  });
 
   test('displays validation errors when form is submitted with empty fields', async () => {});
 });


### PR DESCRIPTION
I was adding the test for the onError and I notice that the code wasn't executing correctly.

It seems like @hey-client/api doesn't throw and instead offers a response with {error, request, response}

What I did is whenever it returns a status code error, throw the error to make the CostCalculator component to catch it and emit the error with onError callback

