### PR TITLE
fix(cost-calculator) - fix reset handler

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,10 @@
 import './App.css';
-import { CostCalculatorWithResults } from './CostCalculatorWithResults';
+import { BasicCostCalculator } from './BasicCostCalculator';
 
 function App() {
   return (
     <>
-      <CostCalculatorWithResults />
+      <BasicCostCalculator />
     </>
   );
 }

--- a/example/src/BasicCostCalculator.tsx
+++ b/example/src/BasicCostCalculator.tsx
@@ -28,6 +28,11 @@ export function BasicCostCalculator() {
       });
   };
 
+  const onReset = () => {
+    console.log('Reset button clicked');
+    // Add your reset logic here
+  };
+
   return (
     <RemoteFlows auth={() => fetchToken()}>
       <CostCalculatorFlow
@@ -46,7 +51,9 @@ export function BasicCostCalculator() {
               <CostCalculatorSubmitButton>
                 Get estimate
               </CostCalculatorSubmitButton>
-              <CostCalculatorResetButton>Reset</CostCalculatorResetButton>
+              <CostCalculatorResetButton onClick={onReset}>
+                Reset
+              </CostCalculatorResetButton>
             </div>
           );
         }}

--- a/src/flows/CostCalculator/CostCalculatorResetButton.tsx
+++ b/src/flows/CostCalculator/CostCalculatorResetButton.tsx
@@ -4,12 +4,13 @@ import { useCostCalculatorContext } from './context';
 import { cn } from '@/src/lib/utils';
 
 export function CostCalculatorResetButton({
-  onClick,
+  children,
   ...props
 }: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>) {
   const { form, formId, costCalculatorBag } = useCostCalculatorContext();
   return (
     <Button
+      {...props}
       type="reset"
       className={cn(
         'RemoteFlows__CostCalculatorForm__ResetButton',
@@ -19,11 +20,10 @@ export function CostCalculatorResetButton({
       onClick={(evt) => {
         costCalculatorBag?.resetForm();
         form.reset();
-        onClick?.(evt);
+        props.onClick?.(evt);
       }}
-      {...props}
     >
-      {props.children}
+      {children}
     </Button>
   );
 }

--- a/src/flows/CostCalculator/CostCalculatorResetButton.tsx
+++ b/src/flows/CostCalculator/CostCalculatorResetButton.tsx
@@ -3,11 +3,11 @@ import React, { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 import { useCostCalculatorContext } from './context';
 import { cn } from '@/src/lib/utils';
 
-export function CostCalculatorResetButton(
-  props: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>,
-) {
+export function CostCalculatorResetButton({
+  onClick,
+  ...props
+}: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>) {
   const { form, formId, costCalculatorBag } = useCostCalculatorContext();
-
   return (
     <Button
       type="reset"
@@ -19,7 +19,7 @@ export function CostCalculatorResetButton(
       onClick={(evt) => {
         costCalculatorBag?.resetForm();
         form.reset();
-        props.onClick?.(evt);
+        onClick?.(evt);
       }}
       {...props}
     >

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -30,6 +30,7 @@ const wrapper = ({ children }: PropsWithChildren) => (
 const mockOnSubmit = vi.fn();
 const mockOnSuccess = vi.fn();
 const mockOnError = vi.fn();
+const onResetHandler = vi.fn();
 
 const defaultProps = {
   defaultValues: {
@@ -43,6 +44,7 @@ function renderComponent(
   props: Omit<CostCalculatorFlowProps, 'render'> = {
     defaultValues: defaultProps.defaultValues,
   },
+  onReset: typeof onResetHandler = onResetHandler,
 ) {
   return render(
     <CostCalculatorFlow
@@ -61,7 +63,9 @@ function renderComponent(
             <CostCalculatorSubmitButton>
               Get estimate
             </CostCalculatorSubmitButton>
-            <CostCalculatorResetButton>Reset</CostCalculatorResetButton>
+            <CostCalculatorResetButton onClick={onReset}>
+              Reset
+            </CostCalculatorResetButton>
           </div>
         );
       }}


### PR DESCRIPTION
We had a report that we were passing the onClick handler to the `CostCalculatorResetButton ` the form fields weren't resetting any longer.

This was happening as we were overriding the onClick prop, now this doesn't happen anymore and it's catch by the tests