### PR TITLE
fix(css) - scope the styles in a css tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ Import the CSS file in your application:
 @import '@remoteoss/remote-flows/index.css';
 ```
 
+In your JSX create a container with the class remote-flows
+
+```jsx
+<div className="remote-flows">{children}</div>
+```
+
 ### Theme Customization
 
 ```tsx

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -5,6 +5,8 @@ import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <div className="remote-flows">
+      <App />
+    </div>
   </StrictMode>,
 );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 
-:root {
+.remote-flows {
   --background: oklch(1 0 0);
   --foreground: var(--primaryForeground, #4b5865);
   --card: var(--primaryBackground, #ffffff);
@@ -73,11 +73,13 @@
   --text-2xl: calc(var(--fontBase) * 1.5);
 }
 
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
+.remote-flows {
+  @layer base {
+    * {
+      @apply border-border outline-ring/50;
+    }
+    body {
+      @apply bg-background text-foreground;
+    }
   }
 }


### PR DESCRIPTION
We had a report that we were overriding styles in the consumer app.

We scope the styles under a remote-flows css class to avoid problems