### PR TITLE
feat(RemoteFlows): Add support to environment prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ The example app will be available at `http://localhost:3001`. The server handles
 
 The `RemoteFlows` component serves as a provider for authentication and theming.
 
-| Prop            | Type                                                        | Required | Description                                                        |
-| --------------- | ----------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| `auth`          | `() => Promise<{ accessToken: string, expiresIn: number }>` | Yes      | Function to fetch authentication token                             |
-| `isTestingMode` | `boolean`                                                   | No       | When `true`, connects to sandbox environment instead of production |
-| `theme`         | `ThemeOptions`                                              | No       | Custom theme configuration                                         |
-| `components`    | `Components`                                                | No       | Custom field components for form rendering                         |
-| `proxy`         | `{ url: string, headers?: Record<string, string> }`         | No       | Configuration for API request proxy with optional headers          |
+| Prop          | Type                                                        | Required | Description                                               |
+| ------------- | ----------------------------------------------------------- | -------- | --------------------------------------------------------- |
+| `auth`        | `() => Promise<{ accessToken: string, expiresIn: number }>` | Yes      | Function to fetch authentication token                    |
+| `environment` | `'partners' \| 'production' \| 'sandbox' \| 'staging'`      | No       | Environment to use for API calls (defaults to production) |
+| `theme`       | `ThemeOptions`                                              | No       | Custom theme configuration                                |
+| `components`  | `Components`                                                | No       | Custom field components for form rendering                |
+| `proxy`       | `{ url: string, headers?: Record<string, string> }`         | No       | Configuration for API request proxy with optional headers |
 
 ### Custom Field Components
 

--- a/example/src/RemoteFlows.tsx
+++ b/example/src/RemoteFlows.tsx
@@ -23,11 +23,12 @@ type RemoteFlowsProps = Omit<RemoteFlowsSDKProps, 'auth'> & {
 };
 
 export const RemoteFlows = ({ children, ...props }: RemoteFlowsProps) => {
-  const isTestingMode =
-    import.meta.env.VITE_REMOTE_GATEWAY ===
-    'https://gateway.partners.remote-sandbox.com';
   return (
-    <RemoteFlowsAuth isTestingMode={isTestingMode} auth={fetchToken} {...props}>
+    <RemoteFlowsAuth
+      environment={import.meta.env.VITE_REMOTE_GATEWAY || 'partners'}
+      auth={fetchToken}
+      {...props}
+    >
       {children}
     </RemoteFlowsAuth>
   );

--- a/src/RemoteFlowsProvider.tsx
+++ b/src/RemoteFlowsProvider.tsx
@@ -12,21 +12,21 @@ const queryClient = new QueryClient();
 type RemoteFlowContextWrapperProps = {
   auth: RemoteFlowsSDKProps['auth'];
   children: React.ReactNode;
-  isTestingMode?: RemoteFlowsSDKProps['isTestingMode'];
+  environment?: RemoteFlowsSDKProps['environment'];
   proxy?: RemoteFlowsSDKProps['proxy'];
 };
 
 function RemoteFlowContextWrapper({
   children,
   auth,
-  isTestingMode,
   proxy,
+  environment,
 }: RemoteFlowContextWrapperProps) {
   const remoteApiClient = useAuth({
     auth,
     options: {
-      isTestingMode: !!isTestingMode,
       proxy,
+      environment,
     },
   });
   return (
@@ -55,17 +55,17 @@ export function RemoteFlows({
   auth,
   children,
   components,
-  isTestingMode = false,
   theme,
   proxy,
+  environment,
 }: PropsWithChildren<RemoteFlowsSDKProps>) {
   return (
     <QueryClientProvider client={queryClient}>
       <FormFieldsProvider components={components}>
         <RemoteFlowContextWrapper
-          isTestingMode={isTestingMode}
           auth={auth}
           proxy={proxy}
+          environment={environment}
         >
           <ThemeProvider theme={theme}>{children}</ThemeProvider>
         </RemoteFlowContextWrapper>

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,5 +1,6 @@
 export const ENVIRONMENTS = {
-  staging: 'https://gateway.niceremote.com',
   partners: 'https://gateway.partners.remote-sandbox.com',
   production: 'https://gateway.remote.com',
+  sandbox: 'https://gateway.remote-sandbox.com',
+  staging: 'https://gateway.niceremote.com',
 };

--- a/src/tests/useAuth.test.tsx
+++ b/src/tests/useAuth.test.tsx
@@ -65,7 +65,7 @@ describe('useAuth', () => {
     const mockAuth = vi.fn().mockResolvedValue(mockAuthResponse);
 
     renderHook(
-      () => useAuth({ auth: mockAuth, options: { isTestingMode: true } }),
+      () => useAuth({ auth: mockAuth, options: { environment: 'partners' } }),
       { wrapper },
     );
 
@@ -82,10 +82,7 @@ describe('useAuth', () => {
 
     const mockAuth = vi.fn().mockResolvedValue(mockAuthResponse);
 
-    renderHook(
-      () => useAuth({ auth: mockAuth, options: { isTestingMode: false } }),
-      { wrapper },
-    );
+    renderHook(() => useAuth({ auth: mockAuth }), { wrapper });
 
     expect(createClient).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -108,10 +105,9 @@ describe('useAuth', () => {
       }),
     });
 
-    const { result } = renderHook(
-      () => useAuth({ auth: mockAuth, options: { isTestingMode: true } }),
-      { wrapper },
-    );
+    const { result } = renderHook(() => useAuth({ auth: mockAuth }), {
+      wrapper,
+    });
 
     // Wait for the query to be ready
     await act(async () => {
@@ -144,10 +140,9 @@ describe('useAuth', () => {
       }),
     });
 
-    const { result } = renderHook(
-      () => useAuth({ auth: mockAuth, options: { isTestingMode: true } }),
-      { wrapper },
-    );
+    const { result } = renderHook(() => useAuth({ auth: mockAuth }), {
+      wrapper,
+    });
 
     // Wait for the query to be ready
     await act(async () => {
@@ -201,10 +196,9 @@ describe('useAuth', () => {
       }),
     });
 
-    const { result } = renderHook(
-      () => useAuth({ auth: mockAuth, options: { isTestingMode: true } }),
-      { wrapper },
-    );
+    const { result } = renderHook(() => useAuth({ auth: mockAuth }), {
+      wrapper,
+    });
 
     // Wait for the first query to be ready
     await act(async () => {
@@ -252,10 +246,7 @@ describe('useAuth', () => {
       },
     });
 
-    renderHook(
-      () => useAuth({ auth: mockAuth, options: { isTestingMode: true } }),
-      { wrapper },
-    );
+    renderHook(() => useAuth({ auth: mockAuth }), { wrapper });
 
     expect(createClient).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -276,7 +267,7 @@ describe('useAuth', () => {
       () =>
         useAuth({
           auth: mockAuth,
-          options: { isTestingMode: true, proxy: { url: proxyUrl } },
+          options: { proxy: { url: proxyUrl } },
         }),
       { wrapper },
     );
@@ -296,7 +287,7 @@ describe('useAuth', () => {
       () =>
         useAuth({
           auth: mockAuth,
-          options: { isTestingMode: true, proxy: { url: invalidProxyUrl } },
+          options: { environment: 'partners', proxy: { url: invalidProxyUrl } },
         }),
       { wrapper },
     );
@@ -329,7 +320,6 @@ describe('useAuth', () => {
         useAuth({
           auth: mockAuth,
           options: {
-            isTestingMode: true,
             proxy: { url: proxyUrl, headers: proxyHeaders },
           },
         }),

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -8,6 +8,7 @@ import { AnySchema } from 'yup';
 import { SupportedTypes } from '../components/form/fields/types';
 import { StatementProps } from '../components/form/Statement';
 import { ReactNode } from 'react';
+import { ENVIRONMENTS } from '../environments';
 
 type AuthResponse = {
   accessToken: string;
@@ -99,10 +100,10 @@ export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {
    */
   components?: Components;
   /**
-   * Flag to indicate if the SDK is in testing mode and use the testing environment.
-   * If true, the SDK will use the testing environment for all API calls.
+   * Environment to use for API calls.
+   * If not provided, the SDK will use production environment.
    */
-  isTestingMode?: boolean;
+  environment?: keyof typeof ENVIRONMENTS;
   proxy?: {
     /**
      * URL of the proxy server to use for API calls.

--- a/src/useAuth.ts
+++ b/src/useAuth.ts
@@ -10,10 +10,10 @@ type AuthResponse = {
   expiresIn: number;
 };
 
-type Options = {
-  isTestingMode: boolean;
-  proxy?: RemoteFlowsSDKProps['proxy'];
-};
+type Options = Partial<{
+  environment: keyof typeof ENVIRONMENTS;
+  proxy: RemoteFlowsSDKProps['proxy'];
+}>;
 
 function isValidUrl(url: string) {
   try {
@@ -29,7 +29,7 @@ export const useAuth = ({
   options,
 }: {
   auth: () => Promise<AuthResponse>;
-  options: Options;
+  options?: Options;
 }) => {
   const session = useRef<{ accessToken: string; expiresAt: number } | null>(
     null,
@@ -40,15 +40,15 @@ export const useAuth = ({
     enabled: false,
   });
 
-  const baseUrl = options.isTestingMode
-    ? ENVIRONMENTS.partners
+  const baseUrl = options?.environment
+    ? ENVIRONMENTS[options?.environment]
     : process.env.REMOTE_GATEWAY_URL;
 
   const clientConfig = client.getConfig();
   const npmPackageVersion = process.env.VERSION;
-  const isValidProxy = !!options.proxy && isValidUrl(options.proxy.url);
+  const isValidProxy = !!options?.proxy && isValidUrl(options.proxy.url);
 
-  if (options.proxy && !isValidProxy) {
+  if (options?.proxy && !isValidProxy) {
     console.error('Invalid proxy URL provided. Using default base URL.');
   }
 
@@ -57,7 +57,7 @@ export const useAuth = ({
       ...clientConfig,
       headers: {
         ...clientConfig.headers,
-        ...(isValidProxy ? options.proxy?.headers : {}),
+        ...(isValidProxy ? options?.proxy?.headers : {}),
         'X-Client-Name': 'remote-flows-sdk',
         'X-Client-Version': npmPackageVersion,
       },


### PR DESCRIPTION
Replace the deprecated `isTestingMode` boolean prop with the new `environment` prop, providing users with more granular control over Remote API base url.

### **Benefits:**

**More explicit**: Users can now specify exactly which environment they want to connect to instead of a vague "testing mode"

**Better developer experience**: Clear environment options 

**Flexibility**: Supports all available Remote environments (partners, production, sandbox, staging) rather than just production/sandbox toggle

### **Note:**

With this change `VITE_REMOTE_GATEWAY` env variable by the `example` project needs to be one of the values: production, staging, partners or sandbox.