### PR TITLE
feat(proxy): Add proxy support to useAuth and related components

### DIFF
--- a/example/src/ContractAmendment.tsx
+++ b/example/src/ContractAmendment.tsx
@@ -9,6 +9,7 @@ import './App.css';
 
 function AmendmentFlow({ contractAmendmentBag, components }: RenderProps) {
   const { Form, SubmitButton, ConfirmationForm, BackButton } = components;
+
   const [automatable, setAutomatable] = useState<
     ContractAmendmentAutomatableResponse | undefined
   >();
@@ -127,7 +128,10 @@ export function ContractAmendment() {
   };
 
   return (
-    <RemoteFlows auth={() => fetchToken()}>
+    <RemoteFlows
+      auth={() => fetchToken()}
+      proxy={{ url: 'http://localhost:3001/' }}
+    >
       <div style={{ width: 640, padding: 20, margin: '80px auto' }}>
         <ContractAmendmentFlow
           countryCode="PRT"

--- a/src/RemoteFlowsProvider.tsx
+++ b/src/RemoteFlowsProvider.tsx
@@ -13,17 +13,20 @@ type RemoteFlowContextWrapperProps = {
   auth: RemoteFlowsSDKProps['auth'];
   children: React.ReactNode;
   isTestingMode?: RemoteFlowsSDKProps['isTestingMode'];
+  proxy?: RemoteFlowsSDKProps['proxy'];
 };
 
 function RemoteFlowContextWrapper({
   children,
   auth,
   isTestingMode,
+  proxy,
 }: RemoteFlowContextWrapperProps) {
   const remoteApiClient = useAuth({
     auth,
     options: {
       isTestingMode: !!isTestingMode,
+      proxy,
     },
   });
   return (
@@ -54,11 +57,16 @@ export function RemoteFlows({
   components,
   isTestingMode = false,
   theme,
+  proxy,
 }: PropsWithChildren<RemoteFlowsSDKProps>) {
   return (
     <QueryClientProvider client={queryClient}>
       <FormFieldsProvider components={components}>
-        <RemoteFlowContextWrapper isTestingMode={isTestingMode} auth={auth}>
+        <RemoteFlowContextWrapper
+          isTestingMode={isTestingMode}
+          auth={auth}
+          proxy={proxy}
+        >
           <ThemeProvider theme={theme}>{children}</ThemeProvider>
         </RemoteFlowContextWrapper>
       </FormFieldsProvider>

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -72,4 +72,16 @@ export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {
    * If true, the SDK will use the testing environment for all API calls.
    */
   isTestingMode?: boolean;
+  proxy?: {
+    /**
+     * URL of the proxy server to use for API calls.
+     */
+    url: string;
+    /**
+     * Headers to include in the API requests.
+     */
+    headers?: {
+      [key: string]: string;
+    };
+  };
 };


### PR DESCRIPTION
Currently, the SDK makes direct API calls to Remote API from the frontend. This is problematic for endpoints that require client tokens, as these tokens would be exposed in the frontend code.

This PR allows setting a proxy server in the SDK to avoid this problem.