### PR TITLE
fix(contract amendment): update default form values to use stepState

### DIFF
--- a/src/flows/ContractAmendment/ContractAmendmentConfirmationForm.tsx
+++ b/src/flows/ContractAmendment/ContractAmendmentConfirmationForm.tsx
@@ -2,6 +2,7 @@ import {
   ContractAmendmentResponse,
   PostCreateContractAmendmentError,
 } from '@/src/client';
+import { parseJSFToValidate } from '@/src/components/form/utils';
 import { Form } from '@/src/components/ui/form';
 import React from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
@@ -41,6 +42,7 @@ export function ContractAmendmentConfirmationForm({
       stepState,
       isSubmitting,
       onSubmit: submitContractAmendment,
+      fields,
     },
     formId,
   } = useContractAmendmentContext();
@@ -49,7 +51,10 @@ export function ContractAmendmentConfirmationForm({
   });
 
   const handleSubmit = async (values: FieldValues) => {
-    await onSubmit?.(values);
+    const parsedValues = parseJSFToValidate(values, fields, {
+      isPartialValidation: false,
+    });
+    await onSubmit?.(parsedValues);
 
     const contractAmendmentResult = await submitContractAmendment(values);
 

--- a/src/flows/ContractAmendment/ContractAmendmentConfirmationForm.tsx
+++ b/src/flows/ContractAmendment/ContractAmendmentConfirmationForm.tsx
@@ -38,14 +38,14 @@ export function ContractAmendmentConfirmationForm({
 }: ContractAmendmentConfirmationFormProps) {
   const {
     contractAmendment: {
-      values,
+      stepState,
       isSubmitting,
       onSubmit: submitContractAmendment,
     },
     formId,
   } = useContractAmendmentContext();
   const form = useForm({
-    defaultValues: values,
+    defaultValues: stepState.values?.form,
   });
 
   const handleSubmit = async (values: FieldValues) => {

--- a/src/flows/ContractAmendment/ContractAmendmentForm.tsx
+++ b/src/flows/ContractAmendment/ContractAmendmentForm.tsx
@@ -3,6 +3,7 @@ import {
   PostAutomatableContractAmendmentError,
 } from '@/src/client';
 import { JSONSchemaFormFields } from '@/src/components/form/JSONSchemaForm';
+import { parseJSFToValidate } from '@/src/components/form/utils';
 import { useJsonSchemasValidationFormResolver } from '@/src/components/form/yupValidationResolver';
 import { Form } from '@/src/components/ui/form';
 import React, { useEffect } from 'react';
@@ -114,7 +115,11 @@ export function ContractAmendmentForm({
       });
     }
 
-    await onSubmit?.(values);
+    const parsedValues = parseJSFToValidate(values, fields, {
+      isPartialValidation: false,
+    });
+
+    await onSubmit?.(parsedValues);
 
     const contractAmendmentResult = await submitContractAmendment(values);
 

--- a/src/flows/ContractAmendment/hooks.ts
+++ b/src/flows/ContractAmendment/hooks.ts
@@ -200,6 +200,7 @@ export const useContractAmendment = ({
         values,
         contractAmendmentHeadlessForm?.fields,
       );
+
       return contractAmendmentHeadlessForm?.handleValidation(parsedValues);
     }
     return null;
@@ -254,7 +255,15 @@ export const useContractAmendment = ({
      * Function to update the current form field values
      * @param values - New form values to set
      */
-    checkFieldUpdates: setFieldValues,
+    checkFieldUpdates: (values: FieldValues) => {
+      if (contractAmendmentHeadlessForm) {
+        const parsedValues = parseJSFToValidate(
+          values,
+          contractAmendmentHeadlessForm?.fields,
+        );
+        setFieldValues(parsedValues);
+      }
+    },
     /**
      * Function to handle form submission
      * @param values - Form values to submit

--- a/src/flows/ContractAmendment/hooks.ts
+++ b/src/flows/ContractAmendment/hooks.ts
@@ -6,7 +6,10 @@ import {
   postCreateContractAmendment,
 } from '@/src/client';
 
-import { parseJSFToValidate } from '@/src/components/form/utils';
+import {
+  convertToCents,
+  parseJSFToValidate,
+} from '@/src/components/form/utils';
 import { mutationToPromise } from '@/src/lib/mutations';
 
 import { Client } from '@hey-api/client-fetch';
@@ -64,7 +67,14 @@ const useContractAmendmentSchemaQuery = ({
         const { schema } = modify(jsfSchema, options.jsfModify);
         jsfSchema = schema;
       }
-      const copyFieldValues = { ...fieldValues };
+
+      const copyFieldValues = {
+        ...fieldValues,
+        annual_gross_salary: fieldValues?.annual_gross_salary
+          ? convertToCents(fieldValues?.annual_gross_salary)
+          : undefined,
+      };
+
       const hasFieldValues = Object.keys(copyFieldValues).length > 0;
 
       const result = createHeadlessForm(jsfSchema, {
@@ -127,6 +137,7 @@ export const useContractAmendment = ({
   const isNavigatingBackToForm =
     Object.keys(fieldValues).length === 0 &&
     Object.keys(stepState.values?.form || {}).length > 0;
+
   const {
     data: contractAmendmentHeadlessForm,
     isLoading: isLoadingContractAmendments,
@@ -255,15 +266,7 @@ export const useContractAmendment = ({
      * Function to update the current form field values
      * @param values - New form values to set
      */
-    checkFieldUpdates: (values: FieldValues) => {
-      if (contractAmendmentHeadlessForm) {
-        const parsedValues = parseJSFToValidate(
-          values,
-          contractAmendmentHeadlessForm?.fields,
-        );
-        setFieldValues(parsedValues);
-      }
-    },
+    checkFieldUpdates: setFieldValues,
     /**
      * Function to handle form submission
      * @param values - Form values to submit

--- a/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
+++ b/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
@@ -92,7 +92,7 @@ describe('ContractAmendmentFlow', () => {
     vi.clearAllMocks();
   });
 
-  it.only('submits the form when contract details are changed', async () => {
+  it('submits the form when contract details are changed', async () => {
     const user = userEvent.setup();
     render(<ContractAmendmentFlow {...defaultProps} />, { wrapper });
 

--- a/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
+++ b/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
@@ -92,7 +92,7 @@ describe('ContractAmendmentFlow', () => {
     vi.clearAllMocks();
   });
 
-  it.only('submits the form when contract details are changed', async () => {
+  it('submits the form when contract details are changed', async () => {
     const user = userEvent.setup();
     render(<ContractAmendmentFlow {...defaultProps} />, { wrapper });
 
@@ -125,13 +125,13 @@ describe('ContractAmendmentFlow', () => {
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
         additional_comments_toggle: false,
-        annual_gross_salary: '360000',
+        annual_gross_salary: 36000000,
         contract_duration_type: 'indefinite',
         effective_date: '2025-04-15',
         experience_level:
           'Level 3 - Associate - Employees who perform independently tasks and/or with coordination and control functions',
         job_title: 'engineer',
-        reason_for_change: '',
+        reason_for_change: null,
         role_description:
           'Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.',
         work_hours_per_week: 40,
@@ -145,13 +145,13 @@ describe('ContractAmendmentFlow', () => {
     await waitFor(() => {
       expect(mockOnSubmitConfirmation).toHaveBeenCalledWith({
         additional_comments_toggle: false,
-        annual_gross_salary: '360000',
+        annual_gross_salary: 36000000,
         contract_duration_type: 'indefinite',
         effective_date: '2025-04-15',
         experience_level:
           'Level 3 - Associate - Employees who perform independently tasks and/or with coordination and control functions',
         job_title: 'engineer',
-        reason_for_change: '',
+        reason_for_change: null,
         role_description:
           'Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.',
         work_hours_per_week: 40,

--- a/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
+++ b/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
@@ -92,7 +92,7 @@ describe('ContractAmendmentFlow', () => {
     vi.clearAllMocks();
   });
 
-  it('submits the form when contract details are changed', async () => {
+  it.only('submits the form when contract details are changed', async () => {
     const user = userEvent.setup();
     render(<ContractAmendmentFlow {...defaultProps} />, { wrapper });
 

--- a/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
+++ b/src/flows/ContractAmendment/tests/ContractAmendmentFlow.test.tsx
@@ -1,4 +1,5 @@
 import { FormFieldsProvider } from '@/src/RemoteFlowsProvider';
+import { employment } from '@/src/tests/fixtures';
 import { server } from '@/src/tests/server';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -8,7 +9,6 @@ import React, { PropsWithChildren } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ContractAmendmentFlow, RenderProps } from '../ContractAmendmentFlow';
 import { contractAmendementSchema } from './fixtures';
-import { employment } from '@/src/tests/fixtures';
 
 const queryClient = new QueryClient();
 
@@ -21,6 +21,8 @@ const wrapper = ({ children }: PropsWithChildren) => (
 const mockError = vi.fn();
 const mockSuccess = vi.fn();
 const mockOnSubmit = vi.fn();
+
+const mockOnSubmitConfirmation = vi.fn();
 
 describe('ContractAmendmentFlow', () => {
   const mockRender = vi.fn(
@@ -47,7 +49,7 @@ describe('ContractAmendmentFlow', () => {
         case 'confirmation_form':
           return (
             <div data-testid="confirmation-form">
-              <ConfirmationForm />
+              <ConfirmationForm onSubmit={mockOnSubmitConfirmation} />
               <SubmitButton disabled={contractAmendmentBag.isSubmitting}>
                 Confirm
               </SubmitButton>
@@ -80,6 +82,9 @@ describe('ContractAmendmentFlow', () => {
       http.post('*/v1/contract-amendments/automatable', () => {
         return HttpResponse.json({ data: { automatable: true, message: '' } });
       }),
+      http.post('*/v1/contract-amendments', () => {
+        return HttpResponse.json({ data: {} });
+      }),
     );
   });
 
@@ -87,7 +92,7 @@ describe('ContractAmendmentFlow', () => {
     vi.clearAllMocks();
   });
 
-  it('submits the form when contract details are changed', async () => {
+  it.only('submits the form when contract details are changed', async () => {
     const user = userEvent.setup();
     render(<ContractAmendmentFlow {...defaultProps} />, { wrapper });
 
@@ -119,6 +124,26 @@ describe('ContractAmendmentFlow', () => {
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
+        additional_comments_toggle: false,
+        annual_gross_salary: '360000',
+        contract_duration_type: 'indefinite',
+        effective_date: '2025-04-15',
+        experience_level:
+          'Level 3 - Associate - Employees who perform independently tasks and/or with coordination and control functions',
+        job_title: 'engineer',
+        reason_for_change: '',
+        role_description:
+          'Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.Very nice job.',
+        work_hours_per_week: 40,
+        work_schedule: 'full_time',
+      });
+    });
+
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    confirmButton.click();
+
+    await waitFor(() => {
+      expect(mockOnSubmitConfirmation).toHaveBeenCalledWith({
         additional_comments_toggle: false,
         annual_gross_salary: '360000',
         contract_duration_type: 'indefinite',


### PR DESCRIPTION
Fixes a bug in the contract amendment payload that was sending an empty object. This issue was introduced when we switched to using useStepState.