### PR TITLE
fix(cost-calculator) - load region fields if a country has them

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -50,7 +50,7 @@ function CostCalculatorForm() {
       <CostCalculator
         estimationParams={estimationParams}
         defaultValues={{
-          countryRegionSlug: 'a1aea868-0e0a-4cd7-9b73-9941d92e5bbe',
+          countryRegionSlug: 'bf098ccf-7457-4556-b2a8-80c48f67cca4',
           currencySlug: 'eur-acf7d6b5-654a-449f-873f-aca61a280eba',
           salary: '50000',
         }}

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -95,7 +95,9 @@ export function CostCalculator({
     onSubmit: submitCostCalculator,
     fields,
     validationSchema,
-  } = useCostCalculator();
+  } = useCostCalculator({
+    countryRegionSlug: defaultValues.countryRegionSlug,
+  });
 
   const resolver = useValidationFormResolver(validationSchema);
   const form = useForm<FormValues>({

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -96,7 +96,7 @@ export function CostCalculator({
     fields,
     validationSchema,
   } = useCostCalculator({
-    countryRegionSlug: defaultValues.countryRegionSlug,
+    defaultRegion: defaultValues.countryRegionSlug,
   });
 
   const resolver = useValidationFormResolver(validationSchema);

--- a/src/flows/CostCalculator/hooks.ts
+++ b/src/flows/CostCalculator/hooks.ts
@@ -161,14 +161,14 @@ function buildValidationSchema(fields: Field[]) {
 }
 
 type UseCostCalculatorParams = {
-  countryRegionSlug?: string;
+  defaultRegion?: string;
 };
 
 /**
  * Hook to use the cost calculator.
  */
 export const useCostCalculator = ({
-  countryRegionSlug,
+  defaultRegion,
 }: UseCostCalculatorParams = {}): BaseHookReturn<
   CostCalculatorEstimateParams,
   CostCalculatorEstimateResponse
@@ -180,7 +180,7 @@ export const useCostCalculator = ({
   const { data: currencies } = useCompanyCurrencies();
 
   const jsonSchemaRegionSlug =
-    selectedRegion || selectedCountry?.value || countryRegionSlug;
+    selectedRegion || selectedCountry?.value || defaultRegion;
 
   const { data: jsonSchemaRegionFields } =
     useRegionFields(jsonSchemaRegionSlug);

--- a/src/flows/CostCalculator/hooks.ts
+++ b/src/flows/CostCalculator/hooks.ts
@@ -160,10 +160,16 @@ function buildValidationSchema(fields: Field[]) {
   return object(fieldsSchema) as AnyObjectSchema;
 }
 
+type UseCostCalculatorParams = {
+  countryRegionSlug?: string;
+};
+
 /**
  * Hook to use the cost calculator.
  */
-export const useCostCalculator = (): BaseHookReturn<
+export const useCostCalculator = ({
+  countryRegionSlug,
+}: UseCostCalculatorParams = {}): BaseHookReturn<
   CostCalculatorEstimateParams,
   CostCalculatorEstimateResponse
 > => {
@@ -172,9 +178,12 @@ export const useCostCalculator = (): BaseHookReturn<
     useState<CostCalculatorCountry>();
   const { data: countries } = useCostCalculatorCountries();
   const { data: currencies } = useCompanyCurrencies();
-  const { data: jsonSchemaRegionFields } = useRegionFields(
-    selectedRegion || selectedCountry?.value,
-  );
+
+  const jsonSchemaRegionSlug =
+    selectedRegion || selectedCountry?.value || countryRegionSlug;
+
+  const { data: jsonSchemaRegionFields } =
+    useRegionFields(jsonSchemaRegionSlug);
   const costCalculatorEstimationMutation = useCostCalculatorEstimation();
 
   /**
@@ -260,6 +269,7 @@ export const useCostCalculator = (): BaseHookReturn<
     ...fields,
     ...(jsonSchemaRegionFields?.fields || []),
   ] as Field[];
+
   const validationSchema = buildValidationSchema(allFields);
 
   return {

--- a/src/flows/CostCalculator/tests/CostCalculator.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculator.test.tsx
@@ -5,7 +5,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React, { PropsWithChildren } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { countries, currencies, estimation, regionFields } from './fixtures';
+import {
+  countries,
+  currencies,
+  estimation,
+  regionFields,
+  regionFieldsWithAgeProperty,
+} from './fixtures';
 
 const queryClient = new QueryClient();
 
@@ -114,5 +120,22 @@ describe('CostCalculator', () => {
     await waitFor(() => {
       expect(screen.getByText(/salary is required/i)).toBeInTheDocument();
     });
+  });
+
+  test("loads the form with dynamic fields from json schema based on the selected country's region", async () => {
+    server.use(
+      http.get('*/v1/cost-calculator/regions/*/fields', () => {
+        return HttpResponse.json(regionFieldsWithAgeProperty);
+      }),
+    );
+
+    render(<CostCalculator {...defaultProps} />, {
+      wrapper,
+    });
+
+    const inputElement = await screen.findByRole('textbox', {
+      name: /age/i,
+    });
+    expect(inputElement).toBeInTheDocument();
   });
 });

--- a/src/flows/CostCalculator/tests/fixtures.ts
+++ b/src/flows/CostCalculator/tests/fixtures.ts
@@ -50,6 +50,29 @@ export const regionFields = {
   },
 };
 
+export const regionFieldsWithAgeProperty = {
+  data: {
+    version: 7,
+    schema: {
+      additionalProperties: false,
+      properties: {
+        age: {
+          description: 'The age of the employee, eg. 30',
+          minimum: 0,
+          title: 'Age',
+          type: 'number',
+          'x-jsf-presentation': {
+            inputType: 'number',
+          },
+        },
+      },
+      required: ['age'],
+      type: 'object',
+      'x-jsf-order': ['age'],
+    },
+  },
+};
+
 export const estimation = {
   data: {
     employments: [],


### PR DESCRIPTION
I noticed when you set a country with defaultValues that had region fields like Japan, the JSON schema wasn't getting fetched.

I fixed it and add some tests as I discovered this problem when I was doing some.

![image](https://github.com/user-attachments/assets/46352377-f1ba-42fa-abc6-0dcc90895675)


