### PR TITLE
feat: disable overridding currency rate & use client token in premium cc

### DIFF
--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -109,7 +109,7 @@ function CostCalculatorFormDemo() {
 
 export function CostCalculatorWithPremiumBenefits() {
   return (
-    <RemoteFlows>
+    <RemoteFlows isClientToken>
       <CostCalculatorFormDemo />
     </RemoteFlows>
   );

--- a/src/flows/CostCalculator/Results/CostCalculatorResults.tsx
+++ b/src/flows/CostCalculator/Results/CostCalculatorResults.tsx
@@ -1,4 +1,3 @@
-import { Euro } from 'lucide-react';
 import { lazy, useState } from 'react';
 
 import { CostCalculatorEstimateResponse } from '@/src/client';
@@ -101,7 +100,6 @@ export function CostCalculatorResults({
         <div className="RemoteFlows__CostCalculatorResults__Header">
           <h2 className="text-xl font-semibold flex items-center gap-2">
             <span className="flex items-center gap-1">
-              <Euro className="h-5 w-5 text-gray-600" />
               {options?.title ?? 'Cost Calculator'}
             </span>
             <Badge className="ml-2">{employment.country.name}</Badge>

--- a/src/flows/CostCalculator/tests/utils.test.ts
+++ b/src/flows/CostCalculator/tests/utils.test.ts
@@ -25,7 +25,6 @@ describe('buildPayload', () => {
           annual_gross_salary_in_employer_currency: 100_000,
           employment_term: 'fixed',
           title: defaultEstimationOptions.title,
-          regional_to_employer_exchange_rate: '1',
         },
       ],
     });

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -64,7 +64,6 @@ export function buildPayload(
         annual_gross_salary_in_employer_currency: values.salary,
         employment_term: values.contract_duration_type ?? 'fixed',
         title: estimationOptions.title,
-        regional_to_employer_exchange_rate: '1',
         age: values.age ?? undefined,
         ...(values.benefits && { benefits: formatBenefits(values.benefits) }),
       },


### PR DESCRIPTION
Removes the hardcoded EURO sign
stops overriding the conversion rate, and adds isClientToken to the endpoint.

I will need a release to point to once it's merged, so i can update package.json.

I think we should setup vercel to always use the local directory, but i think we need a monorepo setup on vercel for that, not critical, but a bit annoying to have to always update package.json, since you almost always want to point to master. or splitting the apps to make it clearer, not sure, no strong opinion.