### PR TITLE
feat(demo) - group all demos into the same file and allow navigation between one to another

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@radix-ui/react-collapsible": "1.1.2",
         "@remoteoss/remote-flows": "file:../",
         "axios": "^1.8.3",
         "express": "^4.21.2",
@@ -30,7 +31,7 @@
     },
     "..": {
       "name": "@remoteoss/remote-flows",
-      "version": "0.0.5",
+      "version": "0.3.0",
       "dependencies": {
         "@hey-api/client-fetch": "^0.8.1",
         "@hookform/resolvers": "^4.1.3",
@@ -52,6 +53,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "dompurify": "^3.2.5",
+        "lodash": "^4.17.21",
         "lucide-react": "0.477.0",
         "postcss": "^8.5.3",
         "react-day-picker": "^8.10.1",
@@ -692,6 +695,192 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.2.tgz",
+      "integrity": "sha512-PliMB63vxz7vggcyq0IxNYk8vGDrLXVWw4+W4B8YnwI1s18x7YZYqlG9PLX7XxAJUi0g2DxP4XKJMFHh/iVh9A==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remoteoss/remote-flows": {
       "resolved": "..",
       "link": true
@@ -1183,7 +1372,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1193,7 +1382,7 @@
       "version": "19.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
       "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -1579,7 +1768,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "peer": true
     },
     "node_modules/debug": {

--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "postinstall": "react-flagpack"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "1.1.2",
     "@remoteoss/remote-flows": "file:../",
     "axios": "^1.8.3",
     "express": "^4.21.2",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,592 @@
-import { Termination } from './Termination';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './components/card';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/tabs';
+import { Check, Copy, ChevronRight, ChevronDown } from 'lucide-react';
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from './components/collapsible';
+import { useState } from 'react';
+import { Button } from './components/button';
+import { cn } from './utils';
+import React from 'react';
+import './App.css';
+import { $TSFixMe } from '@remoteoss/json-schema-form';
+import { BasicCostCalculator } from './BasicCostCalculator';
+import { BasicCostCalculatorWithDefaultValues } from './BasicCostCalculatorDefaultValues';
+
+const sourceCode = {
+  // Cost Calculator source codes
+  basicCostCalculator: `
+import {
+  CostCalculatorFlow,
+  CostCalculatorForm,
+  CostCalculatorSubmitButton,
+  CostCalculatorResetButton,
+  RemoteFlows,
+  CostCalculatorDisclaimer,
+} from '@remoteoss/remote-flows';
+
+const estimationOptions = {
+  title: 'Estimate for a new company',
+  includeBenefits: true,
+  includeCostBreakdowns: true,
+};
+
+const fetchToken = () => {
+  return fetch('/api/token')
+    .then((res) => res.json())
+    .then((data) => ({
+      accessToken: data.access_token,
+      expiresIn: data.expires_in,
+    }))
+    .catch((error) => {
+      console.error({ error });
+      throw error;
+    });
+};
+
+export function BasicCostCalculator() {
+  const onReset = () => {
+    console.log('Reset button clicked');
+    // Add your reset logic here
+  };
+
+  return (
+    <RemoteFlows auth={fetchToken}>
+      <CostCalculatorFlow
+        estimationOptions={estimationOptions}
+        render={(props) => {
+          if (props.isLoading) {
+            return <div>Loading...</div>;
+          }
+          return (
+            <div>
+              <CostCalculatorForm
+                onSubmit={(payload) => console.log(payload)}
+                onError={(error) => console.error({ error })}
+                onSuccess={(response) => console.log({ response })}
+              />
+              <CostCalculatorSubmitButton>
+                Get estimate
+              </CostCalculatorSubmitButton>
+              <CostCalculatorResetButton onClick={onReset}>
+                Reset
+              </CostCalculatorResetButton>
+            </div>
+          );
+        }}
+      />
+      <CostCalculatorDisclaimer label="Disclaimer" />
+    </RemoteFlows>
+  );
+}`,
+  basicCostCalculatorWithDefaultValues: `
+    import {
+  CostCalculatorFlow,
+  CostCalculatorForm,
+  CostCalculatorSubmitButton,
+  CostCalculatorResetButton,
+  RemoteFlows,
+  CostCalculatorDisclaimer,
+} from '@remoteoss/remote-flows';
+
+const estimationOptions = {
+  title: 'Estimate for a new company',
+  includeBenefits: true,
+  includeCostBreakdowns: true,
+};
+
+export function BasicCostCalculatorWithDefaultValues() {
+  const fetchToken = () => {
+    return fetch('/api/token')
+      .then((res) => res.json())
+      .then((data) => ({
+        accessToken: data.access_token,
+        expiresIn: data.expires_in,
+      }))
+      .catch((error) => {
+        console.error({ error });
+        throw error;
+      });
+  };
+
+  return (
+    <RemoteFlows auth={() => fetchToken()}>
+      <CostCalculatorFlow
+        estimationOptions={estimationOptions}
+        defaultValues={{
+          countryRegionSlug: 'bf098ccf-7457-4556-b2a8-80c48f67cca4',
+          currencySlug: 'eur-acf7d6b5-654a-449f-873f-aca61a280eba',
+          salary: '50000',
+        }}
+        render={(props) => {
+          if (props.isLoading) {
+            return <div>Loading...</div>;
+          }
+          return (
+            <div>
+              <CostCalculatorForm
+                onSubmit={(payload) => console.log(payload)}
+                onError={(error) => console.error({ error })}
+                onSuccess={(response) => console.log({ response })}
+              />
+              <CostCalculatorSubmitButton>
+                Get estimate
+              </CostCalculatorSubmitButton>
+              <CostCalculatorResetButton>Reset</CostCalculatorResetButton>
+            </div>
+          );
+        }}
+      />
+      <CostCalculatorDisclaimer label="Disclaimer" />
+    </RemoteFlows>
+  );
+}
+  `,
+
+  advancedCostCalculator: `
+import { SDK } from 'your-sdk';
+import { Button } from "@/components/ui/button";
+
+const AdvancedCostCalculator = () => {
+  const calculator = SDK.createCalculator({ advanced: true });
+  const basePrice = 100;
+  const taxRate = 0.1; // 10%
+  const discountRate = 0.05; // 5%
+  
+  // Calculate total with tax and discount
+  const total = calculator.calculateWithTaxAndDiscount(
+    basePrice, 
+    taxRate, 
+    discountRate
+  );
+  
+  const handleApplyDiscount = () => {
+    // Apply additional discount logic
+    calculator.applyAdditionalDiscount(0.02);
+  };
+  
+  const handleReset = () => {
+    // Reset calculator to default values
+    calculator.reset();
+  };
+  
+  return (
+    <div className="p-4 border rounded-md bg-slate-50">
+      <h3 className="font-medium mb-2">Advanced Cost Calculator</h3>
+      <div className="space-y-4">
+        <div className="grid grid-cols-3 gap-2">
+          <div className="p-2 border rounded bg-white">Base: $100</div>
+          <div className="p-2 border rounded bg-white">Tax: 10%</div>
+          <div className="p-2 border rounded bg-white">Discount: 5%</div>
+        </div>
+        <div className="flex gap-2 mb-2">
+          <Button size="sm" onClick={handleApplyDiscount}>Apply Discount</Button>
+          <Button size="sm" variant="outline" onClick={handleReset}>Reset</Button>
+        </div>
+        <div className="p-3 border rounded bg-white font-medium">Total: $\${total}</div>
+      </div>
+    </div>
+  );
+}`,
+
+  customCostCalculator: `
+import { SDK } from 'your-sdk';
+import { useState } from 'react';
+
+const CustomCostCalculator = () => {
+  const calculator = SDK.createCalculator({ customizable: true });
+  const [basePrice, setBasePrice] = useState(100);
+  const [customFee, setCustomFee] = useState(25);
+  
+  // Calculate total with custom fee
+  const total = calculator.calculateWithCustomFee(basePrice, customFee);
+  
+  return (
+    <div className="p-4 border rounded-md bg-slate-50">
+      <h3 className="font-medium mb-2">Custom Cost Calculator</h3>
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-2">
+          <div className="p-2 border rounded bg-white">
+            <div className="text-sm text-muted-foreground">Base Price</div>
+            <div className="flex items-center">
+              <span className="mr-1">$</span>
+              <input 
+                type="number" 
+                value={basePrice}
+                onChange={(e) => setBasePrice(Number(e.target.value))}
+                className="w-full border-0 p-0 focus:ring-0" 
+              />
+            </div>
+          </div>
+          <div className="p-2 border rounded bg-white">
+            <div className="text-sm text-muted-foreground">Custom Fee</div>
+            <div className="flex items-center">
+              <span className="mr-1">$</span>
+              <input 
+                type="number" 
+                value={customFee}
+                onChange={(e) => setCustomFee(Number(e.target.value))}
+                className="w-full border-0 p-0 focus:ring-0" 
+              />
+            </div>
+          </div>
+        </div>
+        <div className="p-3 border rounded bg-white font-medium">Total: $\${total.toFixed(2)}</div>
+      </div>
+    </div>
+  );
+}`,
+
+  // Termination Flow source code
+  terminationFlow: `
+import { SDK } from 'your-sdk';
+import { ChevronRight } from 'lucide-react';
+
+const TerminationFlow = () => {
+  const termination = SDK.createTerminationFlow();
+  
+  // Initialize the termination flow
+  termination.initialize({
+    contractId: 'CONT-123',
+    terminationReason: 'end-of-term'
+  });
+  
+  // Get the current step in the flow
+  const currentStep = termination.getCurrentStep();
+  
+  return (
+    <div className="p-4 border rounded-md bg-slate-50">
+      <h3 className="font-medium mb-2">Contract Termination Flow</h3>
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">1</div>
+          <div className="flex-1 p-2 border rounded bg-white">Initiate Termination</div>
+          <ChevronRight className="w-5 h-5 text-muted-foreground" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">2</div>
+          <div className="flex-1 p-2 border rounded bg-white">Review Terms</div>
+          <ChevronRight className="w-5 h-5 text-muted-foreground" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">3</div>
+          <div className="flex-1 p-2 border rounded bg-white">Confirm Termination</div>
+        </div>
+      </div>
+    </div>
+  );
+}`,
+
+  // Contract Amendments source code
+  contractAmendments: `
+import { SDK } from 'your-sdk';
+import { Button } from "@/components/ui/button";
+
+const ContractAmendments = () => {
+  const amendments = SDK.createAmendmentManager();
+  
+  // Load original contract
+  const originalContract = amendments.getOriginalContract('CONT-123');
+  
+  // Create an amendment
+  const amendment = amendments.createAmendment({
+    field: 'duration',
+    oldValue: '12 months',
+    newValue: '18 months',
+    reason: 'business needs'
+  });
+  
+  const handleApplyAmendment = () => {
+    // Apply the amendment to the contract
+    amendments.applyAmendment(amendment);
+  };
+  
+  return (
+    <div className="p-4 border rounded-md bg-slate-50">
+      <h3 className="font-medium mb-2">Contract Amendments</h3>
+      <div className="space-y-4">
+        <div className="p-3 border rounded bg-white">
+          <div className="font-medium">Original Terms</div>
+          <div className="text-sm text-muted-foreground">Duration: 12 months</div>
+        </div>
+        <div className="p-3 border rounded bg-white">
+          <div className="font-medium">Amendment</div>
+          <div className="text-sm text-muted-foreground">Duration: 18 months</div>
+          <div className="mt-2 text-sm bg-yellow-50 p-1 rounded border border-yellow-200">
+            Changed: Duration extended by 6 months
+          </div>
+        </div>
+        <Button size="sm" onClick={handleApplyAmendment}>Apply Amendment</Button>
+      </div>
+    </div>
+  );
+}`,
+};
+
+const demoStructure = [
+  {
+    id: 'cost-calculator',
+    title: 'Cost Calculator',
+    description:
+      'Calculate the total cost of your employee in different countries',
+    children: [
+      {
+        id: 'cost-calculator/basic',
+        title: 'Basic',
+        description: 'The most basic cost calculator',
+        component: BasicCostCalculator,
+        sourceCode: sourceCode.basicCostCalculator,
+      },
+      {
+        id: 'cost-calculator/with-default-values',
+        title: 'Default Values',
+        description: 'Cost Calculator with default values',
+        component: BasicCostCalculatorWithDefaultValues,
+        sourceCode: sourceCode.basicCostCalculatorWithDefaultValues,
+      },
+      {
+        id: 'cost-calculator/custom',
+        title: 'Custom',
+        description: 'Customizable calculation with user inputs',
+        component: () => <div>Custom Cost Calculator</div>,
+        sourceCode: sourceCode.customCostCalculator,
+      },
+    ],
+  },
+  {
+    id: 'termination-flow',
+    title: 'Termination Flow',
+    description: 'Process for terminating contracts',
+    component: () => <div>Termination Flow</div>,
+    sourceCode: sourceCode.terminationFlow,
+  },
+  {
+    id: 'contract-amendments',
+    title: 'Contract Amendments',
+    description: 'Manage changes to existing contracts',
+    component: () => <div>Contract Amendments</div>,
+    sourceCode: sourceCode.contractAmendments,
+  },
+];
+
+const flattenedDemos = demoStructure.reduce(
+  (acc, category) => {
+    if (category.children) {
+      // Add parent category
+      acc[category.id] = {
+        id: category.id,
+        title: category.title,
+        description: category.description,
+        isParent: true,
+      };
+
+      // Add children
+      category.children.forEach((child) => {
+        acc[child.id] = {
+          id: child.id,
+          title: child.title,
+          description: child.description,
+          component: child.component,
+          sourceCode: child.sourceCode,
+          parentId: category.id,
+        };
+      });
+    } else {
+      // Add standalone item
+      acc[category.id] = {
+        id: category.id,
+        title: category.title,
+        description: category.description,
+        component: category.component,
+        sourceCode: category.sourceCode,
+      };
+    }
+    return acc;
+  },
+  {} as Record<
+    string,
+    {
+      id: string;
+      title: string;
+      description: string;
+      isParent?: boolean;
+      parentId?: string;
+      component?: () => $TSFixMe;
+      sourceCode?: string;
+    }
+  >,
+);
 
 function App() {
-  return <Termination />;
+  const [expandedCategories, setExpandedCategories] = useState<
+    Record<string, boolean>
+  >({
+    'cost-calculator': true, // Start with Cost Calculator expanded
+  });
+  const [activeDemo, setActiveDemo] = useState('cost-calculator/basic'); // Default to first demo
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const selectDemo = (demoId: string) => {
+    setActiveDemo(demoId);
+
+    // If this is a child demo, ensure its parent is expanded
+    const demo = flattenedDemos[demoId];
+    if (demo.parentId) {
+      setExpandedCategories((prev) => ({
+        ...prev,
+        [demo.parentId as string]: true,
+      }));
+    }
+  };
+
+  const toggleCategory = (categoryId: string) => {
+    setExpandedCategories((prev) => ({
+      ...prev,
+      [categoryId]: !prev[categoryId],
+    }));
+  };
+
+  const copyToClipboard = (code: string, id: string) => {
+    navigator.clipboard.writeText(code);
+    setCopied(id);
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  const currentDemo = flattenedDemos[activeDemo];
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-6">SDK Demos</h1>
+
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        {/* Nested Navigation Sidebar */}
+        <div className="lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Demos</CardTitle>
+              <CardDescription>Browse all available demos</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col space-y-1">
+                {demoStructure.map((category) => (
+                  <div key={category.id} className="space-y-1">
+                    {category.children ? (
+                      // Category with children
+                      <Collapsible
+                        open={expandedCategories[category.id]}
+                        onOpenChange={() => toggleCategory(category.id)}
+                      >
+                        <CollapsibleTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            className="w-full justify-between"
+                          >
+                            {category.title}
+                            {expandedCategories[category.id] ? (
+                              <ChevronDown className="h-4 w-4" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>
+                          <div className="pl-4 space-y-1 mt-1">
+                            {category.children.map((child) => (
+                              <Button
+                                key={child.id}
+                                variant={
+                                  activeDemo === child.id ? 'accent' : 'ghost'
+                                }
+                                size="sm"
+                                className="w-full justify-start"
+                                onClick={() => selectDemo(child.id)}
+                              >
+                                {child.title}
+                              </Button>
+                            ))}
+                          </div>
+                        </CollapsibleContent>
+                      </Collapsible>
+                    ) : (
+                      // Standalone item
+                      <Button
+                        variant={
+                          activeDemo === category.id ? 'accent' : 'ghost'
+                        }
+                        className="w-full justify-start"
+                        onClick={() => selectDemo(category.id)}
+                      >
+                        {category.title}
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Main Content */}
+        <div className="lg:col-span-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>{currentDemo.title}</CardTitle>
+              <CardDescription>{currentDemo.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Tabs defaultValue="demo" className="w-full">
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="demo">Demo</TabsTrigger>
+                  <TabsTrigger value="code">Code</TabsTrigger>
+                </TabsList>
+                <TabsContent value="demo" className="mt-4">
+                  {React.createElement(currentDemo.component as $TSFixMe)}
+                </TabsContent>
+                <TabsContent value="code" className="mt-4">
+                  <div className="relative">
+                    <pre className="p-4 rounded-md bg-slate-950 text-slate-50 overflow-x-auto text-sm">
+                      <code>{currentDemo.sourceCode}</code>
+                    </pre>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className={cn(
+                        'absolute top-2 right-2 h-8 w-8 p-0',
+                        copied === currentDemo.id && 'text-green-500',
+                      )}
+                      onClick={() =>
+                        copyToClipboard(
+                          currentDemo.sourceCode as string,
+                          currentDemo.id,
+                        )
+                      }
+                    >
+                      {copied === currentDemo.id ? (
+                        <Check className="h-4 w-4" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                      <span className="sr-only">Copy code</span>
+                    </Button>
+                  </div>
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default App;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -898,42 +898,42 @@ const demoStructure = [
       'Calculate the total cost of your employee in different countries',
     children: [
       {
-        id: 'cost-calculator/basic',
+        id: 'basic-cost-calculator',
         title: 'Basic',
         description: 'The most basic cost calculator',
         component: BasicCostCalculator,
         sourceCode: sourceCode.basicCostCalculator,
       },
       {
-        id: 'cost-calculator/with-default-values',
+        id: 'with-default-values-cost-calculator',
         title: 'Default Values',
         description: 'Cost Calculator with default values',
         component: BasicCostCalculatorWithDefaultValues,
         sourceCode: sourceCode.basicCostCalculatorWithDefaultValues,
       },
       {
-        id: 'cost-calculator/with-custom-labels',
+        id: 'with-custom-labels-cost-calculator',
         title: 'Custom Fields Labels',
         description: 'Custom Field Labels in Cost Calculator',
         component: BasicCostCalculatorLabels,
         sourceCode: sourceCode.basicCostCalculatorLabels,
       },
       {
-        id: 'cost-calculator/with-results',
+        id: 'with-results-cost-calculator',
         title: 'Estimation Results',
         description: 'Cost Calculator with an estimation component',
         component: CostCalculatorWithResults,
         sourceCode: sourceCode.costCalculatorWithResults,
       },
       {
-        id: 'cost-calculator/with-export-pdf',
+        id: 'with-export-pdf-cost-calculator',
         title: 'Export PDF',
         description: 'Cost Calculator with an estimation component',
         component: CostCalculatorWithExportPdf,
         sourceCode: sourceCode.costCalculatorWithExportPdf,
       },
       {
-        id: 'cost-calculator/with-premium-benefits',
+        id: 'with-premium-benefits-cost-calculator',
         title: 'Premium Benefits',
         description: 'Cost Calculator with premium benefits',
         component: CostCalculatorWithPremiumBenefits,
@@ -1011,11 +1011,19 @@ function App() {
   >({
     'cost-calculator': true, // Start with Cost Calculator expanded
   });
-  const [activeDemo, setActiveDemo] = useState('cost-calculator/basic'); // Default to first demo
+  const [activeDemo, setActiveDemo] = useState(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const demoId = urlParams.get('demo');
+    return demoId && flattenedDemos[demoId] ? demoId : 'basic-cost-calculator';
+  });
   const [copied, setCopied] = useState<string | null>(null);
 
   const selectDemo = (demoId: string) => {
     setActiveDemo(demoId);
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('demo', demoId);
+    window.history.pushState({}, '', url);
 
     // If this is a child demo, ensure its parent is expanded
     const demo = flattenedDemos[demoId];

--- a/example/src/Termination.tsx
+++ b/example/src/Termination.tsx
@@ -191,31 +191,29 @@ export const Termination = () => {
   const [open, setOpen] = useState(false);
   return (
     <RemoteFlows auth={fetchToken}>
-      <div className="cost-calculator__container">
-        <TerminationFlow
-          employmentId="7df92706-59ef-44a1-91f6-a275b9149994"
-          render={TerminationForm}
-          options={{
-            jsfModify: {
-              // fields for the termination flow are defined here https://github.com/remoteoss/remote-flows/blob/main/src/flows/Termination/json-schemas/jsonSchema.ts#L108
-              fields: {
-                confidential: {
-                  'x-jsf-presentation': {
-                    statement: null, // this removes potential fixed statements that come from the confidential field
-                  },
-                },
-                termination_reason: {
-                  description: () => (
-                    <TerminationReasonDetailsDescription
-                      onClick={() => setOpen(true)}
-                    />
-                  ),
+      <TerminationFlow
+        employmentId="7df92706-59ef-44a1-91f6-a275b9149994"
+        render={TerminationForm}
+        options={{
+          jsfModify: {
+            // fields for the termination flow are defined here https://github.com/remoteoss/remote-flows/blob/main/src/flows/Termination/json-schemas/jsonSchema.ts#L108
+            fields: {
+              confidential: {
+                'x-jsf-presentation': {
+                  statement: null, // this removes potential fixed statements that come from the confidential field
                 },
               },
+              termination_reason: {
+                description: () => (
+                  <TerminationReasonDetailsDescription
+                    onClick={() => setOpen(true)}
+                  />
+                ),
+              },
             },
-          }}
-        />
-      </div>
+          },
+        }}
+      />
       <TerminationDialog open={open} setOpen={setOpen} />
     </RemoteFlows>
   );

--- a/example/src/TerminationDialog.tsx
+++ b/example/src/TerminationDialog.tsx
@@ -4,7 +4,7 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from './Dialog';
+} from './components/dialog';
 
 export function TerminationDialog({
   open,

--- a/example/src/components/button.tsx
+++ b/example/src/components/button.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        accent: 'bg-accent text-accent-foreground hover:bg-accent/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/example/src/components/card.tsx
+++ b/example/src/components/card.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+
+import { cn } from '../utils';
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-lg border bg-card text-card-foreground shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    {...props}
+  />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'text-2xl font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center p-6 pt-0', className)}
+    {...props}
+  />
+));
+CardFooter.displayName = 'CardFooter';
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/example/src/components/collapsible.tsx
+++ b/example/src/components/collapsible.tsx
@@ -1,0 +1,9 @@
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/example/src/components/dialog.tsx
+++ b/example/src/components/dialog.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
-import { cn } from './utils';
+import { cn } from '../utils';
 
 const Dialog = DialogPrimitive.Root;
 

--- a/example/src/components/tabs.tsx
+++ b/example/src/components/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '../utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
I build a simple navigation to allow switching between the different demos, I also built a simple tab to copy the code.

I'd like to host it somewhere in the future to allow other stakeholders to check it live easily, partnerships can show it to other customers etc...

![image](https://github.com/user-attachments/assets/7c6ffee9-9a66-483a-920c-06ef9455c1e4)
