### PR TITLE
feat(termination) - inject components into description

### DIFF
--- a/example/src/Termination.tsx
+++ b/example/src/Termination.tsx
@@ -1,6 +1,21 @@
 import { TerminationFlow, RemoteFlows } from '@remoteoss/remote-flows';
 import './App.css';
 
+function PersonalEmailDescription({ onClick }: { onClick: () => void }) {
+  return (
+    <p>
+      <strong>Personal email</strong> is used to send the termination letter to
+      the employee. It is not mandatory, but it is recommended to add it.
+      <br />
+      <br />
+      <strong>Note:</strong> If you do not have a personal email, you can use
+      the company email. The employee will receive the termination letter in
+      their company email.
+      <a onClick={onClick}>more here</a>
+    </p>
+  );
+}
+
 export const Termination = () => {
   const fetchToken = () => {
     return fetch('/api/token')
@@ -19,6 +34,19 @@ export const Termination = () => {
       <div className="cost-calculator__container">
         <TerminationFlow
           employmentId="7df92706-59ef-44a1-91f6-a275b9149994"
+          options={{
+            jsfModify: {
+              fields: {
+                personal_email: {
+                  description: () => (
+                    <PersonalEmailDescription
+                      onClick={() => console.log('click anchor')}
+                    />
+                  ),
+                },
+              },
+            },
+          }}
           render={({ terminationBag, components }) => {
             if (terminationBag.isLoading) {
               return <div>Loading...</div>;

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -130,7 +130,13 @@ const FormControl = React.forwardRef<
 
 FormControl.displayName = 'FormControl';
 
-function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
+function FormDescription({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'p'> & {
+  children?: React.ReactNode | (() => React.ReactNode);
+}) {
   const { formDescriptionId } = useFormField();
 
   return (
@@ -139,7 +145,9 @@ function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
       id={formDescriptionId}
       className={cn('text-base-color text-xs', className)}
       {...props}
-    />
+    >
+      {typeof children === 'function' ? children() : children}
+    </p>
   );
 }
 


### PR DESCRIPTION
Inject component into description, if we inline functions we need a way to render the component, I think most of the times inline function is what we want to add different props

<img width="501" alt="image" src="https://github.com/user-attachments/assets/18a0f0c5-edeb-48e9-b884-0416ad966cff" />
