### PR TITLE
fix(statement): make title prop optional in Statement component

### DIFF
--- a/src/components/form/Statement.tsx
+++ b/src/components/form/Statement.tsx
@@ -4,7 +4,7 @@ import { AlertCircle } from 'lucide-react';
 import React from 'react';
 
 export type StatementProps = {
-  title: string;
+  title?: string;
   description: string;
   severity: 'warning' | 'error' | 'success' | 'info' | 'neutral' | 'time';
 };
@@ -28,7 +28,7 @@ export function Statement({ title, description, severity }: StatementProps) {
   return (
     <Alert variant="warning">
       <AlertCircle className="h-4 w-4" />
-      <AlertTitle>{title}</AlertTitle>
+      {title && <AlertTitle>{title}</AlertTitle>}
       <AlertDescription>{description}</AlertDescription>
     </Alert>
   );


### PR DESCRIPTION
Make statement title optional to fix handling of undefined titles.

<img width="721" alt="image" src="https://github.com/user-attachments/assets/d88688db-a8ce-48a1-bd52-9b3b25e2835f" />
