### PR TITLE
feat(cost-calculator) - use client token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ npm install
 2. Create a `.env` file in the example directory with your Remote credentials:
 
 ```env
-CLIENT_ID=your_client_id
-CLIENT_SECRET=your_client_secret
-REFRESH_TOKEN=your_refresh_token
+VITE_CLIENT_ID=your_client_id
+VITE_CLIENT_SECRET=your_client_secret
+VITE_REFRESH_TOKEN=your_refresh_token
 VITE_REMOTE_GATEWAY=partners # for sandbox
 # VITE_REMOTE_GATEWAY=production # for production
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ create an .env file
 
 ```sh
 cd example
-echo "CLIENT_ID=\nCLIENT_SECRET=\nVITE_REMOTE_GATEWAY=\nREFRESH_TOKEN=\n" >> .env
+echo "VITE_CLIENT_ID=\nVITE_CLIENT_SECRET=\nVITE_REMOTE_GATEWAY=\nVITE_REFRESH_TOKEN=\n" >> .env
 ```
 
 Complete the env file with your env variables and you should be able to run the next step

--- a/example/api/get_token.js
+++ b/example/api/get_token.js
@@ -6,20 +6,29 @@ const ENVIRONMENTS = {
 };
 
 async function getToken(req, res) {
-  const { CLIENT_ID, CLIENT_SECRET, VITE_REMOTE_GATEWAY, REFRESH_TOKEN } =
-    process.env;
+  const {
+    VITE_CLIENT_ID,
+    VITE_CLIENT_SECRET,
+    VITE_REMOTE_GATEWAY,
+    VITE_REFRESH_TOKEN,
+  } = process.env;
 
-  if (!CLIENT_ID || !CLIENT_SECRET || !VITE_REMOTE_GATEWAY || !REFRESH_TOKEN) {
+  if (
+    !VITE_CLIENT_ID ||
+    !VITE_CLIENT_SECRET ||
+    !VITE_REMOTE_GATEWAY ||
+    !VITE_REFRESH_TOKEN
+  ) {
     return res.status(400).json({
       error:
-        'Missing CLIENT_ID, CLIENT_SECRET, VITE_REMOTE_GATEWAY, or REFRESH_TOKEN',
+        'Missing VITE_CLIENT_ID, VITE_CLIENT_SECRET, VITE_REMOTE_GATEWAY, or REFRESH_TOKEN',
     });
   }
 
   const gatewayUrl = ENVIRONMENTS[VITE_REMOTE_GATEWAY];
 
   const encodedCredentials = Buffer.from(
-    `${CLIENT_ID}:${CLIENT_SECRET}`,
+    `${VITE_CLIENT_ID}:${VITE_CLIENT_SECRET}`,
   ).toString('base64');
 
   try {
@@ -31,7 +40,7 @@ async function getToken(req, res) {
       },
       body: new URLSearchParams({
         grant_type: 'refresh_token',
-        refresh_token: REFRESH_TOKEN,
+        refresh_token: VITE_REFRESH_TOKEN,
       }),
     });
 

--- a/example/src/BasicCostCalculator.tsx
+++ b/example/src/BasicCostCalculator.tsx
@@ -21,7 +21,7 @@ export function BasicCostCalculator() {
   };
 
   return (
-    <RemoteFlows>
+    <RemoteFlows isClientToken>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
         render={(props) => {

--- a/example/src/BasicCostCalculatorDefaultValues.tsx
+++ b/example/src/BasicCostCalculatorDefaultValues.tsx
@@ -16,7 +16,7 @@ const estimationOptions = {
 
 export function BasicCostCalculatorWithDefaultValues() {
   return (
-    <RemoteFlows>
+    <RemoteFlows isClientToken>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
         defaultValues={{

--- a/example/src/BasicCostCalculatorLabels.tsx
+++ b/example/src/BasicCostCalculatorLabels.tsx
@@ -16,7 +16,7 @@ const estimationOptions = {
 
 export function BasicCostCalculatorLabels() {
   return (
-    <RemoteFlows>
+    <RemoteFlows isClientToken>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
         render={(props) => {

--- a/example/src/CostCalculatorWithReplaceableComponents.tsx
+++ b/example/src/CostCalculatorWithReplaceableComponents.tsx
@@ -3,24 +3,11 @@ import {
   CostCalculatorForm,
   CostCalculatorSubmitButton,
   CostCalculatorResetButton,
-  RemoteFlows,
   CostCalculatorDisclaimer,
 } from '@remoteoss/remote-flows';
 import { components } from './Components';
+import { RemoteFlows } from './RemoteFlows';
 import './css/main.css';
-
-const fetchToken = () => {
-  return fetch('/api/token')
-    .then((res) => res.json())
-    .then((data) => ({
-      accessToken: data.access_token,
-      expiresIn: data.expires_in,
-    }))
-    .catch((error) => {
-      console.error({ error });
-      throw error;
-    });
-};
 
 const estimationOptions = {
   title: 'Estimate for a new company',
@@ -35,7 +22,7 @@ export const CostCalculatorWithReplaceableComponents = () => {
   };
 
   return (
-    <RemoteFlows components={components} auth={fetchToken}>
+    <RemoteFlows isClientToken components={components}>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
         render={(props) => {

--- a/example/src/CostCalculatorWithResults.tsx
+++ b/example/src/CostCalculatorWithResults.tsx
@@ -23,7 +23,7 @@ export function CostCalculatorWithResults() {
     useState<CostCalculatorEstimateResponse | null>(null);
 
   return (
-    <RemoteFlows>
+    <RemoteFlows isClientToken>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
         render={(props) => {

--- a/example/src/RemoteFlows.tsx
+++ b/example/src/RemoteFlows.tsx
@@ -18,8 +18,11 @@ const fetchToken = () => {
 };
 
 const fetchClientToken = () => {
+  const accessToken = btoa(
+    `${import.meta.env.VITE_CLIENT_ID}:${import.meta.env.VITE_CLIENT_TOKEN}`,
+  );
   return Promise.resolve({
-    accessToken: import.meta.env.VITE_CLIENT_TOKEN || '',
+    accessToken: accessToken || '',
     expiresIn: 3600, // Default expiration time in seconds
   });
 };

--- a/example/src/RemoteFlows.tsx
+++ b/example/src/RemoteFlows.tsx
@@ -17,16 +17,28 @@ const fetchToken = () => {
     });
 };
 
+const fetchClientToken = () => {
+  return Promise.resolve({
+    accessToken: import.meta.env.VITE_CLIENT_TOKEN || '',
+    expiresIn: 3600, // Default expiration time in seconds
+  });
+};
+
 type RemoteFlowsProps = Omit<RemoteFlowsSDKProps, 'auth'> & {
   children: ReactNode;
   auth?: RemoteFlowsSDKProps['auth'];
+  isClientToken?: boolean;
 };
 
-export const RemoteFlows = ({ children, ...props }: RemoteFlowsProps) => {
+export const RemoteFlows = ({
+  children,
+  isClientToken,
+  ...props
+}: RemoteFlowsProps) => {
   return (
     <RemoteFlowsAuth
       environment={import.meta.env.VITE_REMOTE_GATEWAY || 'partners'}
-      auth={fetchToken}
+      auth={!isClientToken ? fetchToken : fetchClientToken}
       {...props}
     >
       {children}


### PR DESCRIPTION
Use the client token for the authentication

I decided to change the naming of the vars for consistency

To access the vars in the FE, I need the VITE prefix

I am going to set in local the envs that we have in vercel to make the changes there and make sure nothing breaks