### PR TITLE
fix(contract-amendments) - add missing json-schema-query param

### DIFF
--- a/src/flows/ContractAmendment/hooks.ts
+++ b/src/flows/ContractAmendment/hooks.ts
@@ -22,6 +22,7 @@ import { useClient } from '@/src/context';
 import { FieldValues } from 'react-hook-form';
 import { useStepState } from '../useStepState';
 import { buildInitialValues, STEPS } from './utils';
+import { FlowOptions } from '@/src/flows/types';
 
 type ContractAmendmentSchemaParams = {
   countryCode: string;
@@ -93,8 +94,13 @@ const useContractAmendmentSchemaQuery = ({
   });
 };
 
-const useCreateContractAmendmentMutation = () => {
+const useCreateContractAmendmentMutation = (options?: FlowOptions) => {
   const { client } = useClient();
+  const jsonSchemaQueryParam = options?.jsonSchemaVersion?.contract_amendments
+    ? {
+        json_schema_version: options.jsonSchemaVersion.contract_amendments,
+      }
+    : {};
   return useMutation({
     mutationFn: (payload: CreateContractAmendmentParams) => {
       return postCreateContractAmendment({
@@ -103,13 +109,21 @@ const useCreateContractAmendmentMutation = () => {
           Authorization: ``,
         },
         body: payload,
+        query: {
+          ...jsonSchemaQueryParam,
+        },
       });
     },
   });
 };
 
-const useAutomatableContractAmendmentMutation = () => {
+const useAutomatableContractAmendmentMutation = (options?: FlowOptions) => {
   const { client } = useClient();
+  const jsonSchemaQueryParam = options?.jsonSchemaVersion?.contract_amendments
+    ? {
+        json_schema_version: options.jsonSchemaVersion.contract_amendments,
+      }
+    : {};
   return useMutation({
     mutationFn: (payload: CreateContractAmendmentParams) => {
       return postAutomatableContractAmendment({
@@ -118,6 +132,9 @@ const useAutomatableContractAmendmentMutation = () => {
           Authorization: ``,
         },
         body: payload,
+        query: {
+          ...jsonSchemaQueryParam,
+        },
       });
     },
   });
@@ -163,9 +180,10 @@ export const useContractAmendment = ({
     contractAmendmentHeadlessForm?.fields,
   );
 
-  const createContractAmendmentMutation = useCreateContractAmendmentMutation();
+  const createContractAmendmentMutation =
+    useCreateContractAmendmentMutation(options);
   const automatableContractAmendmentMutation =
-    useAutomatableContractAmendmentMutation();
+    useAutomatableContractAmendmentMutation(options);
 
   async function onSubmit(values: FieldValues) {
     const parsedValues = parseJSFToValidate(


### PR DESCRIPTION
I noticed that both post requests in contract amendments support json_schema_version makes sense that if the schema supports that, the POST requests need that too