### PR TITLE
feat(onboarding) - add save draft button functionality

### DIFF
--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -94,7 +94,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
             <SubmitButton
               className="submit-button"
               disabled={onboardingBag.isSubmitting}
-              onSuccess={() => console.log('navigate')}
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
             >
               Create Employment & Continue
             </SubmitButton>
@@ -142,7 +142,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
             </SubmitButton>
             <SaveDraftButton
               className="save-draft-button"
-              onClick={() => console.log('saving draft')}
+              onSuccess={() => console.log('saving draft')}
               disabled={onboardingBag.isSubmitting}
             >
               Save Draft

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -141,8 +141,19 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               Continue
             </SubmitButton>
             <SaveDraftButton
-              className="save-draft-button"
               onSuccess={() => console.log('saving draft')}
+              onError={({
+                error,
+                fieldErrors,
+              }: {
+                error: Error;
+                fieldErrors: NormalizedFieldError[];
+              }) => {
+                setErrors({
+                  apiError: error.message,
+                  fieldErrors,
+                });
+              }}
               disabled={onboardingBag.isSubmitting}
             >
               Save Draft

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -52,6 +52,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     BenefitsStep,
     SubmitButton,
     BackButton,
+    SaveDraftButton,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -93,7 +94,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
             <SubmitButton
               className="submit-button"
               disabled={onboardingBag.isSubmitting}
-              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+              onSuccess={() => console.log('navigate')}
             >
               Create Employment & Continue
             </SubmitButton>
@@ -139,6 +140,13 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
             >
               Continue
             </SubmitButton>
+            <SaveDraftButton
+              className="save-draft-button"
+              onClick={() => console.log('saving draft')}
+              disabled={onboardingBag.isSubmitting}
+            >
+              Save Draft
+            </SaveDraftButton>
           </div>
         </>
       );

--- a/src/flows/Onboarding/OnboardingFlow.tsx
+++ b/src/flows/Onboarding/OnboardingFlow.tsx
@@ -10,6 +10,7 @@ import { ContractDetailsStep } from '@/src/flows/Onboarding/ContractDetailsStep'
 import { BenefitsStep } from '@/src/flows/Onboarding/BenefitsStep';
 import { SelectCountryStep } from '@/src/flows/Onboarding/SelectCountryStep';
 import { ReviewStep } from '@/src/flows/Onboarding/ReviewStep';
+import { SaveDraftButton } from '@/src/flows/Onboarding/SaveDraftButton';
 
 export type OnboardingRenderProps = {
   /**
@@ -31,6 +32,7 @@ export type OnboardingRenderProps = {
    * @see {@link InvitationSection}
    * @see {@link SelectCountryStep}
    * @see {@link ReviewStep}
+   * @see {@link SaveDraftButton}
    */
   components: {
     SubmitButton: typeof OnboardingSubmit;
@@ -41,6 +43,7 @@ export type OnboardingRenderProps = {
     BenefitsStep: typeof BenefitsStep;
     SelectCountryStep: typeof SelectCountryStep;
     ReviewStep: typeof ReviewStep;
+    SaveDraftButton: typeof SaveDraftButton;
   };
 };
 
@@ -94,6 +97,7 @@ export const OnboardingFlow = ({
           ContractDetailsStep: ContractDetailsStep,
           BenefitsStep: BenefitsStep,
           SubmitButton: OnboardingSubmit,
+          SaveDraftButton: SaveDraftButton,
           BackButton: OnboardingBack,
           OnboardingInvite: OnboardingInvite,
           SelectCountryStep: SelectCountryStep,

--- a/src/flows/Onboarding/SaveDraftButton.tsx
+++ b/src/flows/Onboarding/SaveDraftButton.tsx
@@ -1,0 +1,68 @@
+import { useFormFields } from '@/src/context';
+import { useOnboardingContext } from './context';
+import { ButtonHTMLAttributes } from 'react';
+
+type SaveDraftButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'onError'
+> & {
+  onSuccess?: () => void | Promise<void>;
+  onError?: (error: Error) => void | Promise<void>;
+};
+
+export const SaveDraftButton = ({
+  onSuccess,
+  onError,
+  className,
+  children,
+  disabled = false,
+  ...props
+}: SaveDraftButtonProps) => {
+  const { onboardingBag } = useOnboardingContext();
+
+  const { components } = useFormFields();
+
+  const handleSaveDraft = async () => {
+    try {
+      // Get current form values
+      const currentValues = onboardingBag.getCurrentFormValues();
+
+      // Submit without moving to next step
+      console.log('submitting draft with current values', currentValues);
+      const response = await onboardingBag.onSubmit(currentValues);
+
+      if (response?.data) {
+        onSuccess?.();
+      } else if (response?.error) {
+        onError?.(response.error);
+      }
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  };
+
+  const CustomButton = components?.button;
+  if (CustomButton) {
+    return (
+      <CustomButton
+        {...props}
+        onClick={handleSaveDraft}
+        disabled={disabled || onboardingBag.isSubmitting}
+        className={className}
+      >
+        {children}
+      </CustomButton>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleSaveDraft}
+      disabled={disabled || onboardingBag.isSubmitting}
+      className={className}
+    >
+      {children}
+    </button>
+  );
+};

--- a/src/flows/Onboarding/SaveDraftButton.tsx
+++ b/src/flows/Onboarding/SaveDraftButton.tsx
@@ -37,7 +37,6 @@ export const SaveDraftButton = ({
   const handleSaveDraft = async () => {
     try {
       const response = await onboardingBag.onSubmit(onboardingBag.fieldValues);
-      console.log('response', response);
 
       if (response?.data) {
         onSuccess?.();

--- a/src/flows/Onboarding/SaveDraftButton.tsx
+++ b/src/flows/Onboarding/SaveDraftButton.tsx
@@ -24,13 +24,7 @@ export const SaveDraftButton = ({
 
   const handleSaveDraft = async () => {
     try {
-      // Get current form values
-      const currentValues = onboardingBag.getCurrentFormValues();
-
-      // Submit without moving to next step
-      console.log('submitting draft with current values', currentValues);
-      const response = await onboardingBag.onSubmit(currentValues);
-
+      const response = await onboardingBag.onSubmit(onboardingBag.fieldValues);
       if (response?.data) {
         onSuccess?.();
       } else if (response?.error) {

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -556,7 +556,6 @@ export const useOnboarding = ({
           };
           try {
             const response = await createEmploymentMutationAsync(payload);
-            await refetchCompany();
             setInternalEmploymentId(
               // @ts-expect-error the types from the response are not matching
               response.data?.data?.employment?.id,

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -175,8 +175,6 @@ export const useOnboarding = ({
     stepsToUse as Record<keyof typeof STEPS, Step<keyof typeof STEPS>>,
   );
 
-  const currentFormValuesRef = useRef<Record<string, unknown>>({});
-
   const { selectCountryForm, isLoading: isLoadingCountries } =
     useCountriesSchemaField({
       jsfModify: options?.jsfModify?.select_country,
@@ -615,24 +613,6 @@ export const useOnboarding = ({
     goToStep(step);
   }
 
-  const checkFieldUpdates = (values: FieldValues) => {
-    setFieldValues(values);
-    // We store the values of the form in a ref as the save draft button doesn't have access to formik's context
-    currentFormValuesRef.current = {
-      ...currentFormValuesRef.current,
-      ...values,
-    };
-  };
-
-  const getCurrentFormValues = () => {
-    const stepName = stepState.currentStep.name;
-    const stepValues = stepState.values?.[stepName] || {};
-    return {
-      ...stepValues,
-      ...currentFormValuesRef.current,
-    };
-  };
-
   return {
     /**
      * Employment id passed useful to be used between components
@@ -652,7 +632,10 @@ export const useOnboarding = ({
      */
 
     creditRiskStatus: company?.default_legal_entity_credit_risk_status,
-
+    /**
+     * Current state of the form fields for the current step.
+     */
+    fieldValues,
     /**
      * Current step state containing the current step and total number of steps
      */
@@ -721,13 +704,7 @@ export const useOnboarding = ({
      * Function to update the current form field values
      * @param values - New form values to set
      */
-    checkFieldUpdates: checkFieldUpdates,
-
-    /**
-     * Function to get current form values (for SaveDraftButton)
-     * @returns Current form values
-     */
-    getCurrentFormValues,
+    checkFieldUpdates: setFieldValues,
 
     /**
      * Function to parse form values before submission

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -175,6 +175,8 @@ export const useOnboarding = ({
     stepsToUse as Record<keyof typeof STEPS, Step<keyof typeof STEPS>>,
   );
 
+  const currentFormValuesRef = useRef<Record<string, unknown>>({});
+
   const { selectCountryForm, isLoading: isLoadingCountries } =
     useCountriesSchemaField({
       jsfModify: options?.jsfModify?.select_country,
@@ -613,6 +615,24 @@ export const useOnboarding = ({
     goToStep(step);
   }
 
+  const checkFieldUpdates = (values: FieldValues) => {
+    setFieldValues(values);
+    // We store the values of the form in a ref as the save draft button doesn't have access to formik's context
+    currentFormValuesRef.current = {
+      ...currentFormValuesRef.current,
+      ...values,
+    };
+  };
+
+  const getCurrentFormValues = () => {
+    const stepName = stepState.currentStep.name;
+    const stepValues = stepState.values?.[stepName] || {};
+    return {
+      ...stepValues,
+      ...currentFormValuesRef.current,
+    };
+  };
+
   return {
     /**
      * Employment id passed useful to be used between components
@@ -701,7 +721,13 @@ export const useOnboarding = ({
      * Function to update the current form field values
      * @param values - New form values to set
      */
-    checkFieldUpdates: setFieldValues,
+    checkFieldUpdates: checkFieldUpdates,
+
+    /**
+     * Function to get current form values (for SaveDraftButton)
+     * @returns Current form values
+     */
+    getCurrentFormValues,
 
     /**
      * Function to parse form values before submission

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -33,17 +33,13 @@ import {
   assertRadioValue,
   fillRadio,
   fillSelect,
-  selectDayInCalendar,
 } from '@/src/tests/testHelpers';
 import { NormalizedFieldError } from '@/src/lib/mutations';
 import { fireEvent } from '@testing-library/react';
-
-// Helper function to generate unique employment IDs for each test
-let employmentIdCounter = 0;
-const generateUniqueEmploymentId = () => {
-  employmentIdCounter++;
-  return `test-employment-${employmentIdCounter}-${Date.now()}`;
-};
+import {
+  fillBasicInformation,
+  generateUniqueEmploymentId,
+} from '@/src/flows/Onboarding/tests/helpers';
 
 const queryClient = new QueryClient();
 
@@ -382,75 +378,6 @@ describe('OnboardingFlow', () => {
     vi.clearAllMocks();
     mockRender.mockReset();
   });
-
-  async function fillBasicInformation(
-    values?: Partial<{
-      fullName: string;
-      personalEmail: string;
-      workEmail: string;
-      jobTitle: string;
-      country: string;
-      jobCategory: string;
-      provisionalStartDate: string;
-      hasSeniorityDate: string;
-    }>,
-  ) {
-    const defaultValues = {
-      fullName: 'John Doe',
-      personalEmail: 'john.doe@gmail.com',
-      workEmail: 'john.doe@remote.com',
-      jobTitle: 'Software Engineer',
-      provisionalStartDate: '15',
-      hasSeniorityDate: 'No',
-    };
-
-    const newValues = {
-      ...defaultValues,
-      ...values,
-    };
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/Full name/i)).toBeInTheDocument();
-    });
-
-    if (newValues?.fullName) {
-      fireEvent.change(screen.getByLabelText(/Full name/i), {
-        target: { value: newValues?.fullName },
-      });
-    }
-
-    if (newValues?.personalEmail) {
-      fireEvent.change(screen.getByLabelText(/Personal email/i), {
-        target: { value: newValues?.personalEmail },
-      });
-    }
-
-    if (newValues?.workEmail) {
-      fireEvent.change(screen.getByLabelText(/Work email/i), {
-        target: { value: newValues?.workEmail },
-      });
-    }
-
-    if (newValues?.jobTitle) {
-      fireEvent.change(screen.getByLabelText(/Job title/i), {
-        target: { value: newValues?.jobTitle },
-      });
-    }
-
-    if (newValues?.provisionalStartDate) {
-      await selectDayInCalendar(
-        newValues?.provisionalStartDate,
-        'provisional_start_date',
-      );
-    }
-
-    if (newValues?.hasSeniorityDate) {
-      await fillRadio(
-        'Does the employee have a seniority date?',
-        newValues?.hasSeniorityDate,
-      );
-    }
-  }
 
   async function fillCountry(country: string) {
     await screen.findByText(/Step: Select Country/i);

--- a/src/flows/Onboarding/tests/SaveDraftButton.test.tsx
+++ b/src/flows/Onboarding/tests/SaveDraftButton.test.tsx
@@ -1,0 +1,484 @@
+import {
+  OnboardingFlow,
+  OnboardingRenderProps,
+} from '@/src/flows/Onboarding/OnboardingFlow';
+import {
+  basicInformationSchema,
+  benefitOffersResponse,
+  benefitOffersSchema,
+  companyResponse,
+  contractDetailsSchema,
+  employmentCreatedResponse,
+  employmentResponse,
+} from '@/src/flows/Onboarding/tests/fixtures';
+import { fillBasicInformation } from '@/src/flows/Onboarding/tests/helpers';
+import { OnboardingFlowParams } from '@/src/flows/Onboarding/types';
+import { FormFieldsProvider } from '@/src/RemoteFlowsProvider';
+import { server } from '@/src/tests/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { PropsWithChildren } from 'react';
+import { vi } from 'vitest';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>
+    <FormFieldsProvider components={{}}>{children}</FormFieldsProvider>
+  </QueryClientProvider>
+);
+
+const mockSuccess = vi.fn();
+const mockError = vi.fn();
+
+const mockRender = vi.fn(
+  ({ onboardingBag, components }: OnboardingRenderProps) => {
+    const currentStepIndex = onboardingBag.stepState.currentStep.index;
+
+    const {
+      SaveDraftButton,
+      BasicInformationStep,
+      ContractDetailsStep,
+      BenefitsStep,
+      SubmitButton,
+    } = components;
+
+    const steps: Record<number, string> = {
+      [0]: 'Basic Information',
+      [1]: 'Contract Details',
+      [2]: 'Benefits',
+      [3]: 'Review',
+    };
+
+    if (onboardingBag.isLoading) {
+      return <div data-testid="spinner">Loading...</div>;
+    }
+
+    // Render the appropriate step component based on current step
+    switch (onboardingBag.stepState.currentStep.name) {
+      case 'basic_information':
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <BasicInformationStep
+              onSubmit={vi.fn()}
+              onSuccess={vi.fn()}
+              onError={vi.fn()}
+            />
+            <SubmitButton>Next Step</SubmitButton>
+            <SaveDraftButton onSuccess={mockSuccess} onError={mockError}>
+              Save Draft
+            </SaveDraftButton>
+          </>
+        );
+      case 'contract_details':
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <ContractDetailsStep
+              onSubmit={vi.fn()}
+              onSuccess={vi.fn()}
+              onError={vi.fn()}
+            />
+            <SubmitButton>Next Step</SubmitButton>
+            <SaveDraftButton onSuccess={mockSuccess} onError={mockError}>
+              Save Draft
+            </SaveDraftButton>
+          </>
+        );
+      case 'benefits':
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <BenefitsStep
+              onSubmit={vi.fn()}
+              onSuccess={vi.fn()}
+              onError={vi.fn()}
+            />
+            <SaveDraftButton onSuccess={mockSuccess} onError={mockError}>
+              Save Draft
+            </SaveDraftButton>
+          </>
+        );
+      case 'review':
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+          </>
+        );
+
+      default:
+        return null;
+    }
+  },
+);
+
+const defaultProps = {
+  companyId: '1234',
+  countryCode: 'PRT',
+  options: {},
+  render: mockRender,
+  skipSteps: ['select_country'] as OnboardingFlowParams['skipSteps'],
+};
+
+describe('SaveDraftButton', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('*/v1/companies/:companyId', () => {
+        return HttpResponse.json(companyResponse);
+      }),
+      http.get('*/v1/countries', () => {
+        return HttpResponse.json({
+          data: [
+            {
+              code: 'PRT',
+              name: 'Portugal',
+            },
+            {
+              code: 'ESP',
+              name: 'Spain',
+            },
+          ],
+        });
+      }),
+      http.get('*/v1/countries/PRT/employment_basic_information*', () => {
+        return HttpResponse.json(basicInformationSchema);
+      }),
+      http.get('*/v1/countries/PRT/contract_details*', () => {
+        return HttpResponse.json(contractDetailsSchema);
+      }),
+      http.get('*/v1/employments/:id', ({ params }) => {
+        // Create a response with the actual employment ID from the request
+        const employmentId = params?.id;
+        return HttpResponse.json({
+          ...employmentResponse,
+          data: {
+            ...employmentResponse.data,
+            employment: {
+              ...employmentResponse.data.employment,
+              id: employmentId,
+            },
+          },
+        });
+      }),
+      http.get('*/v1/employments/*/benefit-offers/schema', () => {
+        return HttpResponse.json(benefitOffersSchema);
+      }),
+      http.get('*/v1/employments/*/benefit-offers', () => {
+        return HttpResponse.json(benefitOffersResponse);
+      }),
+      http.post('*/v1/employments', () => {
+        return HttpResponse.json(employmentCreatedResponse);
+      }),
+      http.patch('*/v1/employments/*', () => {
+        return HttpResponse.json({
+          data: { status: 'ok' },
+        });
+      }),
+      http.put('*/v1/employments/*/benefit-offers', () => {
+        return HttpResponse.json({
+          data: { status: 'ok' },
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockRender.mockReset();
+  });
+
+  it('should render the SaveDraftButton component with default text', async () => {
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    await screen.findByText(/Step: Basic Information/);
+
+    const button = await screen.findByText(/Save Draft/i);
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should call onSuccess when save draft is successful for basic information step', async () => {
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    await screen.findByText(/Step: Basic Information/i); // This should work now
+
+    await fillBasicInformation();
+
+    const saveDraftButton = screen.getByText(/Save Draft/i);
+    fireEvent.click(saveDraftButton);
+
+    await waitFor(() => {
+      expect(mockSuccess).toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not advance to next step when save draft is clicked', async () => {
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    await screen.findByText(/Step: Basic Information/i);
+
+    await fillBasicInformation();
+
+    const saveDraftButton = screen.getByText(/Save Draft/i);
+    fireEvent.click(saveDraftButton);
+
+    await waitFor(() => {
+      expect(mockSuccess).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText(/Step: Basic Information/i)).toBeInTheDocument();
+  });
+
+  it('should call onError when save draft fails', async () => {
+    server.use(
+      http.post('*/v1/employments', () => {
+        return HttpResponse.json(
+          { error: 'Failed to save draft' },
+          { status: 400 },
+        );
+      }),
+    );
+
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    await screen.findByText(/Step: Basic Information/i);
+
+    await fillBasicInformation();
+
+    const saveDraftButton = screen.getByText(/Save Draft/i);
+    fireEvent.click(saveDraftButton);
+
+    await waitFor(() => {
+      expect(mockError).toHaveBeenCalled();
+      expect(mockSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should call onError with correct error structure when save draft fails with 422', async () => {
+    server.use(
+      http.post('*/v1/employments', () => {
+        return HttpResponse.json(
+          {
+            message: 'Validation failed',
+            errors: {
+              provisional_start_date: ['cannot be in a holiday'],
+            },
+          },
+          { status: 422 },
+        );
+      }),
+    );
+
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    await screen.findByText(/Step: Basic Information/i);
+
+    await fillBasicInformation();
+
+    const saveDraftButton = screen.getByText(/Save Draft/i);
+    fireEvent.click(saveDraftButton);
+
+    await waitFor(() => {
+      expect(mockError).toHaveBeenCalledWith({
+        error: new Error('Validation failed'),
+        rawError: {
+          message: 'Validation failed',
+          errors: {
+            provisional_start_date: ['cannot be in a holiday'],
+          },
+        },
+        fieldErrors: [
+          {
+            field: 'provisional_start_date',
+            messages: ['cannot be in a holiday'],
+            userFriendlyLabel: 'Provisional start date',
+          },
+        ],
+      });
+    });
+    expect(mockSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should disable button when disabled prop is passed', async () => {
+    mockRender.mockImplementationOnce(({ components }) => {
+      const { SaveDraftButton } = components;
+      return (
+        <SaveDraftButton
+          disabled={true}
+          onSuccess={mockSuccess}
+          onError={mockError}
+        >
+          Save Draft
+        </SaveDraftButton>
+      );
+    });
+
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    const button = await screen.findByText(/Save Draft/i);
+    expect(button).toBeDisabled();
+  });
+
+  it('should disable button when onboardingBag.isSubmitting is true', async () => {
+    server.use(
+      http.post('*/v1/employments', () => {
+        // Return a delayed response to keep the mutation pending
+        return new Promise(() => {}); // Never resolves to keep pending
+      }),
+    );
+
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    // Navigate to contract details step
+    await screen.findByText(/Step: Basic Information/i);
+
+    await fillBasicInformation();
+
+    const saveDraftButton = screen.getByText(/Save Draft/i);
+    expect(saveDraftButton).toBeInTheDocument();
+
+    fireEvent.click(saveDraftButton);
+
+    // Wait a bit and check if button becomes disabled
+    await waitFor(() => {
+      expect(saveDraftButton).toBeDisabled();
+    });
+  });
+
+  it('should show custom children text when provided', async () => {
+    mockRender.mockImplementationOnce(({ components }) => {
+      const { SaveDraftButton } = components;
+      return (
+        <SaveDraftButton
+          className="custom-class"
+          onSuccess={mockSuccess}
+          onError={mockError}
+        >
+          Custom Save Text
+        </SaveDraftButton>
+      );
+    });
+
+    render(<OnboardingFlow {...defaultProps} />, { wrapper });
+
+    const button = await screen.findByText(/Custom Save Text/i);
+    expect(button).toHaveTextContent('Custom Save Text');
+    expect(button).toHaveClass('custom-class');
+  });
+
+  describe('custom button component support', () => {
+    const MockCustomButton = vi.fn(
+      ({ children, onClick, disabled, ...props }) => (
+        <button onClick={onClick} disabled={disabled} {...props}>
+          {children}
+        </button>
+      ),
+    );
+
+    beforeEach(() => {
+      MockCustomButton.mockClear();
+    });
+
+    const customWrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>
+        <FormFieldsProvider components={{ button: MockCustomButton }}>
+          {children}
+        </FormFieldsProvider>
+      </QueryClientProvider>
+    );
+
+    it('should use custom button when provided via FormFieldsProvider', async () => {
+      mockRender.mockImplementation(({ components }) => {
+        const { SaveDraftButton } = components;
+        return (
+          <SaveDraftButton
+            onSuccess={mockSuccess}
+            onError={mockError}
+            disabled={true}
+            className="test-class"
+          >
+            Save Draft
+          </SaveDraftButton>
+        );
+      });
+
+      render(<OnboardingFlow {...defaultProps} />, {
+        wrapper: customWrapper,
+      });
+
+      const customButton = await screen.findByText(/Save Draft/i);
+      expect(customButton).toBeInTheDocument();
+
+      // Verify custom button received correct props
+      expect(MockCustomButton).toHaveBeenCalledWith(
+        expect.objectContaining({
+          className: 'test-class',
+          disabled: true,
+          onClick: expect.any(Function),
+          children: 'Save Draft',
+        }),
+        {},
+      );
+    });
+
+    it('should handle onClick correctly with custom button', async () => {
+      mockRender.mockImplementationOnce(({ components }) => {
+        const { SaveDraftButton } = components;
+        return (
+          <SaveDraftButton onSuccess={mockSuccess} onError={mockError}>
+            Save Draft
+          </SaveDraftButton>
+        );
+      });
+
+      render(<OnboardingFlow {...defaultProps} />, {
+        wrapper: customWrapper,
+      });
+
+      await screen.findByText(/Step: Basic Information/i);
+
+      await fillBasicInformation();
+
+      const customButton = await screen.findByText(/Save Draft/i);
+      fireEvent.click(customButton);
+
+      await waitFor(() => {
+        expect(mockSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it('should disable custom button during mutation loading', async () => {
+      server.use(
+        http.post('*/v1/employments', () => {
+          // Return a delayed response to keep the mutation pending
+          return new Promise(() => {}); // Never resolves to keep pending
+        }),
+      );
+
+      render(<OnboardingFlow {...defaultProps} />, {
+        wrapper: customWrapper,
+      });
+
+      await screen.findByText(/Step: Basic Information/i);
+
+      await fillBasicInformation();
+
+      const customButton = await screen.findByText(/Save Draft/i);
+      expect(customButton).not.toBeDisabled(); // Initially not disabled
+
+      fireEvent.click(customButton);
+
+      // Wait for the button to become disabled due to pending mutation
+      await waitFor(() => {
+        expect(MockCustomButton).toHaveBeenCalledWith(
+          expect.objectContaining({
+            disabled: true,
+          }),
+          {},
+        );
+      });
+    });
+  });
+});

--- a/src/flows/Onboarding/tests/helpers.ts
+++ b/src/flows/Onboarding/tests/helpers.ts
@@ -1,0 +1,78 @@
+import { fillRadio, selectDayInCalendar } from '@/src/tests/testHelpers';
+import { fireEvent, waitFor, screen } from '@testing-library/react';
+
+// Helper function to generate unique employment IDs for each test
+let employmentIdCounter = 0;
+export const generateUniqueEmploymentId = () => {
+  employmentIdCounter++;
+  return `test-employment-${employmentIdCounter}-${Date.now()}`;
+};
+
+export async function fillBasicInformation(
+  values?: Partial<{
+    fullName: string;
+    personalEmail: string;
+    workEmail: string;
+    jobTitle: string;
+    country: string;
+    jobCategory: string;
+    provisionalStartDate: string;
+    hasSeniorityDate: string;
+  }>,
+) {
+  const defaultValues = {
+    fullName: 'John Doe',
+    personalEmail: 'john.doe@gmail.com',
+    workEmail: 'john.doe@remote.com',
+    jobTitle: 'Software Engineer',
+    provisionalStartDate: '15',
+    hasSeniorityDate: 'No',
+  };
+
+  const newValues = {
+    ...defaultValues,
+    ...values,
+  };
+
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Full name/i)).toBeInTheDocument();
+  });
+
+  if (newValues?.fullName) {
+    fireEvent.change(screen.getByLabelText(/Full name/i), {
+      target: { value: newValues?.fullName },
+    });
+  }
+
+  if (newValues?.personalEmail) {
+    fireEvent.change(screen.getByLabelText(/Personal email/i), {
+      target: { value: newValues?.personalEmail },
+    });
+  }
+
+  if (newValues?.workEmail) {
+    fireEvent.change(screen.getByLabelText(/Work email/i), {
+      target: { value: newValues?.workEmail },
+    });
+  }
+
+  if (newValues?.jobTitle) {
+    fireEvent.change(screen.getByLabelText(/Job title/i), {
+      target: { value: newValues?.jobTitle },
+    });
+  }
+
+  if (newValues?.provisionalStartDate) {
+    await selectDayInCalendar(
+      newValues?.provisionalStartDate,
+      'provisional_start_date',
+    );
+  }
+
+  if (newValues?.hasSeniorityDate) {
+    await fillRadio(
+      'Does the employee have a seniority date?',
+      newValues?.hasSeniorityDate,
+    );
+  }
+}


### PR DESCRIPTION
Add a draft button, which saves the data into the form but it doesn't advance to the next step

Partners want to have a button that saves and then they can listen to the onSuccess callback and navigate to other page