### PR TITLE
fix(onboarding): Fix selected benefits

### DIFF
--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -122,7 +122,10 @@ export const useBenefitOffers = (employmentId: string | undefined) => {
           return {
             ...acc,
             [item.benefit_group.slug]: {
-              value: item.benefit_tier?.slug ?? '',
+              value: item.benefit_tier?.slug ?? 'no',
+              ...(item.benefit_group?.filter?.slug
+                ? { filter: item.benefit_group?.filter?.slug }
+                : {}),
             },
           };
         },


### PR DESCRIPTION
Fix the default values for the review step when:
- `I don't want to offer this benefit.` is the selected option
- A benefit is selected under a different tab