### PR TITLE
feat(CostCalculator): support isLoading and isSubmitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,35 @@ A component to display cost calculation results.
 | ---------------- | ------------------------------------ | -------- | ---------------------------- |
 | `employmentData` | `CostCalculatorEstimateResponseData` | Yes      | The estimation response data |
 
+### useCostCalculator
+
+The `useCostCalculator` hook provides access to the underlying functionality of the cost calculator, allowing for custom implementations.
+
+| Property           | Type                                                                                                               | Description                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `stepState`        | `{ current: number; total: number; isLastStep: boolean }`                                                          | Information about the current step in multi-step forms                                                                   |
+| `fields`           | `Field[]`                                                                                                          | Array of form field definitions with metadata ([json-schema-form](https://github.com/remoteoss/json-schema-form) format) |
+| `validationSchema` | `yup.Schema`                                                                                                       | Yup validation schema for the form                                                                                       |
+| `handleValidation` | `Function`                                                                                                         | Function to handle custom field validation                                                                               |
+| `isSubmitting`     | `boolean`                                                                                                          | Whether the form is currently submitting                                                                                 |
+| `isLoading`        | `boolean`                                                                                                          | Whether any required data is still loading                                                                               |
+| `onSubmit`         | `(values: CostCalculatorEstimationFormValues) => Promise<Result<CostCalculatorEstimateResponse, EstimationError>>` | Function to submit the form data to the Remote API                                                                       |
+
+#### Parameters
+
+| Parameter           | Type                              | Required | Description                                                                                    |
+| ------------------- | --------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `defaultRegion`     | `string`                          | No       | Pre-selected region slug                                                                       |
+| `estimationOptions` | `CostCalculatorEstimationOptions` | Yes      | Options for the cost estimation (same as `estimationParams` in the `CostCalculator` component) |
+
+The `estimationOptions` object has the following properties:
+
+| Property                | Type      | Description                                                  |
+| ----------------------- | --------- | ------------------------------------------------------------ |
+| `title`                 | `string`  | Custom title for the estimation report                       |
+| `includeBenefits`       | `boolean` | If `true`, includes benefits information in the response     |
+| `includeCostBreakdowns` | `boolean` | If `true`, includes detailed cost breakdowns in the response |
+
 ## Authentication
 
 You need to implement a server endpoint to securely handle authentication with Remote. This prevents exposing client credentials in your frontend code.

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -1,5 +1,8 @@
 @import '@remoteoss/remote-flows/index.css';
 
+.cost-calculator__container {
+  padding: 100px;
+}
 .cost-calculator-disclaimer-drawer-body {
   padding: 16px;
 

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -3,6 +3,11 @@
 .cost-calculator__container {
   padding: 100px;
 }
+
+.cost-calculator__results {
+  margin-top: 64px;
+}
+
 .cost-calculator-disclaimer-drawer-body {
   padding: 16px;
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,16 +51,6 @@ function CostCalculatorForm() {
     <>
       <CostCalculator
         estimationOptions={estimationOptions}
-        defaultValues={{
-          countryRegionSlug: 'bf098ccf-7457-4556-b2a8-80c48f67cca4',
-          currencySlug: 'eur-acf7d6b5-654a-449f-873f-aca61a280eba',
-          salary: '50000',
-        }}
-        params={{
-          disclaimer: {
-            label: 'Remote Disclaimer',
-          },
-        }}
         onSubmit={(payload) => setPayload(payload)}
         onError={(error) => console.error({ error })}
         onSuccess={(response) => {
@@ -90,18 +80,11 @@ function App() {
   };
 
   return (
-    <RemoteFlows
-      theme={{
-        colors: {
-          primaryBackground: 'blue',
-          accentBackground: 'green',
-          accentForeground: 'red',
-        },
-      }}
-      auth={() => fetchToken()}
-    >
-      <CostCalculatorForm />
-    </RemoteFlows>
+    <div className="cost-calculator__container">
+      <RemoteFlows auth={() => fetchToken()}>
+        <CostCalculatorForm />
+      </RemoteFlows>
+    </div>
   );
 }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -58,7 +58,9 @@ function CostCalculatorForm() {
         }}
       />
       {estimations && (
-        <CostCalculatorResults employmentData={estimations.data} />
+        <div className="cost-calculator__results">
+          <CostCalculatorResults employmentData={estimations.data} />
+        </div>
       )}
       {estimations && <button onClick={handleExportPdf}>Export as PDF</button>}
     </>

--- a/src/flows/CostCalculator/CostCalculator.tsx
+++ b/src/flows/CostCalculator/CostCalculator.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/src/components/ui/button';
 import { Disclaimer } from '@/src/flows/CostCalculator/Disclaimer';
 import {
   defaultEstimationOptions,
+  EstimationError,
   useCostCalculator,
 } from '@/src/flows/CostCalculator/hooks';
 
@@ -69,7 +70,7 @@ type CostCalculatorProps = Partial<{
    * Callback function to handle the error when the estimation fails.
    * @param error - The error object.
    */
-  onError: (error: Error) => void;
+  onError: (error: EstimationError) => void;
 }>;
 
 export function CostCalculator({
@@ -88,6 +89,7 @@ export function CostCalculator({
     onSubmit: submitCostCalculator,
     fields,
     validationSchema,
+    isSubmitting,
   } = useCostCalculator({
     defaultRegion: defaultValues.countryRegionSlug,
     estimationOptions,
@@ -128,8 +130,9 @@ export function CostCalculator({
           <Button
             type="submit"
             className="w-full bg-gray-900 hover:bg-gray-800 text-white"
+            disabled={isSubmitting}
           >
-            Save
+            Get estimate
           </Button>
         </form>
       </Form>

--- a/src/flows/CostCalculator/tests/CostCalculator.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculator.test.tsx
@@ -75,7 +75,7 @@ describe('CostCalculator', () => {
   test('submits the form with default values', async () => {
     render(<CostCalculator {...defaultProps} />, { wrapper });
 
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Get estimate/i }));
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
@@ -95,7 +95,7 @@ describe('CostCalculator', () => {
     );
     render(<CostCalculator {...defaultProps} />, { wrapper });
 
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Get estimate/i }));
 
     await waitFor(() => {
       expect(mockOnError).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('CostCalculator', () => {
   test('displays validation errors when form is submitted with empty fields', async () => {
     render(<CostCalculator />, { wrapper });
 
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Get estimate/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/salary is required/i)).toBeInTheDocument();

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -5,7 +5,7 @@ type Success<T> = {
 
 type Failure<E> = {
   data: null;
-  error: E;
+  error: E | Error;
 };
 
 export type Result<T, E = Error> = Success<T> | Failure<E>;


### PR DESCRIPTION
This PR adds `isLoading` and `isSubmitting` to `useCostCalculator` hook.
- `isLoading` state derives from loading countries, currencies and region field
- `isSubmitting` state derives from the mutation isPending state

It also adds `useCostCalculator` documentation and some minor CSS improvements to the cost calculator example