### PR TITLE
feat(termination) - clean submit form

### DIFF
--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -283,8 +283,6 @@ export const fieldTypesTransformations: Record<string, any> = {
   },
   [supportedTypes.RADIO]: {
     transformValueToAPI: (field: any) => (value: string) => {
-      console.log('radio value', value);
-      console.log('radio field', { field });
       if (field.transformToBool) {
         return value === 'yes';
       }

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -283,6 +283,8 @@ export const fieldTypesTransformations: Record<string, any> = {
   },
   [supportedTypes.RADIO]: {
     transformValueToAPI: (field: any) => (value: string) => {
+      console.log('radio value', value);
+      console.log('radio field', { field });
       if (field.transformToBool) {
         return value === 'yes';
       }

--- a/src/flows/Termination/hooks.ts
+++ b/src/flows/Termination/hooks.ts
@@ -66,8 +66,6 @@ export const useTermination = ({
   const { data: terminationHeadlessForm, isLoading: isLoadingTermination } =
     useTerminationSchema({ formValues, jsfModify: options?.jsfModify });
 
-  console.log({ terminationHeadlessForm: terminationHeadlessForm?.fields });
-
   const createTermination = useCreateTermination();
   const { mutateAsync } = mutationToPromise(createTermination);
 
@@ -95,10 +93,30 @@ export const useTermination = ({
             },
           }
         : undefined;
-
-      const normalizedValues = omit(
-        parsedValues,
+      // I want to iterate parsedValues, check if field name is contained in radioFieldKeys
+      // if it is if the value is yes, set the value to true
+      // if it is no, set the value to false
+      const radioFieldKeys = [
+        'agrees_to_pto_amount',
+        'confidential',
         'customer_informed_employee',
+        'will_challenge_termination',
+      ];
+      const parsedRadioValues = Object.entries(parsedValues).reduce(
+        (acc, [key, value]) => {
+          if (radioFieldKeys.includes(key)) {
+            acc[key] = value === 'yes' ? true : false;
+          } else {
+            acc[key] = value;
+          }
+          return acc;
+        },
+        {} as TerminationFormValues,
+      );
+
+      console.log({ parsedRadioValues });
+      const normalizedValues = omit(
+        parsedRadioValues,
         'customer_informed_employee_date',
         'customer_informed_employee_description',
       );

--- a/src/flows/Termination/hooks.ts
+++ b/src/flows/Termination/hooks.ts
@@ -93,15 +93,14 @@ export const useTermination = ({
             },
           }
         : undefined;
-      // I want to iterate parsedValues, check if field name is contained in radioFieldKeys
-      // if it is if the value is yes, set the value to true
-      // if it is no, set the value to false
+
       const radioFieldKeys = [
         'agrees_to_pto_amount',
         'confidential',
         'customer_informed_employee',
         'will_challenge_termination',
       ];
+
       const parsedRadioValues = Object.entries(parsedValues).reduce(
         (acc, [key, value]) => {
           if (radioFieldKeys.includes(key)) {
@@ -111,10 +110,10 @@ export const useTermination = ({
           }
           return acc;
         },
-        {} as TerminationFormValues,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
       );
 
-      console.log({ parsedRadioValues });
       const normalizedValues = omit(
         parsedRadioValues,
         'customer_informed_employee_date',

--- a/src/flows/Termination/hooks.ts
+++ b/src/flows/Termination/hooks.ts
@@ -70,15 +70,6 @@ export const useTermination = ({
   const { mutateAsync } = mutationToPromise(createTermination);
 
   async function onSubmit(values: TerminationFormValues) {
-    // const validation =
-    //   jsonSchemaContractAmendmentFields?.handleValidation(values);
-    // if (validation?.formErrors && Object.keys(validation?.formErrors)) {
-    //   return {
-    //     data: null,
-    //     error: validation.formErrors,
-    //   };
-    // }
-
     if (!employmentId) {
       throw new Error('Employment id is missing');
     }
@@ -105,9 +96,6 @@ export const useTermination = ({
 
       const normalizedValues = omit(
         parsedValues,
-        'acknowledge_termination_procedure',
-        'agrees_to_pto_amount',
-        'agrees_to_pto_amount_notes',
         'customer_informed_employee',
         'customer_informed_employee_date',
         'customer_informed_employee_description',

--- a/src/flows/Termination/hooks.ts
+++ b/src/flows/Termination/hooks.ts
@@ -66,6 +66,8 @@ export const useTermination = ({
   const { data: terminationHeadlessForm, isLoading: isLoadingTermination } =
     useTerminationSchema({ formValues, jsfModify: options?.jsfModify });
 
+  console.log({ terminationHeadlessForm: terminationHeadlessForm?.fields });
+
   const createTermination = useCreateTermination();
   const { mutateAsync } = mutationToPromise(createTermination);
 

--- a/src/flows/Termination/hooks.ts
+++ b/src/flows/Termination/hooks.ts
@@ -10,6 +10,7 @@ import { JSFModify } from '@/src/flows/CostCalculator/types';
 import { TerminationFormValues } from '@/src/flows/Termination/types';
 import { useClient } from '@/src/context';
 import omit from 'lodash/omit';
+import { parseFormRadioValues } from '@/src/flows/utils';
 
 const useCreateTermination = () => {
   const { client } = useClient();
@@ -101,17 +102,9 @@ export const useTermination = ({
         'will_challenge_termination',
       ];
 
-      const parsedRadioValues = Object.entries(parsedValues).reduce(
-        (acc, [key, value]) => {
-          if (radioFieldKeys.includes(key)) {
-            acc[key] = value === 'yes' ? true : false;
-          } else {
-            acc[key] = value;
-          }
-          return acc;
-        },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {} as any,
+      const parsedRadioValues = parseFormRadioValues(
+        parsedValues,
+        radioFieldKeys,
       );
 
       const normalizedValues = omit(

--- a/src/flows/Termination/jsonSchema.ts
+++ b/src/flows/Termination/jsonSchema.ts
@@ -103,7 +103,6 @@ export const jsonSchema = {
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
-            transformToBool: true,
           },
         },
         customer_informed_employee: {
@@ -125,7 +124,6 @@ export const jsonSchema = {
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
-            transformToBool: false,
           },
         },
         customer_informed_employee_date: {
@@ -324,7 +322,6 @@ export const jsonSchema = {
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
-            transformToBool: true,
           },
         },
         will_challenge_termination_description: {
@@ -366,7 +363,6 @@ export const jsonSchema = {
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
-            transformToBool: true,
           },
         },
         agrees_to_pto_amount_notes: {

--- a/src/flows/Termination/jsonSchema.ts
+++ b/src/flows/Termination/jsonSchema.ts
@@ -8,7 +8,7 @@ export const jsonSchema = {
           if: {
             properties: {
               customer_informed_employee: {
-                const: true, // Ensure this matches the value in the form data
+                const: 'yes', // Ensure this matches the value in the form data
               },
             },
             required: ['customer_informed_employee'], // Ensure this field is required
@@ -38,7 +38,7 @@ export const jsonSchema = {
           if: {
             properties: {
               will_challenge_termination: {
-                const: true,
+                const: 'yes',
               },
             },
             required: ['will_challenge_termination'],
@@ -88,42 +88,44 @@ export const jsonSchema = {
             'Confidential requests are visible only to you. Non-confidential requests are visible to all admins in your company.',
           oneOf: [
             {
-              const: true,
+              const: 'yes',
               description: '',
               title: 'Yes',
             },
             {
-              const: false,
+              const: 'no',
               description: '',
               title: 'No',
             },
           ],
           title: 'Is this request confidential?',
-          type: 'boolean',
+          type: 'string',
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
+            transformToBool: true,
           },
         },
         customer_informed_employee: {
           description: '',
           oneOf: [
             {
-              const: true,
+              const: 'yes',
               description: '',
               title: 'Yes',
             },
             {
-              const: false,
+              const: 'no',
               description: '',
               title: 'No',
             },
           ],
           title: 'Have you informed the employee of the termination?',
-          type: 'boolean',
+          type: 'string',
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
+            transformToBool: false,
           },
         },
         customer_informed_employee_date: {
@@ -306,22 +308,23 @@ export const jsonSchema = {
           description: '',
           oneOf: [
             {
-              const: true,
+              const: 'yes',
               description: '',
               title: 'Yes',
             },
             {
-              const: false,
+              const: 'no',
               description: '',
               title: 'No',
             },
           ],
           title:
             'Do you consider it is likely that the employee will challenge their termination?',
-          type: 'boolean',
+          type: 'string',
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
+            transformToBool: true,
           },
         },
         will_challenge_termination_description: {
@@ -363,6 +366,7 @@ export const jsonSchema = {
           'x-jsf-presentation': {
             direction: 'column',
             inputType: 'radio',
+            transformToBool: true,
           },
         },
         agrees_to_pto_amount_notes: {

--- a/src/flows/utils.ts
+++ b/src/flows/utils.ts
@@ -15,3 +15,35 @@ export function buildValidationSchema(fields: Field[]) {
   );
   return object(fieldsSchema) as AnyObjectSchema;
 }
+
+type ParsedRadioValues = Record<string, unknown>;
+
+/**
+ * Parses the form values to convert radio button values from 'yes'/'no' to boolean.
+ *
+ * @param values - The form values as a record of key-value pairs.
+ * @param fieldKeys - An array of field keys that represent radio button fields.
+ * @returns A new object with the parsed values, where radio button fields are converted to boolean.
+ *
+ * @example
+ * const values = {
+ *   ack: 'yes',
+ *   confidential: 'no',
+ *   username: 'john_doe',
+ * };
+ * const fieldKeys = ['ack', 'confidential'];
+ * const parsedValues = parseFormRadioValues(values, fieldKeys);
+ * // Output: { ack: true, confidential: false, username: 'john_doe' }
+ */
+export function parseFormRadioValues(
+  values: Record<string, unknown>,
+  fieldKeys: string[],
+) {
+  return Object.entries(values).reduce<ParsedRadioValues>(
+    (acc, [key, value]) => {
+      acc[key] = fieldKeys.includes(key) ? value === 'yes' : value;
+      return acc;
+    },
+    {},
+  );
+}


### PR DESCRIPTION
As the BE now accepts new fields like

* customer_informed_employee
* agrees_to_pto_amount
* agrees_to_pto_amount_notes
* acknowledge_termination_procedure

We can clean a little bit, we need to parse manually the radio values from yes/no to booleans to make it work 