### PR TITLE
feat(checkboxes) - render multiple checkboxes

### DIFF
--- a/src/components/form/fields/CheckBoxField.tsx
+++ b/src/components/form/fields/CheckBoxField.tsx
@@ -75,14 +75,15 @@ export function CheckBoxField({
             <CustomCheckboxField
               field={{
                 ...field,
-                onChange: (value: any, optionValue: any) => {
+                onChange: (evt: any) => {
                   if (multiple) {
-                    handleCheckboxChange(optionValue, value, field);
-                    onChange?.(value, optionValue);
+                    const { checked, value } = evt.target;
+                    handleCheckboxChange(value, checked, field);
+                    onChange?.(checked);
                     return;
                   }
-                  field.onChange(value);
-                  onChange?.(value);
+                  field.onChange(evt);
+                  onChange?.(evt);
                 },
               }}
               fieldState={fieldState}

--- a/src/components/form/fields/CheckBoxField.tsx
+++ b/src/components/form/fields/CheckBoxField.tsx
@@ -67,6 +67,8 @@ export function CheckBoxField({
             description,
             label,
             defaultValue,
+            multiple,
+            options,
             ...rest,
           };
           return (

--- a/src/components/form/fields/CheckBoxField.tsx
+++ b/src/components/form/fields/CheckBoxField.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react-hook-form';
 
 export type CheckBoxFieldProps = JSFField & {
-  onChange?: (value: any) => void;
+  onChange?: (checked: any, optionId?: string) => void;
 };
 
 export function CheckBoxField({
@@ -78,6 +78,7 @@ export function CheckBoxField({
                 onChange: (value: any, optionValue: any) => {
                   if (multiple) {
                     handleCheckboxChange(optionValue, value, field);
+                    onChange?.(value, optionValue);
                     return;
                   }
                   field.onChange(value);
@@ -104,6 +105,7 @@ export function CheckBoxField({
                             checked === true,
                             field,
                           );
+                          onChange?.(checked, option.value);
                         }}
                         checked={field.value?.includes(option.value)}
                         className="RemoteFlows__CheckBox__Input"

--- a/src/components/form/fields/CheckBoxField.tsx
+++ b/src/components/form/fields/CheckBoxField.tsx
@@ -75,7 +75,11 @@ export function CheckBoxField({
             <CustomCheckboxField
               field={{
                 ...field,
-                onChange: (value: any) => {
+                onChange: (value: any, optionValue: any) => {
+                  if (multiple) {
+                    handleCheckboxChange(optionValue, value, field);
+                    return;
+                  }
                   field.onChange(value);
                   onChange?.(value);
                 },

--- a/src/components/form/fields/tests/CheckBoxField.test.tsx
+++ b/src/components/form/fields/tests/CheckBoxField.test.tsx
@@ -168,4 +168,26 @@ describe('CheckBoxField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(true, 'option1');
   });
+
+  it("should call handleCheckboxChange with 'false' when checkbox is clicked 2 times", () => {
+    const options = [
+      { label: 'Option 1', value: 'option1' },
+      { label: 'Option 2', value: 'option2' },
+    ];
+
+    const props = {
+      ...defaultProps,
+      multiple: true,
+      options,
+      onChange: mockOnChange,
+    };
+
+    renderWithFormContext(props);
+
+    const checkbox = screen.getByLabelText('Option 1');
+    fireEvent.click(checkbox);
+    fireEvent.click(checkbox);
+
+    expect(mockOnChange).toHaveBeenCalledWith(false, 'option1');
+  });
 });

--- a/src/components/form/fields/tests/CheckBoxField.test.tsx
+++ b/src/components/form/fields/tests/CheckBoxField.test.tsx
@@ -129,4 +129,43 @@ describe('CheckBoxField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it("should render multiple checkboxes when 'multiple' prop is true and 'options' are defined", () => {
+    const options = [
+      { label: 'Option 1', value: 'option1' },
+      { label: 'Option 2', value: 'option2' },
+    ];
+
+    const props = {
+      ...defaultProps,
+      multiple: true,
+      options,
+    };
+
+    renderWithFormContext(props);
+
+    expect(screen.getByLabelText('Option 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Option 2')).toBeInTheDocument();
+  });
+
+  it('should call handleCheckboxChange when checkbox is clicked', () => {
+    const options = [
+      { label: 'Option 1', value: 'option1' },
+      { label: 'Option 2', value: 'option2' },
+    ];
+
+    const props = {
+      ...defaultProps,
+      multiple: true,
+      options,
+      onChange: mockOnChange,
+    };
+
+    renderWithFormContext(props);
+
+    const checkbox = screen.getByLabelText('Option 1');
+    fireEvent.click(checkbox);
+
+    expect(mockOnChange).toHaveBeenCalledWith(true, 'option1');
+  });
 });

--- a/src/flows/Termination/hooks.ts
+++ b/src/flows/Termination/hooks.ts
@@ -81,10 +81,8 @@ export const useTermination = ({
         terminationHeadlessForm.fields,
       );
 
-      const {
-        customer_informed_employee: customerInformedEmployee,
-        risk_assessment_reasons: riskAssessmentReasons,
-      } = parsedValues;
+      const { customer_informed_employee: customerInformedEmployee } =
+        parsedValues;
 
       const employeeAwareness =
         customerInformedEmployee === 'yes'
@@ -118,7 +116,6 @@ export const useTermination = ({
         employment_id: employmentId,
         termination_details: {
           ...normalizedValues,
-          ...{ risk_assessment_reasons: [riskAssessmentReasons] },
           ...employeeAwareness,
         } as TerminationFormValues,
         type: 'termination',

--- a/src/flows/Termination/jsonSchema.ts
+++ b/src/flows/Termination/jsonSchema.ts
@@ -237,24 +237,10 @@ export const jsonSchema = {
           },
         },
         risk_assessment_reasons: {
-          description:
-            'Please upload any supporting documents regarding the termination reason.',
+          description: '',
           title: 'This employee is...',
-          type: 'string',
-          oneOf: [
-            {
-              const: 'sick_leave',
-              description: '',
-              title: 'Sick leave',
-            },
-            {
-              const: 'family_leave',
-              description: '',
-              title:
-                'Currently on or recently returned from maternity, paternity, or other family leave',
-            },
-          ],
-          /*  items: {
+          type: 'array',
+          items: {
             anyOf: [
               {
                 const: 'sick_leave',
@@ -296,9 +282,9 @@ export const jsonSchema = {
                   'To the best of my knowledge, I am not aware of any of these',
               },
             ],
-          }, */
+          },
           'x-jsf-presentation': {
-            inputType: 'radio',
+            inputType: 'checkbox',
             direction: 'column',
           },
         },


### PR DESCRIPTION
Did some changes to support multiple checkboxes when using json schemas.

I did the changes using the Checkbox as it will allow us to select multiple options and we do not longer need to parse the values onSubmit as the values will be stored in an array

https://github.com/user-attachments/assets/f4af23cb-dd36-47c3-b89f-d618bbc704b1


Things that I didn't do in this PR:

* Test default values of the checkboxes
