### PR TITLE
chore(contract amendment): Add error handling for contract amendment 

### DIFF
--- a/example/src/App.css
+++ b/example/src/App.css
@@ -89,6 +89,19 @@
   display: flex;
   flex-direction: column;
   gap: 40px;
+
+  .amendment_form__error {
+    background-color: rgb(255, 250, 250);
+    border: 1px solid rgb(253, 155, 155);
+    border-radius: 4px;
+    padding: 10px;
+    font-size: 12px;
+    color: #000000;
+  }
+
+  .amendment_form__error__title {
+    font-weight: bold;
+  }
 }
 
 .amendment_form__buttons__submit,

--- a/example/src/ContractAmendment.tsx
+++ b/example/src/ContractAmendment.tsx
@@ -12,6 +12,7 @@ function AmendmentFlow({ contractAmendmentBag, components }: RenderProps) {
   const [automatable, setAutomatable] = useState<
     ContractAmendmentAutomatableResponse | undefined
   >();
+  const [error, setError] = useState<string | null>(null);
 
   function handleSuccess(data: ContractAmendmentAutomatableResponse) {
     setAutomatable(data);
@@ -25,7 +26,29 @@ function AmendmentFlow({ contractAmendmentBag, components }: RenderProps) {
     case 'form':
       return (
         <div className="amendment_form">
-          <Form onSuccess={handleSuccess} />
+          <Form
+            onSuccess={handleSuccess}
+            onError={(err) => {
+              if (
+                'message' in err &&
+                err.message === 'no_changes_detected_contract_details'
+              ) {
+                setError(err.message);
+              }
+            }}
+          />
+          {error && (
+            <div className="amendment_form__error">
+              <p className="amendment_form__error__title">
+                Contract detail change required
+              </p>
+              <p>
+                You haven't changed any contract detail value yet. Please change
+                at least one value in order to be able to proceed with the
+                request.
+              </p>
+            </div>
+          )}
           <SubmitButton
             className="amendment_form__buttons__submit"
             disabled={contractAmendmentBag.isSubmitting}

--- a/src/flows/ContractAmendment/ContractAmendmentForm.tsx
+++ b/src/flows/ContractAmendment/ContractAmendmentForm.tsx
@@ -24,7 +24,11 @@ type ContractAmendmentFormProps = {
    * @param error
    * @returns
    */
-  onError?: (error: PostAutomatableContractAmendmentError) => void;
+  onError?: (
+    error:
+      | PostAutomatableContractAmendmentError
+      | { message: 'no_changes_detected_contract_details' },
+  ) => void;
   /**
    * Callback function to be called when the contract amendment is successfully submitted.
    * This function is called after the contract amendment is submitted.


### PR DESCRIPTION
Improve Contract Amendment example by showing an error when the form is submitted without any contract details changed.

Test:
- Change `Effective date of change`
- Submit form

An error should be rendered at the bottom of the form:

<img width="663" alt="image" src="https://github.com/user-attachments/assets/7d82eb4c-f2b8-40c5-be93-75bba8a90fb6" />
