### PR TITLE
chore: return client token on production

### DIFF
--- a/example/api/get_token.js
+++ b/example/api/get_token.js
@@ -19,6 +19,7 @@ function buildGatewayURL() {
 async function getToken(req, res) {
   const {
     VITE_CLIENT_ID,
+    VITE_CLIENT_TOKEN,
     VITE_CLIENT_SECRET,
     VITE_REMOTE_GATEWAY,
     VITE_REFRESH_TOKEN,
@@ -26,8 +27,13 @@ async function getToken(req, res) {
   } = process.env;
 
   if (NODE_ENV === 'production') {
-    return res.status(403).json({
-      error: 'This endpoint is not available in production mode',
+    const encodedClientToken = Buffer.from(
+      `${VITE_CLIENT_ID}:${VITE_CLIENT_TOKEN}`,
+    ).toString('base64');
+
+    return res.status(200).json({
+      access_token: encodedClientToken,
+      expires_in: 3600,
     });
   }
 


### PR DESCRIPTION
This commit returns client token on production instead of the access token.

We probably want a safer strategy, we should return client token unless explicitly set that we should return the access token, if we want to use access tokens at all.
i.e instead of NODE_ENV == production, we should return by default the cient token, unless say something like RETURN_ACCESS_TOKEN == true. That way if say the app is deployed publicly, but with NODE_ENV set to a different environment (staging), we wuold not be be leaking the access token.