### PR TITLE
fix(checkbox): handle const values in checkboxes

### DIFF
--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -310,9 +310,13 @@ export const fieldTypesTransformations: Record<string, any> = {
     },
   },
   [supportedTypes.CHECKBOX]: {
-    transformValueToAPI: () => (value: string) => {
+    transformValueToAPI: (field: any) => (value: string | boolean) => {
       if (value === undefined) {
         return false;
+      }
+
+      if (field.const && value === true) {
+        return field.const;
       }
       return value;
     },


### PR DESCRIPTION
JSON Schemas can have "ack" checkboxes, where a const value is provided, which means the checkbox values needs to use to value, when the form is submit. 

```json
{
  "part_time_salary_confirmation": {
    "const": "acknowledged",
    "description": "We'll include salary changes in the employment agreement amendment, so please double-check that it's correct.",
    "title": "I confirm that this amount is the full annual salary for this part-time employee.",
    "type": "string",
    "x-jsf-presentation": {
        "inputType": "checkbox"
    }
  }
}
```

Currently this isn't happening in the SDK and the value sent is `true` instead of `acknowledged`, like in the example.