### PR TITLE
fix(fieldsets): Trigger manual validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8511,9 +8511,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.54.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
-      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "version": "7.60.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
+      "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
       "engines": {
         "node": ">=18.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8511,9 +8511,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
-      "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "engines": {
         "node": ">=18.0.0"
       },

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -3,6 +3,8 @@ import { cn } from '@/src/lib/utils';
 import { SupportedTypes } from './types';
 import { Components } from '@/src/types/remoteFlows';
 import { Statement, StatementProps } from '@/src/components/form/Statement';
+import { useFormContext } from 'react-hook-form';
+import { useEffect, useRef } from 'react';
 
 type FieldBase = {
   label: string;
@@ -39,6 +41,51 @@ export function FieldSetField({
   components,
   statement,
 }: FieldSetProps) {
+  const { watch, trigger } = useFormContext();
+  const fieldNames = fields.map(
+    ({ name: fieldName }) => `${name}.${fieldName}`,
+  );
+  const watchedValues = watch(fieldNames);
+  const prevValuesRef = useRef<string[]>(watchedValues);
+  const triggerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const currentValues = watchedValues;
+    const previousValues = prevValuesRef.current;
+
+    // Check if any value has changed
+    let hasChanged = false;
+    for (let i = 0; i < currentValues.length; i++) {
+      if (
+        currentValues[i] !== undefined &&
+        previousValues[i] !== currentValues[i]
+      ) {
+        hasChanged = true;
+        // This is to prevent the form from triggering validation too many times
+        break;
+      }
+    }
+    // If changes detected and we haven't triggered yet, run trigger
+    if (hasChanged) {
+      // We need to debounce the validation trigger so that tests don't freeze
+      if (triggerTimeoutRef.current) {
+        clearTimeout(triggerTimeoutRef.current);
+      }
+      triggerTimeoutRef.current = setTimeout(() => {
+        trigger();
+      }, 50);
+
+      return;
+    }
+    prevValuesRef.current = [...currentValues];
+
+    return () => {
+      if (triggerTimeoutRef.current) {
+        clearTimeout(triggerTimeoutRef.current);
+      }
+    };
+  }, [watchedValues, trigger]);
+
   return (
     <fieldset
       className={cn(

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -74,9 +74,8 @@ export function FieldSetField({
       triggerTimeoutRef.current = setTimeout(() => {
         trigger();
       }, 50);
-
-      return;
     }
+
     prevValuesRef.current = [...currentValues];
 
     return () => {


### PR DESCRIPTION
This PR fixes a bug where the error state is not properly updated when a field is inside a fieldset. Even though these fields have no errors, the UI would continue to indicate that an error existed.

The root cause of this behavior with fieldsets isn't entirely clear, so the solution involves triggering manual validation for fieldsets whenever one of their values changes.