### PR TITLE
feat(forms) - Set labels as placeholders

### DIFF
--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -49,7 +49,7 @@ export function SelectField({
             <FormLabel className="RemoteFlows__SelectField__Label">
               {label}
             </FormLabel>
-            <FormControl>
+            <FormControl aria-label={label}>
               <div className="relative">
                 <Select
                   value={field.value || ''}

--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -63,7 +63,7 @@ export function SelectField({
                     aria-invalid={Boolean(fieldState.error)}
                   >
                     <span className="absolute">
-                      <SelectValue />
+                      <SelectValue placeholder={label} />
                     </span>
                   </SelectTrigger>
                   <SelectContent className="RemoteFlows__SelectField__Content">

--- a/src/components/form/fields/TextAreaField.tsx
+++ b/src/components/form/fields/TextAreaField.tsx
@@ -52,6 +52,7 @@ export function TextAreaField({
                     'border-red-500 focus-visible:ring-red-500',
                   'RemoteFlows__TextArea__Input',
                 )}
+                placeholder={label}
               />
             </FormControl>
             {(description || maxLength) && (

--- a/src/components/form/fields/TextField.tsx
+++ b/src/components/form/fields/TextField.tsx
@@ -58,6 +58,7 @@ export function TextField({
               }}
               {...typeAttrs}
               className="RemoteFlows__TextField__Input"
+              placeholder={label}
             />
           </FormControl>
           {description && (

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -175,7 +175,7 @@ describe('CostCalculatorFlow', () => {
     });
   });
 
-  test.only('should load the form with regional fields based on the selected country', async () => {
+  test('should load the form with regional fields based on the selected country', async () => {
     server.use(
       http.get('*/v1/cost-calculator/regions/*/fields', () => {
         return HttpResponse.json(regionFieldsWithAgeProperty);

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -175,7 +175,7 @@ describe('CostCalculatorFlow', () => {
     });
   });
 
-  test('should load the form with regional fields based on the selected country', async () => {
+  test.only('should load the form with regional fields based on the selected country', async () => {
     server.use(
       http.get('*/v1/cost-calculator/regions/*/fields', () => {
         return HttpResponse.json(regionFieldsWithAgeProperty);
@@ -197,8 +197,8 @@ describe('CostCalculatorFlow', () => {
     });
 
     expect(screen.getByText('Benefits')).toBeInTheDocument();
-    expect(screen.getByText('Health Insurance')).toBeInTheDocument();
-    expect(screen.getByText('Life Insurance')).toBeInTheDocument();
+    expect(screen.getByLabelText('Health Insurance')).toBeInTheDocument();
+    expect(screen.getByLabelText('Life Insurance')).toBeInTheDocument();
   });
 
   test('should load, fill and submit form with regional fields', async () => {


### PR DESCRIPTION
Set the labels also as placeholders.

From what I gather the next inputs can have placeholders

* input
* textarea
* select

The datepicker cannot have a placeholder as we render a button, I am guessing partners we'll need to use labels for that.