### PR TITLE
fix(onboarding): fix the values passed to createHeadlessForm

### DIFF
--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -186,11 +186,10 @@ const useJSONSchemaForm = ({
         const { schema } = modify(jsfSchema, options.jsfModify);
         jsfSchema = schema;
       }
-      // const hasFieldValues = Object.keys(fieldValues).length > 0;
-      // const employmentField = jsonSchemaToEmployment[form] as keyof Employment;
-      // const employmentFieldData = (employment?.[employmentField] ||
-      //   {}) as Record<string, unknown>;
 
+      // Contract details contains x-jsf-logic that need to be calculated every time a form value changes
+      // In particular there are calculations involving the annual_gross_salary field. However this field value doesn't get
+      // here in cents. So we need to convert the money fields to cents, so that the calculations are correct.
       const moneyFields = findFieldsByType(jsfSchema.properties || {}, 'money');
       const moneyFieldsData = moneyFields.reduce<Record<string, number | null>>(
         (acc, field) => {

--- a/src/flows/utils.ts
+++ b/src/flows/utils.ts
@@ -1,5 +1,6 @@
 import { AnyObjectSchema, object } from 'yup';
 import { Field } from './types';
+import { SupportedTypes } from '../components/form/fields/types';
 
 /**
  * Build the validation schema for the form.
@@ -46,4 +47,18 @@ export function parseFormRadioValues(
     },
     {},
   );
+}
+
+export function findFieldsByType(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fields: Record<string, any>,
+  type: SupportedTypes,
+) {
+  const fieldsNames = [];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value['x-jsf-presentation'].inputType === type) {
+      fieldsNames.push(key);
+    }
+  }
+  return fieldsNames;
 }


### PR DESCRIPTION
We're not passing money values in cents to `createHeadlessForm` to that computed values in `x-jsf-logic`. This PR creates introduces:
- a function to get all the money fields and convert the correspondent value to cents before passing it to `createHeadlessForm`
- a small refactor to `useJSONSchemaForm` form