### PR TITLE
chore(useCostCalculator): Move form validation to onSubmit

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,22 +1,24 @@
-import { useState } from 'react';
-import {
+import type {
   CostCalculatorEstimateResponse,
-  RemoteFlows,
+  CostCalculatorEstimationFormValues,
+} from '@remoteoss/remote-flows';
+import {
+  buildCostCalculatorEstimationPayload,
   CostCalculator,
   CostCalculatorResults,
+  RemoteFlows,
   useCostCalculatorEstimationPdf,
-  CostCalculatorEstimateParams,
 } from '@remoteoss/remote-flows';
+import { useState } from 'react';
 import './App.css';
 
 function CostCalculatorForm() {
   const [estimations, setEstimations] =
     useState<CostCalculatorEstimateResponse | null>(null);
-  const [payload, setPayload] = useState<CostCalculatorEstimateParams | null>(
-    null,
-  );
+  const [payload, setPayload] =
+    useState<CostCalculatorEstimationFormValues | null>(null);
 
-  const estimationParams = {
+  const estimationOptions = {
     title: 'Estimate for a new company',
     includeBenefits: true,
     includeCostBreakdowns: true,
@@ -26,7 +28,7 @@ function CostCalculatorForm() {
 
   const handleExportPdf = () => {
     if (payload) {
-      exportPdfMutation.mutate(payload, {
+      exportPdfMutation.mutate(buildCostCalculatorEstimationPayload(payload), {
         onSuccess: (response) => {
           if (response?.data?.data?.content !== undefined) {
             const a = document.createElement('a');
@@ -48,7 +50,7 @@ function CostCalculatorForm() {
   return (
     <>
       <CostCalculator
-        estimationParams={estimationParams}
+        estimationOptions={estimationOptions}
         defaultValues={{
           countryRegionSlug: 'a1aea868-0e0a-4cd7-9b73-9941d92e5bbe',
           currencySlug: 'eur-acf7d6b5-654a-449f-873f-aca61a280eba',

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -1,48 +1,27 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 
-import type {
-  CostCalculatorEstimateParams,
-  CostCalculatorEstimateResponse,
-  EmploymentTermType,
-} from '@/src/client';
+import type { CostCalculatorEstimateResponse } from '@/src/client';
 import { Form } from '@/src/components/ui/form';
 
 import { JSONSchemaFormFields } from '@/src/components/form/JSONSchemaForm';
 import { useValidationFormResolver } from '@/src/components/form/yupValidationResolver';
 import { Button } from '@/src/components/ui/button';
 import { Disclaimer } from '@/src/flows/CostCalculator/Disclaimer';
-import { useCostCalculator } from '@/src/flows/CostCalculator/hooks';
-import { convertToCents } from '@/src/lib/utils';
-
-type FormValues = {
-  currency: string;
-  country: string;
-  salary: string;
-} & Partial<{
-  region: string;
-  age: number;
-  contract_duration_type: EmploymentTermType;
-}>;
+import {
+  defaultEstimationOptions,
+  useCostCalculator,
+} from '@/src/flows/CostCalculator/hooks';
+import {
+  CostCalculatorEstimateFormValues,
+  CostCalculatorEstimationOptions,
+} from './types';
 
 type CostCalculatorProps = Partial<{
   /**
    * Estimation params allows you to customize the parameters sent to the /cost-calculator/estimation endpoint.
    */
-  estimationParams: Partial<{
-    /**
-     * Title of the estimation. Default is 'Estimation'.
-     */
-    title: string;
-    /**
-     * Include benefits in the estimation. Default is false.
-     */
-    includeBenefits: boolean;
-    /**
-     * Include cost breakdowns in the estimation. Default is false.
-     */
-    includeCostBreakdowns: boolean;
-  }>;
+  estimationOptions?: CostCalculatorEstimationOptions;
   /**
    * Default values for the form fields.
    */
@@ -66,10 +45,10 @@ type CostCalculatorProps = Partial<{
     };
   }>;
   /**
-   * Callback function to handle the form submission. When the submit button is clicked, the payload is sent back to you.
+   * Callback function that handles form submission. When form is submit, the form values are sent to the consumer app before behind submitted to Remote.
    * @param data - The payload sent to the /cost-calculator/estimation endpoint.
    */
-  onSubmit: (data: CostCalculatorEstimateParams) => Promise<void> | void;
+  onSubmit: (data: CostCalculatorEstimateFormValues) => Promise<void> | void;
   /**
    * Callback function to handle the success when the estimation succeeds. The CostCalculatorEstimateResponse is sent back to you.
    * @param data - The response data from the /cost-calculator/estimation endpoint.
@@ -83,11 +62,7 @@ type CostCalculatorProps = Partial<{
 }>;
 
 export function CostCalculator({
-  estimationParams = {
-    title: 'Estimation',
-    includeBenefits: false,
-    includeCostBreakdowns: false,
-  },
+  estimationOptions = defaultEstimationOptions,
   defaultValues = {
     countryRegionSlug: '',
     currencySlug: '',
@@ -102,10 +77,10 @@ export function CostCalculator({
     onSubmit: submitCostCalculator,
     fields,
     validationSchema,
-  } = useCostCalculator();
+  } = useCostCalculator(estimationOptions);
 
   const resolver = useValidationFormResolver(validationSchema);
-  const form = useForm<FormValues>({
+  const form = useForm<CostCalculatorEstimateFormValues>({
     resolver: resolver,
     defaultValues: {
       country: defaultValues?.countryRegionSlug,
@@ -116,35 +91,15 @@ export function CostCalculator({
     mode: 'onBlur',
   });
 
-  const handleSubmit = async (values: FormValues) => {
-    const payload = {
-      employer_currency_slug: values.currency,
-      include_benefits: estimationParams.includeBenefits,
-      include_cost_breakdowns: estimationParams.includeCostBreakdowns,
-      employments: [
-        {
-          region_slug: values.region || values.country,
-          annual_gross_salary: convertToCents(values.salary),
-          annual_gross_salary_in_employer_currency: convertToCents(
-            values.salary,
-          ),
-          employment_term: values.contract_duration_type ?? 'fixed',
-          title: estimationParams.title,
-          regional_to_employer_exchange_rate: '1',
-          age: values.age ?? undefined,
-        },
-      ],
-    };
+  const handleSubmit = async (values: CostCalculatorEstimateFormValues) => {
+    await onSubmit?.(values);
 
-    await onSubmit?.(payload);
+    const estimation = await submitCostCalculator(values);
 
-    try {
-      const estimation = await submitCostCalculator(payload);
-      if (estimation) {
-        onSuccess?.(estimation);
-      }
-    } catch (error) {
-      onError?.(error as Error);
+    if (estimation.error) {
+      onError?.(estimation.error);
+    } else {
+      onSuccess?.(estimation.data);
     }
   };
 

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -12,8 +12,9 @@ import {
   defaultEstimationOptions,
   useCostCalculator,
 } from '@/src/flows/CostCalculator/hooks';
-import {
-  CostCalculatorEstimateFormValues,
+
+import type {
+  CostCalculatorEstimationFormValues,
   CostCalculatorEstimationOptions,
 } from './types';
 
@@ -48,7 +49,7 @@ type CostCalculatorProps = Partial<{
    * Callback function that handles form submission. When form is submit, the form values are sent to the consumer app before behind submitted to Remote.
    * @param data - The payload sent to the /cost-calculator/estimation endpoint.
    */
-  onSubmit: (data: CostCalculatorEstimateFormValues) => Promise<void> | void;
+  onSubmit: (data: CostCalculatorEstimationFormValues) => Promise<void> | void;
   /**
    * Callback function to handle the success when the estimation succeeds. The CostCalculatorEstimateResponse is sent back to you.
    * @param data - The response data from the /cost-calculator/estimation endpoint.
@@ -80,7 +81,7 @@ export function CostCalculator({
   } = useCostCalculator(estimationOptions);
 
   const resolver = useValidationFormResolver(validationSchema);
-  const form = useForm<CostCalculatorEstimateFormValues>({
+  const form = useForm<CostCalculatorEstimationFormValues>({
     resolver: resolver,
     defaultValues: {
       country: defaultValues?.countryRegionSlug,
@@ -91,7 +92,7 @@ export function CostCalculator({
     mode: 'onBlur',
   });
 
-  const handleSubmit = async (values: CostCalculatorEstimateFormValues) => {
+  const handleSubmit = async (values: CostCalculatorEstimationFormValues) => {
     await onSubmit?.(values);
 
     const estimation = await submitCostCalculator(values);

--- a/src/flows/CostCalculator/index.ts
+++ b/src/flows/CostCalculator/index.ts
@@ -1,3 +1,9 @@
 export { CostCalculator } from './CostCalculator';
+export {
+  useCostCalculator,
+  useCostCalculatorDisclaimer,
+  useCostCalculatorEstimationPdf,
+} from './hooks';
+
 export { CostCalculatorResults } from './Results/CostCalculatorResults';
-export { useCostCalculator, useCostCalculatorEstimationPdf } from './hooks';
+export { buildPayload as buildCostCalculatorEstimationPayload } from './utils';

--- a/src/flows/CostCalculator/tests/CostCalculator.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculator.test.tsx
@@ -73,20 +73,10 @@ describe('CostCalculator', () => {
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
-        employer_currency_slug: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
-        include_benefits: false,
-        include_cost_breakdowns: false,
-        employments: [
-          {
-            region_slug: 'POL',
-            annual_gross_salary: 5000000,
-            annual_gross_salary_in_employer_currency: 5000000,
-            employment_term: 'fixed',
-            title: 'Estimation',
-            regional_to_employer_exchange_rate: '1',
-            age: undefined,
-          },
-        ],
+        country: 'POL',
+        currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
+        region: '',
+        salary: '50000',
       });
     });
   });

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -1,4 +1,14 @@
-import { AnyObjectSchema } from 'yup';
+import type { EmploymentTermType } from '@/src/client';
+
+export type CostCalculatorEstimateFormValues = {
+  currency: string;
+  country: string;
+  salary: string;
+} & Partial<{
+  region: string;
+  age: number;
+  contract_duration_type: EmploymentTermType;
+}>;
 
 export type Field = {
   name: string;
@@ -35,14 +45,17 @@ export type Field = {
   [key: string]: unknown;
 };
 
-export type BaseHookReturn<TFormParams extends object, TResponse> = {
-  stepState: {
-    current: number;
-    total: number;
-    isLastStep: boolean;
-  };
-  fields: Field[];
-  validationSchema: AnyObjectSchema;
-  handleValidation?: (values: Record<string, unknown>) => void;
-  onSubmit: (values: TFormParams) => Promise<TResponse | null>;
-};
+export type CostCalculatorEstimationOptions = Partial<{
+  /**
+   * Title of the estimation. Default is 'Estimation'.
+   */
+  title: string;
+  /**
+   * Include benefits in the estimation. Default is false.
+   */
+  includeBenefits: boolean;
+  /**
+   * Include cost breakdowns in the estimation. Default is false.
+   */
+  includeCostBreakdowns: boolean;
+}>;

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -1,6 +1,6 @@
 import type { EmploymentTermType } from '@/src/client';
 
-export type CostCalculatorEstimateFormValues = {
+export type CostCalculatorEstimationFormValues = {
   currency: string;
   country: string;
   salary: string;

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -1,0 +1,53 @@
+import { AnyObjectSchema, object } from 'yup';
+
+import type { CostCalculatorEstimateParams } from '@/src/client';
+import { convertToCents } from '@/src/lib/utils';
+import { defaultEstimationOptions } from './hooks';
+import type {
+  CostCalculatorEstimationFormValues,
+  CostCalculatorEstimationOptions,
+  Field,
+} from './types';
+
+/**
+ * Build the validation schema for the form.
+ * @returns
+ */
+export function buildValidationSchema(fields: Field[]) {
+  const fieldsSchema = fields.reduce<Record<string, AnyObjectSchema>>(
+    (fieldsSchemaAcc, field) => {
+      fieldsSchemaAcc[field.name] = field.schema as AnyObjectSchema;
+      return fieldsSchemaAcc;
+    },
+    {},
+  );
+  return object(fieldsSchema) as AnyObjectSchema;
+}
+
+/**
+ * Build the payload for the cost calculator estimation.
+ * @param values
+ * @param estimationOptions
+ * @returns
+ */
+export function buildPayload(
+  values: CostCalculatorEstimationFormValues,
+  estimationOptions: CostCalculatorEstimationOptions = defaultEstimationOptions,
+): CostCalculatorEstimateParams {
+  return {
+    employer_currency_slug: values.currency,
+    include_benefits: estimationOptions.includeBenefits,
+    include_cost_breakdowns: estimationOptions.includeCostBreakdowns,
+    employments: [
+      {
+        region_slug: values.region || values.country,
+        annual_gross_salary: convertToCents(values.salary),
+        annual_gross_salary_in_employer_currency: convertToCents(values.salary),
+        employment_term: values.contract_duration_type ?? 'fixed',
+        title: estimationOptions.title,
+        regional_to_employer_exchange_rate: '1',
+        age: values.age ?? undefined,
+      },
+    ],
+  };
+}

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -1,0 +1,11 @@
+type Success<T> = {
+  data: T;
+  error: null;
+};
+
+type Failure<E> = {
+  data: null;
+  error: E;
+};
+
+export type Result<T, E = Error> = Success<T> | Failure<E>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,9 +5,14 @@ export {
   CostCalculator,
   CostCalculatorResults,
 } from '@/src/flows/CostCalculator';
+
 export {
-  useCostCalculatorEstimationPdf,
   useCostCalculatorDisclaimer,
+  useCostCalculatorEstimationPdf,
 } from '@/src/flows/CostCalculator/hooks';
+
+export { transformYupErrorsIntoObject } from '@/src/lib/utils';
+
 export { RemoteFlows } from '@/src/RemoteFlowsProvider';
+
 export * from './client/types.gen';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,14 @@
 import './styles/global.css';
 
 export {
+  buildCostCalculatorEstimationPayload,
   CostCalculator,
   CostCalculatorResults,
-} from '@/src/flows/CostCalculator';
-
-export {
   useCostCalculatorDisclaimer,
   useCostCalculatorEstimationPdf,
-} from '@/src/flows/CostCalculator/hooks';
+} from '@/src/flows/CostCalculator';
+
+export type * from '@/src/flows/CostCalculator/types';
 
 export { transformYupErrorsIntoObject } from '@/src/lib/utils';
 


### PR DESCRIPTION
`onSubmit` function in `useCostCalculator` should validate form fields before posting the estimation to Remote API. 
If partners use `useCostCalculator` directly they might not have a validation in place, so this change ensures that fields validation is always executed before sending the request.

Beside including the validation, this PR also changes the `onSubmit` parameters. The hook should be responsible for formatting the request payload, not the component.