### PR TITLE
fix(file-uploads) - avoid submission when opening the file selector

### DIFF
--- a/src/components/form/fields/FileUploadField.tsx
+++ b/src/components/form/fields/FileUploadField.tsx
@@ -106,13 +106,8 @@ export function FileUploadField({
                   event: React.ChangeEvent<HTMLInputElement>,
                 ) => {
                   const files = await convertFilesToBase64(event);
-                  if (multiple) {
-                    field.onChange(files);
-                    onChange?.(files);
-                  } else {
-                    field.onChange([files[0]]);
-                    onChange?.([files[0]]);
-                  }
+                  field.onChange(multiple ? files : [files[0]]); // Update the field value
+                  onChange?.(multiple ? files : [files[0]]);
                 }}
                 multiple={multiple}
                 className={cn('RemoteFlows__FileUpload__Input')}

--- a/src/components/ui/file-uploader.tsx
+++ b/src/components/ui/file-uploader.tsx
@@ -17,7 +17,8 @@ export function FileUploader({
   const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     inputRef.current?.click();
   };
 
@@ -44,7 +45,7 @@ export function FileUploader({
         aria-label="File upload"
         multiple={multiple}
       />
-      <Button onClick={handleClick} className="gap-2">
+      <Button type="button" onClick={handleClick} className="gap-2">
         <Upload className="h-4 w-4" />
         Choose File
       </Button>


### PR DESCRIPTION
There was a button that was submitting the form as the type was not specified