### PR TITLE
feat(credit-risk) - improvements to the OnboardingInvite

### DIFF
--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -324,6 +324,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               Back
             </BackButton>
             <OnboardingInvite
+              className="submit-button"
               onSuccess={() => {
                 if (onboardingBag.creditRiskStatus === 'deposit_required') {
                   setShowReserveInvoice(true);

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -13,6 +13,7 @@ import {
 } from '@remoteoss/remote-flows';
 import './App.css';
 import React, { useState } from 'react';
+import { OnboardingAlertStatutes } from './OnboardingAlertStatutes';
 
 export const InviteSection = ({
   title,
@@ -118,14 +119,9 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     case 'basic_information':
       return (
         <>
-          {onboardingBag.creditRiskStatus === 'deposit_required' && (
-            <div className="alert">
-              Reserve payment required to hire this employee. Check this{' '}
-              <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                support article
-              </a>
-            </div>
-          )}
+          <OnboardingAlertStatutes
+            creditRiskStatus={onboardingBag.creditRiskStatus}
+          />
           <BasicInformationStep
             onSubmit={(payload: BasicInformationFormPayload) =>
               console.log('payload', payload)
@@ -156,14 +152,9 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     case 'contract_details':
       return (
         <>
-          {onboardingBag.creditRiskStatus === 'deposit_required' && (
-            <div className="alert">
-              Reserve payment required to hire this employee. Check this{' '}
-              <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                support article
-              </a>
-            </div>
-          )}
+          <OnboardingAlertStatutes
+            creditRiskStatus={onboardingBag.creditRiskStatus}
+          />
           <ContractDetailsStep
             onSubmit={(payload: ContractDetailsFormPayload) =>
               console.log('payload', payload)

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -14,6 +14,7 @@ import {
 import './App.css';
 import React, { useState } from 'react';
 import { OnboardingAlertStatutes } from './OnboardingAlertStatutes';
+import { ReviewStep } from './ReviewStep';
 
 export const InviteSection = ({
   title,
@@ -45,40 +46,6 @@ type MultiStepFormProps = {
   components: OnboardingRenderProps['components'];
 };
 
-function Review({
-  meta,
-}: {
-  meta: Record<string, { label?: string; prettyValue?: string | boolean }>;
-}) {
-  return (
-    <div className="onboarding-values">
-      {Object.entries(meta).map(([key, value]) => {
-        const label = value?.label;
-        const prettyValue = value?.prettyValue;
-
-        // Skip if there's no label or prettyValue is undefined or empty string
-        if (!label || prettyValue === undefined || prettyValue === '') {
-          return null;
-        }
-
-        // Handle boolean prettyValue
-        const displayValue =
-          typeof prettyValue === 'boolean'
-            ? prettyValue
-              ? 'Yes'
-              : 'No'
-            : prettyValue;
-
-        return (
-          <pre key={key}>
-            {label}: {displayValue}
-          </pre>
-        );
-      })}
-    </div>
-  );
-}
-
 const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
   const {
     BasicInformationStep,
@@ -86,12 +53,9 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     BenefitsStep,
     SubmitButton,
     BackButton,
-    OnboardingInvite,
     SelectCountryStep,
   } = components;
   const [apiError, setApiError] = useState<string | null>();
-  const [showReserveInvoice, setShowReserveInvoice] = useState(false);
-  const [showInviteSuccessful, setShowInviteSuccessful] = useState(false);
 
   switch (onboardingBag.stepState.currentStep.name) {
     case 'select_country':
@@ -211,132 +175,11 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
       );
     case 'review':
       return (
-        <div className="onboarding-review">
-          <h2 className="title">Select country</h2>
-          <Review meta={onboardingBag.meta.fields.select_country} />
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('select_country')}
-          >
-            Edit Country
-          </button>
-          <h2 className="title">Basic Information</h2>
-          <Review meta={onboardingBag.meta.fields.basic_information} />
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('basic_information')}
-          >
-            Edit Basic Information
-          </button>
-          <h2 className="title">Contract Details</h2>
-          <Review meta={onboardingBag.meta.fields.contract_details} />
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('contract_details')}
-          >
-            Edit Contract Details
-          </button>
-          <h2 className="title">Benefits</h2>
-          <Review meta={onboardingBag.meta.fields.benefits} />
-
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('benefits')}
-          >
-            Edit Benefits
-          </button>
-          <h2 className="title">Review</h2>
-          {!showReserveInvoice &&
-            onboardingBag.creditRiskStatus === 'deposit_required' && (
-              <InviteSection
-                title="Confirm Details && Continue"
-                description="If the employee's details look good, click Continue to check if your reserve invoice is ready for payment. After we receive payment, you'll be able to invite the employee to onboard to Remote."
-              >
-                <p>Reserve payment required to hire this employee</p>
-                <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                  What is a reserve payment
-                </a>
-              </InviteSection>
-            )}
-          {!showInviteSuccessful &&
-            onboardingBag.creditRiskStatus !== 'deposit_required' && (
-              <InviteSection
-                title={`Ready to invite ${onboardingBag.stepState.values?.basic_information?.name} to Remote?`}
-                description="If you're ready to invite this employee to onboard with Remote, click the button below."
-              />
-            )}
-
-          {onboardingBag.creditRiskStatus === 'deposit_required' &&
-            showReserveInvoice && (
-              <div className="reserve-invoice">
-                <h2>You’ll receive a reserve invoice soon</h2>
-                <p>
-                  We saved{' '}
-                  {onboardingBag.stepState.values?.basic_information.name}{' '}
-                  details as a draft. You’ll be able to invite them to Remote
-                  after you complete the reserve payment.
-                </p>
-                <div>
-                  <button type="submit">Go to dashboard</button>
-
-                  <br />
-
-                  <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                    What is a reserve payment
-                  </a>
-                </div>
-              </div>
-            )}
-
-          {onboardingBag.creditRiskStatus !== 'deposit_required' &&
-            showInviteSuccessful && (
-              <div className="invite-successful">
-                <h2>You’re all set!</h2>
-                <p>
-                  {onboardingBag.stepState.values?.basic_information.name} at{' '}
-                  {
-                    onboardingBag.stepState.values?.basic_information
-                      .personal_email
-                  }{' '}
-                  has been invited to Remote. We’ll let you know once they
-                  complete their onboarding process
-                </p>
-                <div>
-                  <button type="submit">Go to dashboard</button>
-                </div>
-              </div>
-            )}
-
-          <div className="buttons-container">
-            <BackButton
-              className="back-button"
-              onClick={() => setApiError(null)}
-            >
-              Back
-            </BackButton>
-            <OnboardingInvite
-              className="submit-button"
-              onSuccess={() => {
-                if (onboardingBag.creditRiskStatus === 'deposit_required') {
-                  setShowReserveInvoice(true);
-                  return;
-                } else {
-                  setShowInviteSuccessful(true);
-                }
-
-                console.log(
-                  'after inviting or creating a reserve navigate to whatever place you want',
-                );
-              }}
-              onError={(error: Error) => setApiError(error.message)}
-              type="submit"
-            >
-              {onboardingBag.creditRiskStatus === 'deposit_required'
-                ? 'Continue'
-                : 'Invite Employee'}
-            </OnboardingInvite>
-          </div>
-        </div>
+        <ReviewStep
+          onboardingBag={onboardingBag}
+          components={components}
+          setApiError={setApiError}
+        />
       );
   }
 };

--- a/example/src/OnboardingAlertStatutes.tsx
+++ b/example/src/OnboardingAlertStatutes.tsx
@@ -1,0 +1,32 @@
+import { CreditRiskStatus } from '@remoteoss/remote-flows';
+
+export const OnboardingAlertStatutes = ({
+  creditRiskStatus,
+}: {
+  creditRiskStatus: CreditRiskStatus;
+}) => {
+  if (creditRiskStatus === 'deposit_required') {
+    return (
+      <div className="alert">
+        Reserve payment required to hire this employee. Check this{' '}
+        <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
+          support article
+        </a>
+      </div>
+    );
+  }
+
+  if (creditRiskStatus === 'referred') {
+    // TODO: Where does the link go at Remote?
+    return (
+      <div className="alert">
+        We're reviewing your company account
+        <p>
+          You can enter this employee's details and save them as a draft until
+          our review is complete. <a href="#">Learn more</a>
+        </p>
+      </div>
+    );
+  }
+  return null;
+};

--- a/example/src/OnboardingAlertStatutes.tsx
+++ b/example/src/OnboardingAlertStatutes.tsx
@@ -3,7 +3,7 @@ import { CreditRiskStatus } from '@remoteoss/remote-flows';
 export const OnboardingAlertStatutes = ({
   creditRiskStatus,
 }: {
-  creditRiskStatus: CreditRiskStatus;
+  creditRiskStatus?: CreditRiskStatus;
 }) => {
   if (creditRiskStatus === 'deposit_required') {
     return (

--- a/example/src/OnboardingWithCustomBenefits.tsx
+++ b/example/src/OnboardingWithCustomBenefits.tsx
@@ -11,41 +11,12 @@ import {
 } from '@remoteoss/remote-flows';
 import './App.css';
 import { useState } from 'react';
+import { ReviewStep } from './ReviewStep';
 
 type MultiStepFormProps = {
   onboardingBag: OnboardingRenderProps['onboardingBag'];
   components: OnboardingRenderProps['components'];
 };
-
-function Review({ values }: { values: Record<string, unknown> }) {
-  return (
-    <div className="onboarding-values">
-      {Object.entries(values).map(([key, value]) => {
-        if (Array.isArray(value)) {
-          return (
-            <pre>
-              {key}: {value.join(', ')}
-            </pre>
-          );
-        }
-        if (typeof value === 'object') {
-          return (
-            <pre>
-              {key}: {JSON.stringify(value)}
-            </pre>
-          );
-        }
-        if (typeof value === 'string' || typeof value === 'number') {
-          return (
-            <pre>
-              {key}: {value}
-            </pre>
-          );
-        }
-      })}
-    </div>
-  );
-}
 
 const MultiStepForm = ({ onboardingBag, components }: MultiStepFormProps) => {
   const [apiError, setApiError] = useState<string | null>();
@@ -55,7 +26,6 @@ const MultiStepForm = ({ onboardingBag, components }: MultiStepFormProps) => {
     BenefitsStep,
     SubmitButton,
     BackButton,
-    OnboardingInvite,
   } = components;
 
   if (onboardingBag.isLoading) {
@@ -204,24 +174,11 @@ const MultiStepForm = ({ onboardingBag, components }: MultiStepFormProps) => {
       );
     case 'review':
       return (
-        <div className="onboarding-review">
-          <h2 className="title">Basic Information</h2>
-          <Review
-            values={onboardingBag.stepState.values?.basic_information || {}}
-          />
-          <h2 className="title">Contract Details</h2>
-          <Review
-            values={onboardingBag.stepState.values?.contract_details || {}}
-          />
-          <h2 className="title">Benefits</h2>
-          <Review values={onboardingBag.stepState.values?.benefits || {}} />
-          <div className="buttons-container">
-            <BackButton className="back-button">Previous Step</BackButton>
-            <OnboardingInvite className="submit-button">
-              Invite Employee
-            </OnboardingInvite>
-          </div>
-        </div>
+        <ReviewStep
+          onboardingBag={onboardingBag}
+          components={components}
+          setApiError={setApiError}
+        />
       );
   }
 };

--- a/example/src/OnboardingWithCustomBenefits.tsx
+++ b/example/src/OnboardingWithCustomBenefits.tsx
@@ -217,7 +217,9 @@ const MultiStepForm = ({ onboardingBag, components }: MultiStepFormProps) => {
           <Review values={onboardingBag.stepState.values?.benefits || {}} />
           <div className="buttons-container">
             <BackButton className="back-button">Previous Step</BackButton>
-            <OnboardingInvite>Invite Employee</OnboardingInvite>
+            <OnboardingInvite className="submit-button">
+              Invite Employee
+            </OnboardingInvite>
           </div>
         </div>
       );

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -290,6 +290,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               Back
             </BackButton>
             <OnboardingInvite
+              className="submit-button"
               onSuccess={() => {
                 if (onboardingBag.creditRiskStatus === 'deposit_required') {
                   setShowReserveInvoice(true);
@@ -375,7 +376,7 @@ const OnboardingWithProps = ({
   employmentId,
   countryCode,
 }: OnboardingFormData) => (
-  <RemoteFlows auth={fetchToken}>
+  <RemoteFlows isTestingMode auth={fetchToken}>
     <OnboardingFlow
       companyId={companyId}
       type={type}
@@ -389,8 +390,8 @@ const OnboardingWithProps = ({
 export const OnboardingForm = () => {
   const [formData, setFormData] = useState<OnboardingFormData>({
     type: 'employee',
-    employmentId: '',
-    companyId: 'c3c22940-e118-425c-9e31-f2fd4d43c6d8',
+    employmentId: '763d5a55-c269-4ed0-8026-584bda762a7a',
+    companyId: 'e52ffe5c-327e-41a4-8b18-701acdea71ec',
     countryCode: 'PRT',
   });
   const [showOnboarding, setShowOnboarding] = useState(false);

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -12,6 +12,7 @@ import {
 import './App.css';
 import React, { useState } from 'react';
 import { OnboardingAlertStatutes } from './OnboardingAlertStatutes';
+import { ReviewStep } from './ReviewStep';
 
 export const InviteSection = ({
   title,
@@ -42,40 +43,6 @@ type MultiStepFormProps = {
   components: OnboardingRenderProps['components'];
 };
 
-function Review({
-  meta,
-}: {
-  meta: Record<string, { label?: string; prettyValue?: string | boolean }>;
-}) {
-  return (
-    <div className="onboarding-values">
-      {Object.entries(meta).map(([key, value]) => {
-        const label = value?.label;
-        const prettyValue = value?.prettyValue;
-
-        // Skip if there's no label or prettyValue is undefined or empty string
-        if (!label || prettyValue === undefined || prettyValue === '') {
-          return null;
-        }
-
-        // Handle boolean prettyValue
-        const displayValue =
-          typeof prettyValue === 'boolean'
-            ? prettyValue
-              ? 'Yes'
-              : 'No'
-            : prettyValue;
-
-        return (
-          <pre key={key}>
-            {label}: {displayValue}
-          </pre>
-        );
-      })}
-    </div>
-  );
-}
-
 const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
   const {
     BasicInformationStep,
@@ -83,11 +50,8 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     BenefitsStep,
     SubmitButton,
     BackButton,
-    OnboardingInvite,
   } = components;
   const [apiError, setApiError] = useState<string | null>();
-  const [showReserveInvoice, setShowReserveInvoice] = useState(false);
-  const [showInviteSuccessful, setShowInviteSuccessful] = useState(false);
 
   switch (onboardingBag.stepState.currentStep.name) {
     case 'basic_information':
@@ -185,124 +149,11 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
       );
     case 'review':
       return (
-        <div className="onboarding-review">
-          <h2 className="title">Basic Information</h2>
-          <Review meta={onboardingBag.meta.fields.basic_information} />
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('basic_information')}
-          >
-            Edit Basic Information
-          </button>
-          <h2 className="title">Contract Details</h2>
-          <Review meta={onboardingBag.meta.fields.contract_details} />
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('contract_details')}
-          >
-            Edit Contract Details
-          </button>
-          <h2 className="title">Benefits</h2>
-          <Review meta={onboardingBag.meta.fields.benefits} />
-
-          <button
-            className="back-button"
-            onClick={() => onboardingBag.goTo('benefits')}
-          >
-            Edit Benefits
-          </button>
-          <h2 className="title">Review</h2>
-          {!showReserveInvoice &&
-            onboardingBag.creditRiskStatus === 'deposit_required' && (
-              <InviteSection
-                title="Confirm Details && Continue"
-                description="If the employee's details look good, click Continue to check if your reserve invoice is ready for payment. After we receive payment, you'll be able to invite the employee to onboard to Remote."
-              >
-                <p>Reserve payment required to hire this employee</p>
-                <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                  What is a reserve payment
-                </a>
-              </InviteSection>
-            )}
-          {!showInviteSuccessful &&
-            onboardingBag.creditRiskStatus !== 'deposit_required' && (
-              <InviteSection
-                title={`Ready to invite ${onboardingBag.stepState.values?.basic_information?.name} to Remote?`}
-                description="If you're ready to invite this employee to onboard with Remote, click the button below."
-              />
-            )}
-
-          {onboardingBag.creditRiskStatus === 'deposit_required' &&
-            showReserveInvoice && (
-              <div className="reserve-invoice">
-                <h2>You’ll receive a reserve invoice soon</h2>
-                <p>
-                  We saved{' '}
-                  {onboardingBag.stepState.values?.basic_information.name}{' '}
-                  details as a draft. You’ll be able to invite them to Remote
-                  after you complete the reserve payment.
-                </p>
-                <div>
-                  <button type="submit">Go to dashboard</button>
-
-                  <br />
-
-                  <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                    What is a reserve payment
-                  </a>
-                </div>
-              </div>
-            )}
-
-          {onboardingBag.creditRiskStatus !== 'deposit_required' &&
-            showInviteSuccessful && (
-              <div className="invite-successful">
-                <h2>You’re all set!</h2>
-                <p>
-                  {onboardingBag.stepState.values?.basic_information.name} at{' '}
-                  {
-                    onboardingBag.stepState.values?.basic_information
-                      .personal_email
-                  }{' '}
-                  has been invited to Remote. We’ll let you know once they
-                  complete their onboarding process
-                </p>
-                <div>
-                  <button type="submit">Go to dashboard</button>
-                </div>
-              </div>
-            )}
-
-          <div className="buttons-container">
-            <BackButton
-              className="back-button"
-              onClick={() => setApiError(null)}
-            >
-              Back
-            </BackButton>
-            <OnboardingInvite
-              className="submit-button"
-              onSuccess={() => {
-                if (onboardingBag.creditRiskStatus === 'deposit_required') {
-                  setShowReserveInvoice(true);
-                  return;
-                } else {
-                  setShowInviteSuccessful(true);
-                }
-
-                console.log(
-                  'after inviting or creating a reserve navigate to whatever place you want',
-                );
-              }}
-              onError={(error: Error) => setApiError(error.message)}
-              type="submit"
-            >
-              {onboardingBag.creditRiskStatus === 'deposit_required'
-                ? 'Continue'
-                : 'Invite Employee'}
-            </OnboardingInvite>
-          </div>
-        </div>
+        <ReviewStep
+          onboardingBag={onboardingBag}
+          components={components}
+          setApiError={setApiError}
+        />
       );
   }
 };

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -11,6 +11,7 @@ import {
 } from '@remoteoss/remote-flows';
 import './App.css';
 import React, { useState } from 'react';
+import { OnboardingAlertStatutes } from './OnboardingAlertStatutes';
 
 export const InviteSection = ({
   title,
@@ -92,14 +93,9 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     case 'basic_information':
       return (
         <>
-          {onboardingBag.creditRiskStatus === 'deposit_required' && (
-            <div className="alert">
-              Reserve payment required to hire this employee. Check this{' '}
-              <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                support article
-              </a>
-            </div>
-          )}
+          <OnboardingAlertStatutes
+            creditRiskStatus={onboardingBag.creditRiskStatus}
+          />
           <BasicInformationStep
             onSubmit={(payload: BasicInformationFormPayload) =>
               console.log('payload', payload)
@@ -130,14 +126,9 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     case 'contract_details':
       return (
         <>
-          {onboardingBag.creditRiskStatus === 'deposit_required' && (
-            <div className="alert">
-              Reserve payment required to hire this employee. Check this{' '}
-              <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
-                support article
-              </a>
-            </div>
-          )}
+          <OnboardingAlertStatutes
+            creditRiskStatus={onboardingBag.creditRiskStatus}
+          />
           <ContractDetailsStep
             onSubmit={(payload: ContractDetailsFormPayload) =>
               console.log('payload', payload)

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -218,7 +218,7 @@ const OnboardingWithProps = ({
   employmentId,
   countryCode,
 }: OnboardingFormData) => (
-  <RemoteFlows isTestingMode auth={fetchToken}>
+  <RemoteFlows auth={fetchToken}>
     <OnboardingFlow
       companyId={companyId}
       type={type}
@@ -232,8 +232,8 @@ const OnboardingWithProps = ({
 export const OnboardingForm = () => {
   const [formData, setFormData] = useState<OnboardingFormData>({
     type: 'employee',
-    employmentId: '763d5a55-c269-4ed0-8026-584bda762a7a',
-    companyId: 'e52ffe5c-327e-41a4-8b18-701acdea71ec',
+    employmentId: '',
+    companyId: 'c3c22940-e118-425c-9e31-f2fd4d43c6d8',
     countryCode: 'PRT',
   });
   const [showOnboarding, setShowOnboarding] = useState(false);

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { OnboardingAlertStatutes } from './OnboardingAlertStatutes';
+import { OnboardingRenderProps } from '@remoteoss/remote-flows';
+export const InviteSection = ({
+  title,
+  description,
+  children,
+}: {
+  title: React.ReactNode;
+  description: React.ReactNode;
+  children?: React.ReactNode;
+}) => {
+  return (
+    <div className="rmt-invitation-section">
+      <h2 className="rmt-invitation-title">{title}</h2>
+      <p className="rmt-invitation-description">{description}</p>
+      {children}
+    </div>
+  );
+};
+
+function Review({
+  meta,
+}: {
+  meta: Record<string, { label?: string; prettyValue?: string | boolean }>;
+}) {
+  return (
+    <div className="onboarding-values">
+      {Object.entries(meta).map(([key, value]) => {
+        const label = value?.label;
+        const prettyValue = value?.prettyValue;
+
+        // Skip if there's no label or prettyValue is undefined or empty string
+        if (!label || prettyValue === undefined || prettyValue === '') {
+          return null;
+        }
+
+        // Handle boolean prettyValue
+        const displayValue =
+          typeof prettyValue === 'boolean'
+            ? prettyValue
+              ? 'Yes'
+              : 'No'
+            : prettyValue;
+
+        return (
+          <pre key={key}>
+            {label}: {displayValue}
+          </pre>
+        );
+      })}
+    </div>
+  );
+}
+
+export const ReviewStep = ({
+  onboardingBag,
+  components,
+  setApiError,
+}: {
+  components: OnboardingRenderProps['components'];
+  onboardingBag: OnboardingRenderProps['onboardingBag'];
+  setApiError: (error: string | null) => void;
+}) => {
+  const { OnboardingInvite, BackButton } = components;
+  const [showReserveInvoice, setShowReserveInvoice] = useState(false);
+  const [showInviteSuccessful, setShowInviteSuccessful] = useState(false);
+  return (
+    <div className="onboarding-review">
+      <h2 className="title">Basic Information</h2>
+      <Review meta={onboardingBag.meta.fields.basic_information} />
+      <button
+        className="back-button"
+        onClick={() => onboardingBag.goTo('basic_information')}
+      >
+        Edit Basic Information
+      </button>
+      <h2 className="title">Contract Details</h2>
+      <Review meta={onboardingBag.meta.fields.contract_details} />
+      <button
+        className="back-button"
+        onClick={() => onboardingBag.goTo('contract_details')}
+      >
+        Edit Contract Details
+      </button>
+      <h2 className="title">Benefits</h2>
+      <Review meta={onboardingBag.meta.fields.benefits} />
+
+      <button
+        className="back-button"
+        onClick={() => onboardingBag.goTo('benefits')}
+      >
+        Edit Benefits
+      </button>
+      <h2 className="title">Review</h2>
+      {onboardingBag.creditRiskStatus === 'referred' && (
+        <InviteSection
+          title={`Confirm ${onboardingBag.stepState.values?.basic_information?.name} Profile`}
+          description="Once your account is approved, you can invite your employees to Remote."
+        >
+          <OnboardingAlertStatutes
+            creditRiskStatus={onboardingBag.creditRiskStatus}
+          />
+        </InviteSection>
+      )}
+      {!showReserveInvoice &&
+        onboardingBag.creditRiskStatus === 'deposit_required' && (
+          <InviteSection
+            title="Confirm Details && Continue"
+            description="If the employee's details look good, click Continue to check if your reserve invoice is ready for payment. After we receive payment, you'll be able to invite the employee to onboard to Remote."
+          >
+            <OnboardingAlertStatutes
+              creditRiskStatus={onboardingBag.creditRiskStatus}
+            />
+            <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
+              What is a reserve payment
+            </a>
+          </InviteSection>
+        )}
+      {!showInviteSuccessful &&
+        onboardingBag.creditRiskStatus &&
+        !['deposit_required', 'referred'].includes(
+          onboardingBag.creditRiskStatus,
+        ) && (
+          <InviteSection
+            title={`Ready to invite ${onboardingBag.stepState.values?.basic_information?.name} to Remote?`}
+            description="If you're ready to invite this employee to onboard with Remote, click the button below."
+          />
+        )}
+
+      {onboardingBag.creditRiskStatus === 'deposit_required' &&
+        showReserveInvoice && (
+          <div className="reserve-invoice">
+            <h2>You’ll receive a reserve invoice soon</h2>
+            <p>
+              We saved {onboardingBag.stepState.values?.basic_information.name}{' '}
+              details as a draft. You’ll be able to invite them to Remote after
+              you complete the reserve payment.
+            </p>
+            <div>
+              <button type="submit">Go to dashboard</button>
+
+              <br />
+
+              <a href="https://support.remote.com/hc/en-us/articles/12695731865229-What-is-a-reserve-payment">
+                What is a reserve payment
+              </a>
+            </div>
+          </div>
+        )}
+
+      {onboardingBag.creditRiskStatus &&
+        !['deposit_required', 'referred'].includes(
+          onboardingBag.creditRiskStatus,
+        ) &&
+        showInviteSuccessful && (
+          <div className="invite-successful">
+            <h2>You’re all set!</h2>
+            <p>
+              {onboardingBag.stepState.values?.basic_information.name} at{' '}
+              {onboardingBag.stepState.values?.basic_information.personal_email}{' '}
+              has been invited to Remote. We’ll let you know once they complete
+              their onboarding process
+            </p>
+            <div>
+              <button type="submit">Go to dashboard</button>
+            </div>
+          </div>
+        )}
+
+      <div className="buttons-container">
+        <BackButton className="back-button" onClick={() => setApiError(null)}>
+          Back
+        </BackButton>
+        <OnboardingInvite
+          className="submit-button"
+          onSuccess={() => {
+            if (onboardingBag.creditRiskStatus === 'deposit_required') {
+              setShowReserveInvoice(true);
+              return;
+            } else {
+              setShowInviteSuccessful(true);
+            }
+
+            console.log(
+              'after inviting or creating a reserve navigate to whatever place you want',
+            );
+          }}
+          onError={(error: Error) => setApiError(error.message)}
+          type="submit"
+        >
+          {onboardingBag.creditRiskStatus === 'deposit_required'
+            ? 'Continue'
+            : 'Invite Employee'}
+        </OnboardingInvite>
+      </div>
+    </div>
+  );
+};

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -186,7 +186,15 @@ export const ReviewStep = ({
               'after inviting or creating a reserve navigate to whatever place you want',
             );
           }}
-          onError={(error: Error) => setApiError(error.message)}
+          onError={(error: unknown) => {
+            if (error instanceof Error) {
+              setApiError(error.message);
+            } else if (typeof error === 'string') {
+              setApiError(error);
+            } else {
+              setApiError('An unknown error occurred');
+            }
+          }}
           type="submit"
         >
           {onboardingBag.creditRiskStatus === 'deposit_required'

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -59,9 +59,10 @@ export function OnboardingInvite({
         const response = await employmentInviteMutationAsync({
           employment_id: onboardingBag.employmentId,
         });
-        await refetchEmployment();
         if (response.data) {
           await onSuccess?.(response.data as SuccessResponse);
+          await refetchEmployment();
+
           return;
         }
         if (response.error) {

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -62,7 +62,6 @@ export function OnboardingInvite({
         if (response.data) {
           await onSuccess?.(response.data as SuccessResponse);
           await refetchEmployment();
-
           return;
         }
         if (response.error) {

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -73,7 +73,14 @@ export function OnboardingInvite({
     }
   };
 
+  if (onboardingBag.creditRiskStatus === 'referred') {
+    return null;
+  }
+
   // TODO: what's the final status when you invite the employee?
+  // the button should be disabled after:
+  // - a reserve invoice is created
+  // - after the user has been invited
   const isDisabled =
     employment?.data.data.employment?.status === 'created_awaiting_reserve';
 

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -77,12 +77,14 @@ export function OnboardingInvite({
     return null;
   }
 
-  // TODO: what's the final status when you invite the employee?
   // the button should be disabled after:
   // - a reserve invoice is created
   // - after the user has been invited
   const isDisabled =
-    employment?.data.data.employment?.status === 'created_awaiting_reserve';
+    employment?.data.data.employment?.status &&
+    ['created_awaiting_reserve', 'invited'].includes(
+      employment?.data.data.employment?.status,
+    );
 
   return (
     <Button

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -240,6 +240,9 @@ export const useOnboarding = ({
       case 'contract_details': {
         const payload: EmploymentFullParams = {
           contract_details: parsedValues,
+          pricing_plan_details: {
+            frequency: 'monthly',
+          },
         };
         return updateEmploymentMutationAsync({
           employmentId: internalEmploymentId as string,

--- a/src/flows/Onboarding/index.ts
+++ b/src/flows/Onboarding/index.ts
@@ -6,4 +6,5 @@ export type {
   ContractDetailsFormPayload,
   SelectCountryFormPayload,
   SelectCountrySuccess,
+  CreditRiskStatus,
 } from './types';

--- a/src/flows/Onboarding/types.ts
+++ b/src/flows/Onboarding/types.ts
@@ -42,3 +42,12 @@ export type BenefitsFormPayload = Record<
 >;
 
 export type ContractDetailsFormPayload = Record<string, unknown>;
+
+export type CreditRiskStatus =
+  | 'not_started'
+  | 'ready'
+  | 'in_progress'
+  | 'referred'
+  | 'fail'
+  | 'deposit_required'
+  | 'no_deposit_required';


### PR DESCRIPTION
I did several things in this PR

* Fix the onboarding invitation, if you did the whole flow in one go and tried to invite, it didn't work
* When the creditStatus is referred we don't render the button, same as in platform
* We refetch the employment status after we invite or generate an invoice, to avoid requesting the same info twice.
* Add example component OnboardingStatuses to render different banners
* Created a ReviewStep to avoid copy & pasting

