### PR TITLE
feat(onboarding) - prevent user from going back when they're in a final status

### DIFF
--- a/example/src/App.css
+++ b/example/src/App.css
@@ -397,6 +397,11 @@ button.reset-button {
   transition: opacity 0.2s;
 }
 
+.back-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .alert-error {
   color: #dc2626;
   background-color: #fee2e2;

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -538,7 +538,7 @@ button.reset-button {
 }
 
 /* Label styling */
-label {
+.input-container label {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -179,6 +179,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
         <ReviewStep
           onboardingBag={onboardingBag}
           components={components}
+          apiError={apiError}
           setApiError={setApiError}
         />
       );

--- a/example/src/OnboardingWithCustomBenefits.tsx
+++ b/example/src/OnboardingWithCustomBenefits.tsx
@@ -184,6 +184,7 @@ const MultiStepForm = ({ onboardingBag, components }: MultiStepFormProps) => {
         <ReviewStep
           onboardingBag={onboardingBag}
           components={components}
+          apiError={apiError}
           setApiError={setApiError}
         />
       );

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -153,6 +153,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
           onboardingBag={onboardingBag}
           components={components}
           setApiError={setApiError}
+          apiError={apiError}
         />
       );
   }

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -201,6 +201,7 @@ export const ReviewStep = ({
       <button
         className="back-button"
         onClick={() => onboardingBag.goTo('basic_information')}
+        disabled={onboardingBag.isEmploymentInFinalState}
       >
         Edit Basic Information
       </button>
@@ -209,6 +210,7 @@ export const ReviewStep = ({
       <button
         className="back-button"
         onClick={() => onboardingBag.goTo('contract_details')}
+        disabled={onboardingBag.isEmploymentInFinalState}
       >
         Edit Contract Details
       </button>
@@ -218,6 +220,7 @@ export const ReviewStep = ({
       <button
         className="back-button"
         onClick={() => onboardingBag.goTo('benefits')}
+        disabled={onboardingBag.isEmploymentInFinalState}
       >
         Edit Benefits
       </button>

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -201,7 +201,7 @@ export const ReviewStep = ({
       <button
         className="back-button"
         onClick={() => onboardingBag.goTo('basic_information')}
-        disabled={onboardingBag.isEmploymentInFinalState}
+        disabled={onboardingBag.isEmploymentReadOnly}
       >
         Edit Basic Information
       </button>
@@ -210,7 +210,7 @@ export const ReviewStep = ({
       <button
         className="back-button"
         onClick={() => onboardingBag.goTo('contract_details')}
-        disabled={onboardingBag.isEmploymentInFinalState}
+        disabled={onboardingBag.isEmploymentReadOnly}
       >
         Edit Contract Details
       </button>
@@ -220,7 +220,7 @@ export const ReviewStep = ({
       <button
         className="back-button"
         onClick={() => onboardingBag.goTo('benefits')}
-        disabled={onboardingBag.isEmploymentInFinalState}
+        disabled={onboardingBag.isEmploymentReadOnly}
       >
         Edit Benefits
       </button>
@@ -247,7 +247,7 @@ export const ReviewStep = ({
               <div className="buttons-container">
                 <BackButton
                   className="back-button"
-                  disabled={onboardingBag.isEmploymentInFinalState}
+                  disabled={onboardingBag.isEmploymentReadOnly}
                   onBackError={(error: Error) => {
                     setApiError(error.message);
                   }}

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -248,9 +248,6 @@ export const ReviewStep = ({
                 <BackButton
                   className="back-button"
                   disabled={onboardingBag.isEmploymentReadOnly}
-                  onBackError={(error: Error) => {
-                    setApiError(error.message);
-                  }}
                 >
                   Back
                 </BackButton>

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -180,10 +180,12 @@ export const MyOnboardingInviteButton = ({
 export const ReviewStep = ({
   onboardingBag,
   components,
+  apiError,
   setApiError,
 }: {
   components: OnboardingRenderProps['components'];
   onboardingBag: OnboardingRenderProps['onboardingBag'];
+  apiError?: string | null;
   setApiError: (error: string | null) => void;
 }) => {
   const {
@@ -242,7 +244,9 @@ export const ReviewStep = ({
               <div className="buttons-container">
                 <BackButton
                   className="back-button"
-                  onClick={() => setApiError(null)}
+                  onBackError={(error: Error) => {
+                    setApiError(error.message);
+                  }}
                 >
                   Back
                 </BackButton>
@@ -253,6 +257,7 @@ export const ReviewStep = ({
                   employment={onboardingBag.employment}
                 />
               </div>
+              {apiError && <div className="error-message">{apiError}</div>}
             </>
           );
         }}

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -244,6 +244,7 @@ export const ReviewStep = ({
               <div className="buttons-container">
                 <BackButton
                   className="back-button"
+                  disabled={onboardingBag.isEmploymentInFinalState}
                   onBackError={(error: Error) => {
                     setApiError(error.message);
                   }}

--- a/src/flows/Onboarding/OnboardingBack.tsx
+++ b/src/flows/Onboarding/OnboardingBack.tsx
@@ -2,7 +2,6 @@ import { Button } from '@/src/components/ui/button';
 import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 import { useOnboardingContext } from '@/src/flows/Onboarding/context';
 import { useFormFields } from '@/src/context';
-import { reviewStepAllowedEmploymentStatus } from '@/src/flows/Onboarding/utils';
 
 type OnboardingBackProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   onBackError?: (error: Error) => void;
@@ -15,16 +14,13 @@ export function OnboardingBack({
   ...props
 }: PropsWithChildren<OnboardingBackProps>) {
   const {
-    onboardingBag: { back, employment },
+    onboardingBag: { back, isEmploymentInFinalState },
   } = useOnboardingContext();
 
   const { components } = useFormFields();
 
   const onBackHandler = (evt: React.MouseEvent<HTMLButtonElement>) => {
-    if (
-      employment &&
-      !reviewStepAllowedEmploymentStatus.includes(employment?.status)
-    ) {
+    if (!isEmploymentInFinalState) {
       back();
     } else {
       onBackError(

--- a/src/flows/Onboarding/OnboardingBack.tsx
+++ b/src/flows/Onboarding/OnboardingBack.tsx
@@ -3,29 +3,23 @@ import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 import { useOnboardingContext } from '@/src/flows/Onboarding/context';
 import { useFormFields } from '@/src/context';
 
-type OnboardingBackProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  onBackError?: (error: Error) => void;
-} & Record<string, unknown>;
+type OnboardingBackProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  Record<string, unknown>;
 
 export function OnboardingBack({
   children,
   onClick,
-  onBackError = () => {},
   ...props
 }: PropsWithChildren<OnboardingBackProps>) {
   const {
-    onboardingBag: { back, isEmploymentInFinalState },
+    onboardingBag: { back, isEmploymentReadOnly },
   } = useOnboardingContext();
 
   const { components } = useFormFields();
 
   const onBackHandler = (evt: React.MouseEvent<HTMLButtonElement>) => {
-    if (!isEmploymentInFinalState) {
+    if (!isEmploymentReadOnly) {
       back();
-    } else {
-      onBackError(
-        new Error('The employment is in a final state and cannot be modified.'),
-      );
     }
     onClick?.(evt);
   };

--- a/src/flows/Onboarding/OnboardingBack.tsx
+++ b/src/flows/Onboarding/OnboardingBack.tsx
@@ -2,40 +2,49 @@ import { Button } from '@/src/components/ui/button';
 import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 import { useOnboardingContext } from '@/src/flows/Onboarding/context';
 import { useFormFields } from '@/src/context';
+import { reviewStepAllowedEmploymentStatus } from '@/src/flows/Onboarding/utils';
+
+type OnboardingBackProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  onBackError?: (error: Error) => void;
+} & Record<string, unknown>;
 
 export function OnboardingBack({
   children,
+  onClick,
+  onBackError = () => {},
   ...props
-}: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> &
-  Record<string, unknown>) {
+}: PropsWithChildren<OnboardingBackProps>) {
   const {
-    onboardingBag: { back },
+    onboardingBag: { back, employment },
   } = useOnboardingContext();
 
   const { components } = useFormFields();
 
+  const onBackHandler = (evt: React.MouseEvent<HTMLButtonElement>) => {
+    if (
+      employment &&
+      !reviewStepAllowedEmploymentStatus.includes(employment?.status)
+    ) {
+      back();
+    } else {
+      onBackError(
+        new Error('The employment is in a final state and cannot be modified.'),
+      );
+    }
+    onClick?.(evt);
+  };
+
   const CustomButton = components?.button;
   if (CustomButton) {
     return (
-      <CustomButton
-        {...props}
-        onClick={(evt) => {
-          back();
-          props.onClick?.(evt);
-        }}
-      >
+      <CustomButton {...props} onClick={onBackHandler}>
         {children}
       </CustomButton>
     );
   }
 
   return (
-    <Button
-      {...props}
-      onClick={() => {
-        back();
-      }}
-    >
+    <Button {...props} onClick={onBackHandler}>
       {children}
     </Button>
   );

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -3,9 +3,10 @@ import { useEmploymentInvite } from './api';
 import { Button } from '@/src/components/ui/button';
 import { useCreateReserveInvoice } from '@/src/flows/Onboarding/api';
 import { mutationToPromise } from '@/src/lib/mutations';
-import { Employment, SuccessResponse } from '@/src/client';
+import { SuccessResponse } from '@/src/client';
 import { useOnboardingContext } from './context';
 import { useFormFields } from '@/src/context';
+import { reviewStepAllowedEmploymentStatus } from '@/src/flows/Onboarding/utils';
 
 export type OnboardingInviteProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   onSuccess?: ({
@@ -20,13 +21,7 @@ export type OnboardingInviteProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   render: (props: {
     employmentStatus: 'invited' | 'created_awaiting_reserve';
   }) => ReactNode;
-};
-
-const employmentStatusList: Employment['status'][] = [
-  'invited',
-  'created_awaiting_reserve',
-  'created_reserve_paid',
-];
+} & Record<string, unknown>;
 
 export function OnboardingInvite({
   onSubmit,
@@ -34,7 +29,7 @@ export function OnboardingInvite({
   onError,
   render,
   ...props
-}: OnboardingInviteProps & Record<string, unknown>) {
+}: OnboardingInviteProps) {
   const { components } = useFormFields();
   const { onboardingBag, setCreditScore } = useOnboardingContext();
   const employmentInviteMutation = useEmploymentInvite();
@@ -55,7 +50,9 @@ export function OnboardingInvite({
         onboardingBag.creditRiskStatus === 'deposit_required' &&
         onboardingBag.employmentId &&
         onboardingBag.employment?.status &&
-        !employmentStatusList.includes(onboardingBag.employment?.status)
+        !reviewStepAllowedEmploymentStatus.includes(
+          onboardingBag.employment?.status,
+        )
       ) {
         const response = await createReserveInvoiceMutationAsync({
           employment_slug: onboardingBag.employmentId,
@@ -104,7 +101,9 @@ export function OnboardingInvite({
   const isReserveFlow =
     onboardingBag.creditRiskStatus === 'deposit_required' &&
     onboardingBag.employment?.status &&
-    !employmentStatusList.includes(onboardingBag.employment.status);
+    !reviewStepAllowedEmploymentStatus.includes(
+      onboardingBag.employment.status,
+    );
 
   const CustomButton = components?.button;
   if (CustomButton) {

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -49,7 +49,7 @@ export function OnboardingInvite({
         onboardingBag.creditRiskStatus === 'deposit_required' &&
         onboardingBag.employmentId &&
         onboardingBag.employment?.status &&
-        !onboardingBag.isEmploymentInFinalState
+        !onboardingBag.isEmploymentReadOnly
       ) {
         const response = await createReserveInvoiceMutationAsync({
           employment_slug: onboardingBag.employmentId,
@@ -98,7 +98,7 @@ export function OnboardingInvite({
   const isReserveFlow =
     onboardingBag.creditRiskStatus === 'deposit_required' &&
     onboardingBag.employment?.status &&
-    !onboardingBag.isEmploymentInFinalState;
+    !onboardingBag.isEmploymentReadOnly;
 
   const CustomButton = components?.button;
   if (CustomButton) {

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -50,9 +50,7 @@ export function OnboardingInvite({
         onboardingBag.creditRiskStatus === 'deposit_required' &&
         onboardingBag.employmentId &&
         onboardingBag.employment?.status &&
-        !reviewStepAllowedEmploymentStatus.includes(
-          onboardingBag.employment?.status,
-        )
+        !onboardingBag.isEmploymentInFinalState
       ) {
         const response = await createReserveInvoiceMutationAsync({
           employment_slug: onboardingBag.employmentId,
@@ -101,9 +99,7 @@ export function OnboardingInvite({
   const isReserveFlow =
     onboardingBag.creditRiskStatus === 'deposit_required' &&
     onboardingBag.employment?.status &&
-    !reviewStepAllowedEmploymentStatus.includes(
-      onboardingBag.employment.status,
-    );
+    !onboardingBag.isEmploymentInFinalState;
 
   const CustomButton = components?.button;
   if (CustomButton) {

--- a/src/flows/Onboarding/OnboardingInvite.tsx
+++ b/src/flows/Onboarding/OnboardingInvite.tsx
@@ -6,7 +6,6 @@ import { mutationToPromise } from '@/src/lib/mutations';
 import { SuccessResponse } from '@/src/client';
 import { useOnboardingContext } from './context';
 import { useFormFields } from '@/src/context';
-import { reviewStepAllowedEmploymentStatus } from '@/src/flows/Onboarding/utils';
 
 export type OnboardingInviteProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   onSuccess?: ({

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -234,10 +234,13 @@ export const useOnboarding = ({
     isLoadingCompany ||
     isLoadingCountries;
 
+  const isEmploymentInFinalState =
+    employment &&
+    reviewStepAllowedEmploymentStatus.includes(employment?.status);
+
   const isNavigatingToReview = Boolean(
     employmentId &&
-      employment &&
-      reviewStepAllowedEmploymentStatus.includes(employment?.status) &&
+      isEmploymentInFinalState &&
       !initialLoading &&
       stepFields['basic_information'].length > 0 &&
       stepFields['contract_details'].length > 0 &&
@@ -563,5 +566,10 @@ export const useOnboarding = ({
      * Employment data
      */
     employment,
+
+    /**
+     * is employment in a final state
+     */
+    isEmploymentInFinalState: isEmploymentInFinalState,
   };
 };

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -570,6 +570,6 @@ export const useOnboarding = ({
     /**
      * is employment in a final state
      */
-    isEmploymentInFinalState: isEmploymentInFinalState,
+    isEmploymentInFinalState,
   };
 };

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -234,13 +234,13 @@ export const useOnboarding = ({
     isLoadingCompany ||
     isLoadingCountries;
 
-  const isEmploymentInFinalState =
+  const isEmploymentReadOnly =
     employment &&
     reviewStepAllowedEmploymentStatus.includes(employment?.status);
 
   const isNavigatingToReview = Boolean(
     employmentId &&
-      isEmploymentInFinalState &&
+      isEmploymentReadOnly &&
       !initialLoading &&
       stepFields['basic_information'].length > 0 &&
       stepFields['contract_details'].length > 0 &&
@@ -568,9 +568,9 @@ export const useOnboarding = ({
     employment,
 
     /**
-     * tells you if an employment in a final state and no more actions can be performed
+     * let's the user know that the employment cannot be edited, happens when employment.status is invited, created_awaiting_reserve or created_reserve_paid
      * @returns {boolean}
      */
-    isEmploymentInFinalState,
+    isEmploymentReadOnly,
   };
 };

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -568,7 +568,8 @@ export const useOnboarding = ({
     employment,
 
     /**
-     * is employment in a final state
+     * tells you if an employment in a final state and no more actions can be performed
+     * @returns {boolean}
      */
     isEmploymentInFinalState,
   };

--- a/src/flows/Onboarding/hooks.ts
+++ b/src/flows/Onboarding/hooks.ts
@@ -8,6 +8,7 @@ import { Fields } from '@remoteoss/json-schema-form';
 import { useStepState, Step } from '@/src/flows/useStepState';
 import {
   prettifyFormValues,
+  reviewStepAllowedEmploymentStatus,
   STEPS,
   STEPS_WITHOUT_SELECT_COUNTRY,
 } from '@/src/flows/Onboarding/utils';
@@ -52,12 +53,6 @@ const stepToFormSchemaMap: Record<
   benefits: null,
   review: null,
 };
-
-const reviewStepAllowedEmploymentStatus: Employment['status'][] = [
-  'invited',
-  'created_awaiting_reserve',
-  'created_reserve_paid',
-];
 
 export const useOnboarding = ({
   employmentId,

--- a/src/flows/Onboarding/tests/OnboardingBack.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingBack.test.tsx
@@ -22,6 +22,7 @@ describe('OnboardingBack Component', () => {
     (useOnboardingContext as any).mockReturnValue({
       onboardingBag: {
         back: mockBack,
+        isEmploymentInFinalState: false,
       },
     });
     (useFormFields as any).mockReturnValue({ components: {} });
@@ -181,5 +182,77 @@ describe('OnboardingBack Component', () => {
     fireEvent.click(button);
     expect(mockBack).toHaveBeenCalledTimes(1);
     expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when employment is in final state', () => {
+    const mockBack = vi.fn();
+    const mockOnClick = vi.fn();
+    const mockOnBackError = vi.fn(); // Add this line
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      (useOnboardingContext as any).mockReturnValue({
+        onboardingBag: {
+          back: mockBack,
+          isEmploymentInFinalState: true,
+        },
+      });
+      (useFormFields as any).mockReturnValue({ components: {} });
+    });
+
+    it('calls onBackError with appropriate message when clicked', () => {
+      render(
+        <OnboardingBack onClick={mockOnClick} onBackError={mockOnBackError}>
+          Go Back
+        </OnboardingBack>,
+      );
+
+      const button = screen.getByRole('button', { name: 'Go Back' });
+      fireEvent.click(button);
+
+      expect(mockBack).not.toHaveBeenCalled();
+      expect(mockOnBackError).toHaveBeenCalledWith(
+        new Error('The employment is in a final state and cannot be modified.'),
+      );
+      expect(mockOnClick).toHaveBeenCalled();
+    });
+
+    it('still calls onClick even when in final state', () => {
+      render(<OnboardingBack onClick={mockOnClick}>Go Back</OnboardingBack>);
+
+      const button = screen.getByRole('button', { name: 'Go Back' });
+      fireEvent.click(button);
+
+      expect(mockOnClick).toHaveBeenCalled();
+    });
+
+    it('works with custom button component when in final state', () => {
+      const CustomButton = vi
+        .fn()
+        .mockImplementation(({ children, onClick }) => (
+          <button data-testid="custom-button" onClick={onClick}>
+            {children}
+          </button>
+        ));
+
+      (useFormFields as any).mockReturnValue({
+        components: { button: CustomButton },
+      });
+
+      render(
+        <OnboardingBack onClick={mockOnClick} onBackError={mockOnBackError}>
+          Go Back
+        </OnboardingBack>,
+      );
+
+      const button = screen.getByTestId('custom-button');
+      fireEvent.click(button);
+
+      expect(mockBack).not.toHaveBeenCalled();
+      expect(mockOnBackError).toHaveBeenCalledWith(
+        new Error('The employment is in a final state and cannot be modified.'),
+      );
+      expect(mockOnClick).toHaveBeenCalled();
+    });
   });
 });

--- a/src/flows/Onboarding/tests/OnboardingBack.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingBack.test.tsx
@@ -22,7 +22,7 @@ describe('OnboardingBack Component', () => {
     (useOnboardingContext as any).mockReturnValue({
       onboardingBag: {
         back: mockBack,
-        isEmploymentInFinalState: false,
+        isEmploymentReadOnly: false,
       },
     });
     (useFormFields as any).mockReturnValue({ components: {} });
@@ -184,49 +184,32 @@ describe('OnboardingBack Component', () => {
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 
-  describe('when employment is in final state', () => {
+  describe('when employment is readonly', () => {
     const mockBack = vi.fn();
     const mockOnClick = vi.fn();
-    const mockOnBackError = vi.fn(); // Add this line
 
     beforeEach(() => {
       vi.clearAllMocks();
       (useOnboardingContext as any).mockReturnValue({
         onboardingBag: {
           back: mockBack,
-          isEmploymentInFinalState: true,
+          isEmploymentReadOnly: true,
         },
       });
       (useFormFields as any).mockReturnValue({ components: {} });
     });
 
-    it('calls onBackError with appropriate message when clicked', () => {
-      render(
-        <OnboardingBack onClick={mockOnClick} onBackError={mockOnBackError}>
-          Go Back
-        </OnboardingBack>,
-      );
-
-      const button = screen.getByRole('button', { name: 'Go Back' });
-      fireEvent.click(button);
-
-      expect(mockBack).not.toHaveBeenCalled();
-      expect(mockOnBackError).toHaveBeenCalledWith(
-        new Error('The employment is in a final state and cannot be modified.'),
-      );
-      expect(mockOnClick).toHaveBeenCalled();
-    });
-
-    it('still calls onClick even when in final state', () => {
+    it('should not call mockBack', () => {
       render(<OnboardingBack onClick={mockOnClick}>Go Back</OnboardingBack>);
 
       const button = screen.getByRole('button', { name: 'Go Back' });
       fireEvent.click(button);
 
+      expect(mockBack).not.toHaveBeenCalled();
       expect(mockOnClick).toHaveBeenCalled();
     });
 
-    it('works with custom button component when in final state', () => {
+    it('works with custom button component when employment is readonly', () => {
       const CustomButton = vi
         .fn()
         .mockImplementation(({ children, onClick }) => (
@@ -239,19 +222,12 @@ describe('OnboardingBack Component', () => {
         components: { button: CustomButton },
       });
 
-      render(
-        <OnboardingBack onClick={mockOnClick} onBackError={mockOnBackError}>
-          Go Back
-        </OnboardingBack>,
-      );
+      render(<OnboardingBack onClick={mockOnClick}>Go Back</OnboardingBack>);
 
       const button = screen.getByTestId('custom-button');
       fireEvent.click(button);
 
       expect(mockBack).not.toHaveBeenCalled();
-      expect(mockOnBackError).toHaveBeenCalledWith(
-        new Error('The employment is in a final state and cannot be modified.'),
-      );
       expect(mockOnClick).toHaveBeenCalled();
     });
   });

--- a/src/flows/Onboarding/utils.ts
+++ b/src/flows/Onboarding/utils.ts
@@ -1,3 +1,4 @@
+import { Employment } from '@/src/flows/Onboarding/types';
 import { Step } from '@/src/flows/useStepState';
 import { Fields } from '@remoteoss/json-schema-form';
 
@@ -102,3 +103,15 @@ export function prettifyFormValues(
       .filter(Boolean),
   );
 }
+
+/**
+ * Array of employment statuses that are allowed to proceed to the review step.
+ * These statuses indicate that the employment is in a final state and the employment cannot be modified further.
+ * @type {Employment['status'][]}
+ * @constant
+ */
+export const reviewStepAllowedEmploymentStatus: Employment['status'][] = [
+  'invited',
+  'created_awaiting_reserve',
+  'created_reserve_paid',
+];

--- a/src/flows/useStepState.ts
+++ b/src/flows/useStepState.ts
@@ -75,7 +75,7 @@ export const useStepState = <T extends string, Fields = FieldValues>(
   }
 
   function goToStep(step: T) {
-    // to avoid going to a steps that hasn't been filled yetç
+    // to avoid going to a steps that hasn't been filled yet
     if (stepState.values?.[step]) {
       setStepState((previousState) => ({
         ...previousState,


### PR DESCRIPTION
When recover an employment, who is invited, we moved the user to the review step which means that we cannot longer go back.

Besides API doesn't let do any updates to an employment in that situation


