### PR TITLE
feat(form): enhance fields with component prop support

### DIFF
--- a/src/components/form/JSONSchemaForm.tsx
+++ b/src/components/form/JSONSchemaForm.tsx
@@ -1,13 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { fieldsMap } from '@/src/components/form/fields/fieldsMapping';
-import { SupportedTypes } from '@/src/components/form/fields/types';
 import { Fields } from '@remoteoss/json-schema-form';
 import React, { Fragment } from 'react';
-import { Statement, StatementProps } from './Statement';
-import { ForcedValueField } from './fields/ForcedValueField';
+
+import { fieldsMap } from '@/src/components/form/fields/fieldsMapping';
+import { SupportedTypes } from '@/src/components/form/fields/types';
+import { Statement, StatementProps } from '@/src/components/form/Statement';
+import { ForcedValueField } from '@/src/components/form/fields/ForcedValueField';
+import { Components } from '@/src/types/remoteFlows';
 
 type JSONSchemaFormFieldsProps = {
   fields: Fields;
+  components?: Components;
 };
 
 function checkFieldHasForcedValue(field: any) {
@@ -20,7 +23,10 @@ function checkFieldHasForcedValue(field: any) {
   );
 }
 
-export const JSONSchemaFormFields = ({ fields }: JSONSchemaFormFieldsProps) => {
+export const JSONSchemaFormFields = ({
+  fields,
+  components,
+}: JSONSchemaFormFieldsProps) => {
   if (!fields || fields.length === 0) return null;
 
   return (
@@ -45,7 +51,12 @@ export const JSONSchemaFormFields = ({ fields }: JSONSchemaFormFieldsProps) => {
         const FieldComponent = fieldsMap[field.inputType as SupportedTypes];
         return FieldComponent ? (
           <Fragment key={field.name as string}>
-            <FieldComponent {...field} />
+            <FieldComponent
+              {...field}
+              component={
+                components && components[field.inputType as SupportedTypes]
+              }
+            />
             {field.statement ? (
               <Statement {...(field.statement as StatementProps)} />
             ) : null}

--- a/src/components/form/fields/CheckBoxField.tsx
+++ b/src/components/form/fields/CheckBoxField.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/src/components/ui/form';
 import { useFormFields } from '@/src/context';
 import { cn } from '@/src/lib/utils';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { CheckedState } from '@radix-ui/react-checkbox';
 import * as React from 'react';
 import {
@@ -21,6 +21,7 @@ import {
 
 export type CheckBoxFieldProps = JSFField & {
   onChange?: (checked: any, optionId?: string) => void;
+  component?: Components['checkbox'];
 };
 
 export function CheckBoxField({
@@ -31,6 +32,7 @@ export function CheckBoxField({
   onChange,
   multiple,
   options,
+  component,
   ...rest
 }: CheckBoxFieldProps) {
   const { components } = useFormFields();
@@ -60,8 +62,8 @@ export function CheckBoxField({
       name={name}
       defaultValue={defaultValue}
       render={({ field, fieldState }) => {
-        if (components?.checkbox) {
-          const CustomCheckboxField = components?.checkbox;
+        const CustomCheckboxField = component || components?.checkbox;
+        if (CustomCheckboxField) {
           const customCheckboxFieldProps = {
             name,
             description,

--- a/src/components/form/fields/CountryField.tsx
+++ b/src/components/form/fields/CountryField.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 
 import { useFormFields } from '@/src/context';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import {
   FormControl,
@@ -15,14 +15,13 @@ import {
 import { MultiSelect } from '../../ui/multi-select';
 
 type CountryFieldProps = JSFField & {
-  placeholder?: string;
   options: Array<{ value: string; label: string }>;
-  className?: string;
   onChange?: (value: any) => void;
   $meta: {
     regions: Record<string, string[]>;
     subregions: Record<string, string[]>;
   };
+  component?: Components['countries'];
 };
 
 export function CountryField({
@@ -33,6 +32,7 @@ export function CountryField({
   description,
   onChange,
   $meta,
+  component,
   ...rest
 }: CountryFieldProps) {
   const { control } = useFormContext();
@@ -45,8 +45,9 @@ export function CountryField({
       control={control}
       name={name}
       render={({ field, fieldState }) => {
-        if (components?.countries) {
-          const CustomSelectField = components?.countries;
+        const CustomSelectField = component || components?.countries;
+
+        if (CustomSelectField) {
           const customSelectFieldProps = {
             label,
             name,

--- a/src/components/form/fields/DatePickerField.tsx
+++ b/src/components/form/fields/DatePickerField.tsx
@@ -20,12 +20,13 @@ import {
 } from '@/src/components/ui/popover';
 import { useFormFields } from '@/src/context';
 import { cn } from '@/src/lib/utils';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { PopoverClose } from '@radix-ui/react-popover';
 import { format } from 'date-fns';
 
 export type DatePickerFieldProps = JSFField & {
   onChange?: (value: any) => void;
+  component?: Components['date'];
 };
 
 export function DatePickerField({
@@ -34,6 +35,7 @@ export function DatePickerField({
   name,
   minDate,
   onChange,
+  component,
   ...rest
 }: DatePickerFieldProps) {
   const { components } = useFormFields();
@@ -43,8 +45,9 @@ export function DatePickerField({
       control={control}
       name={name}
       render={({ field, fieldState }) => {
-        if (components?.date) {
-          const CustomDatePickerField = components?.date;
+        const CustomDatePickerField = component || components?.date;
+
+        if (CustomDatePickerField) {
           const customDatePickerFieldProps = {
             description,
             label,

--- a/src/components/form/fields/EmailField.tsx
+++ b/src/components/form/fields/EmailField.tsx
@@ -4,18 +4,24 @@ import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { FormField } from '../../ui/form';
 import { TextField, TextFieldProps } from './TextField';
+import { Components } from '@/src/types/remoteFlows';
 
-export function EmailField(props: TextFieldProps) {
+type EmailFieldProps = TextFieldProps & {
+  component?: Components['email'];
+};
+
+export function EmailField(props: EmailFieldProps) {
   const { components } = useFormFields();
   const { control } = useFormContext();
 
-  if (components?.email) {
+  const CustomEmailField = props.component || components?.email;
+
+  if (CustomEmailField) {
     return (
       <FormField
         control={control}
         name={props.name}
         render={({ field, fieldState }) => {
-          const CustomEmailField = components.email as React.ComponentType<any>;
           return (
             <CustomEmailField
               field={{

--- a/src/components/form/fields/FileUploadField.tsx
+++ b/src/components/form/fields/FileUploadField.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { useFormFields } from '@/src/context';
 import { cn } from '@/src/lib/utils';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import { FileUploader } from '../../ui/file-uploader';
 import {
@@ -44,6 +44,7 @@ const convertFilesToBase64 = async (
 export type FileUploadFieldProps = JSFField & {
   onChange?: (value: any) => void;
   multiple?: boolean;
+  component?: Components['file'];
 };
 
 export function FileUploadField({
@@ -52,6 +53,7 @@ export function FileUploadField({
   label,
   multiple,
   onChange,
+  component,
   ...rest
 }: FileUploadFieldProps) {
   const { components } = useFormFields();
@@ -62,8 +64,8 @@ export function FileUploadField({
       control={control}
       name={name}
       render={({ field, fieldState }) => {
-        if (components?.file) {
-          const CustomFileUploadField = components?.file;
+        const CustomFileUploadField = component || components?.file;
+        if (CustomFileUploadField) {
           const customFileUploadFieldProps = {
             name,
             description,

--- a/src/components/form/fields/NumberField.tsx
+++ b/src/components/form/fields/NumberField.tsx
@@ -4,19 +4,24 @@ import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { FormField } from '../../ui/form';
 import { TextField, TextFieldProps } from './TextField';
+import { Components } from '@/src/types/remoteFlows';
 
-export function NumberField(props: TextFieldProps) {
+type NumberFieldProps = TextFieldProps & {
+  component?: Components['number'];
+};
+
+export function NumberField(props: NumberFieldProps) {
   const { components } = useFormFields();
   const { control } = useFormContext();
 
-  if (components?.number) {
+  const CustomNumberField = props.component || components?.number;
+
+  if (CustomNumberField) {
     return (
       <FormField
         control={control}
         name={props.name}
         render={({ field, fieldState }) => {
-          const CustomNumberField =
-            components.number as React.ComponentType<any>;
           return (
             <CustomNumberField
               field={{

--- a/src/components/form/fields/RadioGroupField.tsx
+++ b/src/components/form/fields/RadioGroupField.tsx
@@ -10,12 +10,13 @@ import {
 import { RadioGroup, RadioGroupItem } from '@/src/components/ui/radio-group';
 import { useFormFields } from '@/src/context';
 import { cn } from '@/src/lib/utils';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import * as React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 type RadioGroupFieldProps = JSFField & {
   onChange?: (value: any) => void;
+  component?: Components['radio'];
 };
 
 export function RadioGroupField({
@@ -25,6 +26,7 @@ export function RadioGroupField({
   label,
   options,
   onChange,
+  component,
   ...rest
 }: RadioGroupFieldProps) {
   const { components } = useFormFields();
@@ -35,8 +37,8 @@ export function RadioGroupField({
       name={name}
       defaultValue={defaultValue}
       render={({ field, fieldState }) => {
-        if (components?.radio) {
-          const CustomRadioGroupField = components?.radio;
+        const CustomRadioGroupField = component || components?.radio;
+        if (CustomRadioGroupField) {
           const customRadioGroupFieldProps = {
             name,
             defaultValue,

--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from '@/src/components/ui/select';
 import { useFormFields } from '@/src/context';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import {
   FormControl,
@@ -26,6 +26,7 @@ type SelectFieldProps = JSFField & {
   options: Array<{ value: string; label: string }>;
   className?: string;
   onChange?: (value: any) => void;
+  component?: Components['select'];
 };
 
 export function SelectField({
@@ -35,6 +36,7 @@ export function SelectField({
   defaultValue,
   description,
   onChange,
+  component,
   ...rest
 }: SelectFieldProps) {
   const { control } = useFormContext();
@@ -46,8 +48,8 @@ export function SelectField({
       control={control}
       name={name}
       render={({ field, fieldState }) => {
-        if (components?.select) {
-          const CustomSelectField = components?.select;
+        const CustomSelectField = component || components?.select;
+        if (CustomSelectField) {
           const customSelectFieldProps = {
             label,
             name,

--- a/src/components/form/fields/TextAreaField.tsx
+++ b/src/components/form/fields/TextAreaField.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { useFormFields } from '@/src/context';
 import { cn } from '@/src/lib/utils';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import {
   FormControl,
@@ -18,6 +18,7 @@ import { Textarea } from '../../ui/textarea';
 export type TextAreaFieldProps = JSFField & {
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   maxLength?: number;
+  component?: Components['textarea'];
 };
 
 export function TextAreaField({
@@ -26,6 +27,7 @@ export function TextAreaField({
   label,
   onChange,
   maxLength,
+  component,
   ...rest
 }: TextAreaFieldProps) {
   const { components } = useFormFields();
@@ -35,8 +37,8 @@ export function TextAreaField({
       control={control}
       name={name}
       render={({ field, fieldState }) => {
-        if (components?.textarea) {
-          const CustomTextAreaField = components?.textarea;
+        const CustomTextAreaField = component || components?.textarea;
+        if (CustomTextAreaField) {
           const customTextAreaFieldProps = {
             name,
             description,

--- a/src/components/form/fields/TextField.tsx
+++ b/src/components/form/fields/TextField.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 
 import { useFormFields } from '@/src/context';
-import { JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import {
   FormControl,
@@ -17,6 +17,7 @@ import { Input } from '../../ui/input';
 export type TextFieldProps = React.ComponentProps<'input'> &
   JSFField & {
     onChange?: (value: any) => void;
+    component?: Components['text'];
   };
 
 export function TextField({
@@ -25,6 +26,7 @@ export function TextField({
   label,
   type,
   onChange,
+  component,
   ...rest
 }: TextFieldProps) {
   const { components } = useFormFields();
@@ -35,8 +37,8 @@ export function TextField({
       control={control}
       name={name}
       render={({ field, fieldState }) => {
-        if (components?.text) {
-          const CustomTextField = components?.text;
+        const CustomTextField = component || components?.text;
+        if (CustomTextField) {
           const customTextFieldProps = {
             name,
             description,

--- a/src/components/form/fields/tests/CheckBoxField.test.tsx
+++ b/src/components/form/fields/tests/CheckBoxField.test.tsx
@@ -190,4 +190,33 @@ describe('CheckBoxField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(false, 'option1');
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomCheckboxFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-checkbox-field">Context Checkbox Field</div>
+      ));
+    const CustomCheckboxFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-checkbox-field">Prop Checkbox Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { checkbox: CustomCheckboxFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomCheckboxFieldProp,
+    });
+
+    expect(CustomCheckboxFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-checkbox-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-checkbox-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/CountryField.test.tsx
+++ b/src/components/form/fields/tests/CountryField.test.tsx
@@ -218,4 +218,33 @@ describe('CountryField Component', () => {
       expect(screen.queryByText('United States')).not.toBeInTheDocument();
     });
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomCountryFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-country-field">Context Country Field</div>
+      ));
+    const CustomCountryFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-country-field">Prop Country Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { countries: CustomCountryFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...(defaultProps as any),
+      onChange: mockOnChange,
+      component: CustomCountryFieldProp,
+    });
+
+    expect(CustomCountryFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-country-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-country-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/DatePickerField.test.tsx
+++ b/src/components/form/fields/tests/DatePickerField.test.tsx
@@ -137,4 +137,35 @@ describe('DatePickerField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomDatePickerFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-date-picker-field">
+          Context Date Picker Field
+        </div>
+      ));
+    const CustomDatePickerFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-date-picker-field">Prop Date Picker Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { date: CustomDatePickerFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomDatePickerFieldProp,
+    });
+
+    expect(CustomDatePickerFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-date-picker-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-date-picker-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/FileUploadField.test.tsx
+++ b/src/components/form/fields/tests/FileUploadField.test.tsx
@@ -138,4 +138,35 @@ describe('FileUploadField Component', () => {
       expect(mockOnChange).toHaveBeenCalledOnce();
     });
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomFileUploadFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-file-upload-field">
+          Context File Upload Field
+        </div>
+      ));
+    const CustomFileUploadFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-file-upload-field">Prop File Upload Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { file: CustomFileUploadFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomFileUploadFieldProp,
+    });
+
+    expect(CustomFileUploadFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-file-upload-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-file-upload-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/NumberField.test.tsx
+++ b/src/components/form/fields/tests/NumberField.test.tsx
@@ -124,4 +124,33 @@ describe('NumberField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomNumberFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-number-field">Context Number Field</div>
+      ));
+    const CustomNumberFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-number-field">Prop Number Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { number: CustomNumberFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomNumberFieldProp,
+    });
+
+    expect(CustomNumberFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-number-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-number-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/RadioGroupField.test.tsx
+++ b/src/components/form/fields/tests/RadioGroupField.test.tsx
@@ -11,6 +11,7 @@ import { JSFField } from '@/src/types/remoteFlows';
 type RadioGroupFieldProps = JSFField & {
   onChange?: (value: string | React.ChangeEvent<HTMLInputElement>) => void;
   options: { value: string; label: string }[];
+  component?: any;
 };
 
 // Mock dependencies
@@ -146,5 +147,32 @@ describe('RadioGroupField Component', () => {
     fireEvent.click(customRadioInput);
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomRadioGroupFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-radio-field">Context Radio Field</div>
+      ));
+    const CustomRadioGroupFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-radio-field">Prop Radio Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { radio: CustomRadioGroupFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...(defaultProps as any),
+      onChange: mockOnChange,
+      component: CustomRadioGroupFieldProp,
+    });
+
+    expect(CustomRadioGroupFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-radio-field')).toBeInTheDocument();
+    expect(screen.queryByTestId('context-radio-field')).not.toBeInTheDocument();
   });
 });

--- a/src/components/form/fields/tests/SelectField.test.tsx
+++ b/src/components/form/fields/tests/SelectField.test.tsx
@@ -146,4 +146,33 @@ describe('SelectField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomSelectFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-select-field">Context Select Field</div>
+      ));
+    const CustomSelectFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-select-field">Prop Select Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { select: CustomSelectFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomSelectFieldProp,
+    });
+
+    expect(CustomSelectFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-select-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-select-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/TextAreaField.test.tsx
+++ b/src/components/form/fields/tests/TextAreaField.test.tsx
@@ -123,4 +123,33 @@ describe('TextAreaField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomTextAreaFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-textarea-field">Context TextArea Field</div>
+      ));
+    const CustomTextAreaFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-textarea-field">Prop TextArea Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { textarea: CustomTextAreaFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomTextAreaFieldProp,
+    });
+
+    expect(CustomTextAreaFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-textarea-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-textarea-field'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/form/fields/tests/TextField.test.tsx
+++ b/src/components/form/fields/tests/TextField.test.tsx
@@ -123,4 +123,31 @@ describe('TextField Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomTextFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-text-field">Context Text Field</div>
+      ));
+    const CustomTextFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-text-field">Prop Text Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { text: CustomTextFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomTextFieldProp,
+    });
+
+    expect(CustomTextFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-text-field')).toBeInTheDocument();
+    expect(screen.queryByTestId('context-text-field')).not.toBeInTheDocument();
+  });
 });

--- a/src/flows/Onboarding/BenefitsForm.tsx
+++ b/src/flows/Onboarding/BenefitsForm.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { FieldValues, useForm } from 'react-hook-form';
+import { Components } from '@/src/types/remoteFlows';
+import { Form } from '@/src/components/ui/form';
+import { useOnboardingContext } from './context';
+import { JSONSchemaFormFields } from '@/src/components/form/JSONSchemaForm';
+
+type BenefitsFormProps = {
+  components: Components;
+  /**
+   * Callback function to be called when the benefits form is submitted.
+   * It can be used to perform any additional validation or processing before
+   * the onboarding moves to the last step.
+   * @param values
+   * @returns
+   */
+  onSubmit?: (values: FieldValues) => Promise<void>;
+  /**
+   * Callback function to be called when the submitting benefits form fails.
+   * @param error
+   * @returns
+   */
+  onError?: (error: unknown) => void;
+  /**
+   * Callback function to be called when benefits form is successfully submitted.
+   * This function is called after the submitting benefits form is submitted.
+   * @param data
+   * @returns
+   */
+  onSuccess?: (data: unknown) => void;
+};
+
+export function BenefitsForm({ components }: BenefitsFormProps) {
+  const { formId } = useOnboardingContext();
+
+  const form = useForm({
+    shouldUnregister: false,
+    mode: 'onBlur',
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        id={formId}
+        data-testid="contract-amendment-form"
+        className="space-y-4 RemoteFlows__ContractAmendmentForm"
+      >
+        <JSONSchemaFormFields fields={[]} components={components} />
+      </form>
+    </Form>
+  );
+}


### PR DESCRIPTION
- Updated various field components to accept a `component` prop for custom rendering.
- Modified JSONSchemaFormFields to use the new `components` prop for dynamic field rendering.
- Introduced BenefitsForm component to manage form submission and integrate JSONSchemaFormFields with custom components.