### PR TITLE
fix(cost-calculator) - fix benefits

### DIFF
--- a/src/flows/CostCalculator/tests/utils.test.ts
+++ b/src/flows/CostCalculator/tests/utils.test.ts
@@ -107,4 +107,25 @@ describe('buildPayload', () => {
     expect(payload.include_cost_breakdowns).toBe(false);
     expect(payload.employments[0].title).toBe('Custom Title');
   });
+
+  it('should not include some of the benefits if none is selected', () => {
+    const values: CostCalculatorEstimationSubmitValues = {
+      currency: 'USD',
+      country: 'US',
+      salary: 100_000,
+      benefits: {
+        'benefit-health': 'whatever',
+        'benefit-dental': 'none',
+      },
+    };
+
+    const payload = buildPayload(values);
+
+    expect(payload.employments[0].benefits).toEqual([
+      {
+        benefit_group_slug: 'health',
+        benefit_tier_slug: 'whatever',
+      },
+    ]);
+  });
 });

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -33,10 +33,14 @@ function formatBenefits(benefits: Record<string, string>) {
   return Object.keys(benefits).reduce<
     Array<{ benefit_group_slug: string; benefit_tier_slug: string }>
   >((acc, key) => {
+    const benefitTierSlug = benefits[key];
+    if (benefitTierSlug === 'none') {
+      return acc;
+    }
     const benefitGroupSlug = key.replace(needle, '');
     const benefitEntry = {
       benefit_group_slug: benefitGroupSlug,
-      benefit_tier_slug: benefits[key],
+      benefit_tier_slug: benefitTierSlug,
     };
     return [...acc, benefitEntry];
   }, []);


### PR DESCRIPTION
When a benefit was select as none in the cost calculator produce a 422 error in the API.

Now we filter the value to avoid sending it to the API