### PR TITLE
refactor(Onboarding): integrate getInitialValues for setting up initial form values

### DIFF
--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -209,41 +209,6 @@ function extractFieldsetFieldsValues(
 export const fieldTypesTransformations: Record<string, any> = {
   [supportedTypes.COUNTRIES]: {
     /**
-     *
-     * @param {Object} field - Field config that must contain field.countries
-     * @param {String[]|String} value - Selected country
-     *  - Current data (multi): an array of country names - eg: ['Peru', 'Germany']
-     *  - Legacy data (multi): a string of country names - eg: "Peru,Germany"
-     * @returns {String[]} Eg [{ label: 'PER', name: 'Peru' }]
-     */
-    transformValueFromAPI: (field: any) => (value: string) => {
-      if (!field.multiple) {
-        return value ?? '';
-      }
-
-      let countryNames;
-
-      if (typeof value === 'string') {
-        // support legacy data (when the fields were open text fields before)
-        countryNames = value.split(',');
-      } else {
-        countryNames = value || [];
-      }
-
-      const countryValues = countryNames.map(
-        // Return { name: countryName } as fallback to legacy data
-        // The "name" is used at react-select, to connect to the country flag.
-        (countryName) =>
-          field.countries?.find?.(
-            (country: any) => 'name' in country && country.name === countryName,
-          ) || {
-            name: countryName,
-          },
-      );
-
-      return countryValues;
-    },
-    /**
      * @param {String[] | { name: String }[]} value
      *  - Excepted: array of strings.
      *  - Edge cases: array of objects. (when using dangerousTransformValue)
@@ -256,6 +221,12 @@ export const fieldTypesTransformations: Record<string, any> = {
         if (!field.multiple || typeof selectedCountries === 'string') {
           return selectedCountries;
         }
+        console.log(
+          'selectedCountries',
+          selectedCountries.map((option) =>
+            typeof option === 'string' ? option : option.name,
+          ),
+        );
         // NOTE: The value should be an array of strings, however legacy data can come as
         // an array of country objects. So, we always send an array of strings to normalize
         // the data (eg old form values being modified) until DB migration is done !5667
@@ -447,6 +418,7 @@ export function parseFormValuesToAPI(
     { ...formValues },
   );
 
+  console.log('parsedFormValues', parsedFormValues);
   return parsedFormValues;
 }
 
@@ -704,6 +676,15 @@ export function getInitialValues(
               defaultFieldValues,
             );
             Object.assign(initialValues, subFieldValues);
+          }
+          break;
+        }
+        default: {
+          if (!initialValues[field.name]) {
+            initialValues[field.name] = getInitialDefaultValue(
+              defaultFieldValues,
+              field,
+            );
           }
           break;
         }

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -23,7 +23,10 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useClient } from '@/src/context';
 import { useStepState } from '@/src/flows/useStepState';
 import { STEPS } from '@/src/flows/Onboarding/utils';
-import { parseJSFToValidate } from '@/src/components/form/utils';
+import {
+  getInitialValues,
+  parseJSFToValidate,
+} from '@/src/components/form/utils';
 import { mutationToPromise } from '@/src/lib/mutations';
 import { FieldValues } from 'react-hook-form';
 import { OnboardingFlowParams } from '@/src/flows/Onboarding/types';
@@ -382,12 +385,6 @@ export const useOnboarding = ({
     nextStep();
   }
 
-  const initialValues = {
-    basic_information:
-      employment?.data?.data.employment?.basic_information || {},
-    contract_details: employment?.data?.data.employment?.contract_details || {},
-  };
-
   const stepFields: Record<keyof typeof STEPS, Fields> = {
     basic_information: onboardingForm?.fields || [],
     contract_details: onboardingForm?.fields || [],
@@ -395,6 +392,18 @@ export const useOnboarding = ({
     review: [],
   };
 
+  const initialValues = {
+    basic_information: getInitialValues(
+      stepFields[stepState.currentStep.name as keyof typeof stepFields],
+      employment?.data?.data.employment?.basic_information || {},
+    ),
+    contract_details: getInitialValues(
+      stepFields[stepState.currentStep.name as keyof typeof stepFields],
+      employment?.data?.data.employment?.contract_details || {},
+    ),
+  };
+
+  console.log('hook initialValues', initialValues);
   return {
     /**
      * Employment id passed useful to be used between components


### PR DESCRIPTION
Use the `getInitialValues` function to adjust API values to form fields, such as converting `money` fields from cents.