### PR TITLE
fix(onboarding): Support to multi select and bug fixing

### DIFF
--- a/src/components/form/JSONSchemaForm.tsx
+++ b/src/components/form/JSONSchemaForm.tsx
@@ -55,7 +55,11 @@ export const JSONSchemaFormFields = ({
           return <Component key={field.name as string} {...field} />;
         }
 
-        const FieldComponent = fieldsMap[field.inputType as SupportedTypes];
+        let FieldComponent = fieldsMap[field.inputType as SupportedTypes];
+
+        if (field.inputType === 'select' && field.multiple) {
+          FieldComponent = fieldsMap['multi-select'];
+        }
 
         if (field.inputType === 'fieldset') {
           return <FieldComponent {...field} components={components} />;

--- a/src/components/form/fields/MultiSelectField.tsx
+++ b/src/components/form/fields/MultiSelectField.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useFormFields } from '@/src/context';
+import { Components, JSFField } from '@/src/types/remoteFlows';
+import { useFormContext } from 'react-hook-form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '../../ui/form';
+import { MultiSelect } from '../../ui/multi-select';
+import { useState } from 'react';
+
+type MultiSelectFieldProps = JSFField & {
+  placeholder?: string;
+  options: Array<{ value: string; label: string }>;
+  className?: string;
+  onChange?: (value: any) => void;
+  component?: Components['select'];
+};
+
+export function MultiSelectField({
+  label,
+  name,
+  options,
+  defaultValue,
+  description,
+  onChange,
+  component,
+  ...rest
+}: MultiSelectFieldProps) {
+  const { control } = useFormContext();
+  const { components } = useFormFields();
+  const [selected, setSelected] = useState<any[]>();
+
+  return (
+    <FormField
+      defaultValue={defaultValue}
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        const CustomSelectField = component || components?.['multi-select'];
+        if (CustomSelectField) {
+          const customSelectFieldProps = {
+            label,
+            name,
+            options,
+            defaultValue,
+            description,
+            onChange,
+            ...rest,
+          };
+          return (
+            <CustomSelectField
+              field={{
+                ...field,
+                onChange: (value: any) => {
+                  field.onChange(value);
+                  onChange?.(value);
+                },
+              }}
+              fieldState={fieldState}
+              fieldData={customSelectFieldProps}
+            />
+          );
+        }
+
+        const selectedOptions =
+          selected ||
+          options.filter((option) => field.value.includes(option.value));
+
+        return (
+          <FormItem
+            data-field={name}
+            className={`RemoteFlows__SelectField__Item__${name}`}
+          >
+            <FormLabel className="RemoteFlows__SelectField__Label">
+              {label}
+            </FormLabel>
+            <FormControl>
+              <MultiSelect
+                options={options}
+                selected={selectedOptions}
+                onChange={(rawValues: any[]) => {
+                  const values = rawValues.map(({ value }) => value);
+                  field.onChange(values);
+                  onChange?.(values);
+                  setSelected(rawValues);
+                }}
+                {...rest}
+              />
+            </FormControl>
+            {description && <FormDescription>{description}</FormDescription>}
+            {fieldState.error && <FormMessage />}
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -21,7 +21,7 @@ import {
 
 type SelectFieldProps = JSFField & {
   placeholder?: string;
-  options: Array<{ value: string; label: string }>;
+  options: Array<{ value: string | number; label: string }>;
   className?: string;
   onChange?: (value: any) => void;
   component?: Components['select'];
@@ -61,9 +61,9 @@ export function SelectField({
             <CustomSelectField
               field={{
                 ...field,
-                onChange: (value: any) => {
+                onChange: (value: string | number) => {
                   const maybeCastValue =
-                    typeof value !== 'number' ? +value : value;
+                    !isNaN(Number(value)) && typeof value !== 'boolean';
                   field.onChange(maybeCastValue);
                   onChange?.(maybeCastValue);
                 },
@@ -88,7 +88,9 @@ export function SelectField({
                   value={field.value || ''}
                   onValueChange={(value: string) => {
                     const maybeCastValue =
-                      typeof value !== 'number' ? +value : value;
+                      !isNaN(Number(value)) && typeof value !== 'boolean'
+                        ? Number(value)
+                        : value;
                     field.onChange(maybeCastValue);
                     onChange?.(maybeCastValue);
                   }}

--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -62,8 +62,10 @@ export function SelectField({
               field={{
                 ...field,
                 onChange: (value: any) => {
-                  field.onChange(value);
-                  onChange?.(value);
+                  const maybeCastValue =
+                    typeof value !== 'number' ? +value : value;
+                  field.onChange(maybeCastValue);
+                  onChange?.(maybeCastValue);
                 },
               }}
               fieldState={fieldState}
@@ -85,6 +87,10 @@ export function SelectField({
                 <Select
                   value={field.value || ''}
                   onValueChange={(value: string) => {
+                    // const maybeCastValue =
+                    //   typeof value !== 'number' ? +value : value;
+                    // field.onChange(maybeCastValue);
+                    // onChange?.(maybeCastValue);
                     field.onChange(value);
                     onChange?.(value);
                   }}

--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -87,6 +87,8 @@ export function SelectField({
                 <Select
                   value={field.value || ''}
                   onValueChange={(value: string) => {
+                    // For some reason react-hook-form converts option values from numbers to strings.
+                    // If a value can be cast to a number, the field in the form state should use the numeric type instead.
                     const maybeCastValue =
                       !isNaN(Number(value)) && typeof value !== 'boolean'
                         ? Number(value)

--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -87,12 +87,10 @@ export function SelectField({
                 <Select
                   value={field.value || ''}
                   onValueChange={(value: string) => {
-                    // const maybeCastValue =
-                    //   typeof value !== 'number' ? +value : value;
-                    // field.onChange(maybeCastValue);
-                    // onChange?.(maybeCastValue);
-                    field.onChange(value);
-                    onChange?.(value);
+                    const maybeCastValue =
+                      typeof value !== 'number' ? +value : value;
+                    field.onChange(maybeCastValue);
+                    onChange?.(maybeCastValue);
                   }}
                 >
                   <SelectTrigger

--- a/src/components/form/fields/fieldsMapping.tsx
+++ b/src/components/form/fields/fieldsMapping.tsx
@@ -13,6 +13,7 @@ import { SupportedTypes } from '@/src/components/form/fields/types';
 import { HiddenField } from '@/src/components/form/fields/HiddenField';
 import { WorkScheduleField } from '@/src/components/form/fields/WorkScheduleField';
 import React from 'react';
+import { MultiSelectField } from './MultiSelectField';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fieldsMap: Record<SupportedTypes, React.ComponentType<any>> = {
@@ -21,6 +22,7 @@ export const fieldsMap: Record<SupportedTypes, React.ComponentType<any>> = {
   email: EmailField,
   money: NumberField,
   select: SelectField,
+  'multi-select': MultiSelectField,
   radio: RadioGroupField,
   number: NumberField,
   file: FileUploadField,

--- a/src/components/form/fields/tests/MultiSelectField.test.tsx
+++ b/src/components/form/fields/tests/MultiSelectField.test.tsx
@@ -1,0 +1,340 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useFormFields } from '@/src/context';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { array } from 'yup';
+import { MultiSelectField } from '../MultiSelectField';
+
+type MultiSelectFieldProps = React.ComponentProps<typeof MultiSelectField>;
+
+// Mock dependencies
+vi.mock('@/src/context', () => ({
+  useFormFields: vi.fn(),
+}));
+
+describe('MultiSelectField Component', () => {
+  const mockOnChange = vi.fn();
+  const defaultProps: MultiSelectFieldProps = {
+    name: 'testField',
+    label: 'Test Field',
+    description: 'This is a test field',
+    type: 'array',
+    computedAttributes: {},
+    errorMessage: {
+      required: 'This field is required',
+    },
+    inputType: 'multi-select' as const,
+    isVisible: true,
+    jsonType: 'array',
+    required: true,
+    schema: array(),
+    scopedJsonSchema: {},
+    options: [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2' },
+      { value: 'option3', label: 'Option 3' },
+    ],
+  };
+
+  // Helper function to render the component with a form context
+  const renderWithFormContext = (
+    props: MultiSelectFieldProps,
+    defaultValues?: any,
+  ) => {
+    const TestComponent = () => {
+      const methods = useForm({
+        defaultValues: defaultValues || { [props.name]: [] },
+      });
+      return (
+        <FormProvider {...methods}>
+          <MultiSelectField {...props} />
+        </FormProvider>
+      );
+    };
+
+    return render(<TestComponent />);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useFormFields as any).mockReturnValue({ components: {} });
+  });
+
+  it('renders the default implementation correctly', () => {
+    renderWithFormContext(defaultProps);
+
+    expect(screen.getByText('Test Field')).toBeInTheDocument();
+    expect(screen.getByText('This is a test field')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('displays placeholder when no options are selected', () => {
+    renderWithFormContext(defaultProps);
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+    // MultiSelect should show placeholder text when no options are selected
+  });
+
+  it('handles multi-selection correctly', async () => {
+    renderWithFormContext({ ...defaultProps, onChange: mockOnChange });
+
+    // Open the dropdown
+    const trigger = screen.getByRole('combobox');
+    fireEvent.click(trigger);
+
+    // Wait for options to appear
+    await waitFor(() => {
+      expect(
+        screen.getByRole('option', { name: 'Option 1' }),
+      ).toBeInTheDocument();
+    });
+
+    // Select first option
+    fireEvent.click(screen.getByRole('option', { name: 'Option 1' }));
+
+    expect(mockOnChange).toHaveBeenCalledWith(['option1']);
+  });
+
+  it('handles multiple option selection', async () => {
+    renderWithFormContext({ ...defaultProps, onChange: mockOnChange });
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.click(trigger);
+
+    // Wait for dropdown to open and options to be available
+    await waitFor(() => {
+      expect(
+        screen.getByRole('option', { name: 'Option 1' }),
+      ).toBeInTheDocument();
+    });
+
+    // Select multiple options
+    fireEvent.click(screen.getByRole('option', { name: 'Option 1' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Option 2' }));
+
+    expect(mockOnChange).toHaveBeenCalledWith(['option1']);
+    expect(mockOnChange).toHaveBeenCalledWith(['option1', 'option2']);
+  });
+
+  it('handles option deselection', async () => {
+    renderWithFormContext(
+      { ...defaultProps, onChange: mockOnChange },
+      { testField: ['option1', 'option2'] },
+    );
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('option', { name: 'Option 1' }),
+      ).toBeInTheDocument();
+    });
+
+    // Deselect option 1
+    fireEvent.click(screen.getByRole('option', { name: 'Option 1' }));
+
+    expect(mockOnChange).toHaveBeenCalledWith(['option2']);
+  });
+
+  it('displays selected options as badges', () => {
+    renderWithFormContext(defaultProps, { testField: ['option1', 'option2'] });
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  it('allows removing selected options via badge X button', async () => {
+    renderWithFormContext(
+      { ...defaultProps, onChange: mockOnChange },
+      { testField: ['option1', 'option2'] },
+    );
+
+    // Find the X button for Option 1
+    const removeButton = screen.getByLabelText('remove Option 1');
+    fireEvent.click(removeButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith(['option2']);
+  });
+
+  it('renders custom multi-select component when provided', () => {
+    const CustomMultiSelectField = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="custom-multi-select-field">
+          Custom Multi-Select Field
+        </div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { 'multi-select': CustomMultiSelectField },
+    });
+
+    renderWithFormContext({ ...defaultProps, onChange: mockOnChange });
+
+    expect(CustomMultiSelectField).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('custom-multi-select-field')).toBeInTheDocument();
+  });
+
+  it('passes field props to custom component correctly', () => {
+    const CustomMultiSelectField = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="custom-multi-select-field">
+          Custom Multi-Select Field
+        </div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { 'multi-select': CustomMultiSelectField },
+    });
+
+    renderWithFormContext({ ...defaultProps, onChange: mockOnChange });
+
+    const call = CustomMultiSelectField.mock.calls[0][0];
+    expect(call.fieldData).toMatchObject(defaultProps);
+    expect(call.field).toBeDefined();
+    expect(call.fieldState).toBeDefined();
+  });
+
+  it('handles onChange in custom multi-select component', () => {
+    const CustomMultiSelectField = vi.fn().mockImplementation(({ field }) => {
+      const handleChange = (values: string[]) => {
+        field.onChange(values);
+      };
+
+      return (
+        <div>
+          <button
+            data-testid="custom-select-option"
+            onClick={() => handleChange(['option1', 'option2'])}
+          >
+            Select Options
+          </button>
+        </div>
+      );
+    });
+
+    (useFormFields as any).mockReturnValue({
+      components: { 'multi-select': CustomMultiSelectField },
+    });
+
+    renderWithFormContext({ ...defaultProps, onChange: mockOnChange });
+
+    const selectButton = screen.getByTestId('custom-select-option');
+    fireEvent.click(selectButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith(['option1', 'option2']);
+  });
+
+  it('component prop takes precedence over useFormFields().components', () => {
+    const CustomMultiSelectFieldFromContext = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="context-multi-select-field">
+          Context Multi-Select Field
+        </div>
+      ));
+    const CustomMultiSelectFieldProp = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="prop-multi-select-field">Prop Multi-Select Field</div>
+      ));
+
+    (useFormFields as any).mockReturnValue({
+      components: { 'multi-select': CustomMultiSelectFieldFromContext },
+    });
+
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      component: CustomMultiSelectFieldProp,
+    });
+
+    expect(CustomMultiSelectFieldProp).toHaveBeenCalled();
+    expect(screen.getByTestId('prop-multi-select-field')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('context-multi-select-field'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('handles defaultValue correctly', () => {
+    renderWithFormContext(defaultProps, { testField: ['option1', 'option3'] });
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+  });
+
+  it('applies correct CSS classes', () => {
+    renderWithFormContext(defaultProps);
+
+    const formItem = document.querySelector('[data-field="testField"]');
+    expect(formItem).toHaveClass('RemoteFlows__SelectField__Item__testField');
+  });
+
+  it('shows form validation errors', () => {
+    const TestComponentWithError = () => {
+      const methods = useForm({
+        defaultValues: { testField: [] },
+      });
+
+      // Trigger validation error
+      methods.setError('testField', {
+        type: 'required',
+        message: 'This field is required',
+      });
+
+      return (
+        <FormProvider {...methods}>
+          <MultiSelectField {...defaultProps} />
+        </FormProvider>
+      );
+    };
+
+    render(<TestComponentWithError />);
+
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('handles empty options array', () => {
+    renderWithFormContext({
+      ...defaultProps,
+      options: [],
+    });
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.click(trigger);
+
+    // Should show "No item found" message
+    expect(screen.getByText('No item found.')).toBeInTheDocument();
+  });
+
+  it('passes additional props to MultiSelect component', () => {
+    const placeholder = 'Select multiple options';
+    const className = 'custom-multi-select';
+
+    renderWithFormContext({
+      ...defaultProps,
+      placeholder,
+      className,
+    });
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+    // Additional props should be passed through to the MultiSelect component
+  });
+
+  it('handles keyboard navigation for removing selected options', async () => {
+    renderWithFormContext(
+      { ...defaultProps, onChange: mockOnChange },
+      { testField: ['option1'] },
+    );
+
+    const removeButton = screen.getByLabelText('remove Option 1');
+    fireEvent.keyDown(removeButton, { key: 'Enter' });
+
+    expect(mockOnChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/form/fields/types.ts
+++ b/src/components/form/fields/types.ts
@@ -3,6 +3,7 @@ export type SupportedTypes =
   | 'number'
   | 'email'
   | 'select'
+  | 'multi-select'
   | 'radio'
   | 'fieldset'
   | 'date'

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -43,6 +43,8 @@ export function MultiSelect({
     onChange(selected.filter((item) => item.value !== option.value));
   };
 
+  const hasCategories = options.some((option) => option.category);
+
   const groupedOptions = options.reduce(
     (groups, option) => {
       const category = option.category || 'Uncategorized';
@@ -111,7 +113,7 @@ export function MultiSelect({
               ([category, categoryOptions], index) => (
                 <Fragment key={category}>
                   {index > 0 && <CommandSeparator />}
-                  <CommandGroup heading={category}>
+                  <CommandGroup heading={hasCategories ? category : undefined}>
                     {categoryOptions.map((option) => {
                       const isSelected = selected.some(
                         (item) => item.value === option.value,

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -510,7 +510,7 @@ export const useOnboarding = ({
       stepState.currentStep.name === 'basic_information'
     ) {
       return parseJSFToValidate(values, basicInformationForm?.fields, {
-        isPartialValidation: true,
+        isPartialValidation: false,
       });
     }
 
@@ -519,7 +519,7 @@ export const useOnboarding = ({
       stepState.currentStep.name === 'contract_details'
     ) {
       return parseJSFToValidate(values, contractDetailsForm?.fields, {
-        isPartialValidation: true,
+        isPartialValidation: false,
       });
     }
 
@@ -678,6 +678,7 @@ export const useOnboarding = ({
         const parsedValues = parseJSFToValidate(
           values,
           benefitOffersSchema?.fields,
+          { isPartialValidation: false },
         );
 
         return benefitOffersSchema?.handleValidation(parsedValues);
@@ -689,6 +690,7 @@ export const useOnboarding = ({
         const parsedValues = parseJSFToValidate(
           values,
           basicInformationForm?.fields,
+          { isPartialValidation: false },
         );
         return basicInformationForm?.handleValidation(parsedValues);
       }
@@ -700,6 +702,7 @@ export const useOnboarding = ({
         const parsedValues = parseJSFToValidate(
           values,
           contractDetailsForm?.fields,
+          { isPartialValidation: false },
         );
         return contractDetailsForm?.handleValidation(parsedValues);
       }

--- a/src/tests/testHelpers.ts
+++ b/src/tests/testHelpers.ts
@@ -73,7 +73,7 @@ export async function fillRadio(radioName: string, radioValue: string) {
 
 export async function fillSelect(selectName: string, selectValue: string) {
   const user = userEvent.setup();
-  const select = screen.getByRole('combobox', {
+  const select = await screen.findByRole('combobox', {
     name: new RegExp(selectName, 'i'),
   });
   expect(select).toBeInTheDocument();


### PR DESCRIPTION
- Fixed: `probation_length_days` (or any `select` with numbers as values) is now submitted as an integer instead of a string
- Fixed: `probation_length_days` is no longer submitted when "Add a probation period" is set to "no". The fix is agnostic, which means that a field that isn't visible won't be part of the payload.
- Fixed: Weekly days off are now properly submitted as an array (e.g., `["tuesday"]` or `["tuesday", "wednesday"]`) instead of a single string