### PR TITLE
feat(cost-calculator): Add version parameter to CostCalculatorFlow

### DIFF
--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -1,6 +1,7 @@
 import { useJsonSchemasValidationFormResolver } from '@/src/components/form/yupValidationResolver';
 import { CostCalculatorContext } from '@/src/flows/CostCalculator/context';
 import {
+  CostCalculatorVersion,
   defaultEstimationOptions,
   useCostCalculator,
 } from '@/src/flows/CostCalculator/hooks';
@@ -37,6 +38,10 @@ export type CostCalculatorFlowProps = {
   render: (
     costCalculatorBag: ReturnType<typeof useCostCalculator>,
   ) => React.ReactNode;
+  /**
+   * Whether to include annual_gross_salary in the estimation payload
+   */
+  version?: CostCalculatorVersion;
 };
 
 export const CostCalculatorFlow = ({
@@ -48,11 +53,13 @@ export const CostCalculatorFlow = ({
   },
   options,
   render,
+  version = 'standard',
 }: CostCalculatorFlowProps) => {
   const formId = useId();
   const costCalculatorBag = useCostCalculator({
     defaultRegion: defaultValues.countryRegionSlug,
     estimationOptions,
+    version,
     options,
   });
   const resolver = useJsonSchemasValidationFormResolver(

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -521,12 +521,13 @@ export function CostCalculatorFlowWithPremiumBenefits() {
 
 The `CostCalculatorFlow` component lets you render different components like `CostCalculatorForm`, `CostCalculatorSubmitButton`, `CostCalculatorResetButton`
 
-| Prop               | Type                                                         | Required | Description                                                                             |
-| ------------------ | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------- |
-| `estimationParams` | object                                                       | No       | Customization for the estimation response (see table below)                             |
-| `defaultValues`    | object                                                       | No       | Predefined form values (see table below)                                                |
-| `render`           | `(costCalculatorBag:  ReturnType<typeof useCostCalculator>)` | Yes      | render prop function with the params passed by the useCostCalculator hook               |
-| `options`          | `{jsfModify: JSFModify}`                                     | No       | JSFModify options lets you modify properties from the form, such as changing the labels |
+| Prop               | Type                                                         | Required | Description                                                                                                               |
+| ------------------ | ------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `estimationParams` | object                                                       | No       | Customization for the estimation response (see table below)                                                               |
+| `defaultValues`    | object                                                       | No       | Predefined form values (see table below)                                                                                  |
+| `render`           | `(costCalculatorBag:  ReturnType<typeof useCostCalculator>)` | Yes      | render prop function with the params passed by the useCostCalculator hook                                                 |
+| `options`          | `{jsfModify: JSFModify}`                                     | No       | JSFModify options lets you modify properties from the form, such as changing the labels                                   |
+| `version`          | `'standard' \| 'marketing'`                                  | No       | Controls payload structure. `'standard'` includes `annual_gross_salary`, `'marketing'` excludes it. Default: `'standard'` |
 
 #### estimationParams Properties
 

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -26,6 +26,8 @@ import {
 import { JSFField } from '@/src/types/remoteFlows';
 import { SalaryField } from '@/src/flows/CostCalculator/components/SalaryField';
 
+export type CostCalculatorVersion = 'standard' | 'marketing';
+
 type CostCalculatorCountry = {
   value: string;
   label: string;
@@ -66,6 +68,7 @@ type UseCostCalculatorParams = {
   options?: {
     jsfModify?: JSFModify;
   };
+  version?: CostCalculatorVersion;
 };
 
 export type EstimationError = PostCreateEstimationError | ValidationError;
@@ -83,7 +86,12 @@ const useStaticSchema = (options?: { jsfModify?: JSFModify }) => {
  * Hook to use the cost calculator.
  */
 export const useCostCalculator = (
-  { defaultRegion, estimationOptions, options }: UseCostCalculatorParams = {
+  {
+    defaultRegion,
+    estimationOptions,
+    options,
+    version,
+  }: UseCostCalculatorParams = {
     estimationOptions: defaultEstimationOptions,
   },
 ) => {
@@ -190,7 +198,7 @@ export const useCostCalculator = (
 
     return new Promise((resolve, reject) => {
       costCalculatorEstimationMutation.mutate(
-        buildPayload(values, estimationOptions),
+        buildPayload(values, estimationOptions, version),
         {
           onSuccess: (response) => {
             if (response.data) {

--- a/src/flows/CostCalculator/tests/utils.test.ts
+++ b/src/flows/CostCalculator/tests/utils.test.ts
@@ -128,4 +128,65 @@ describe('buildPayload', () => {
       },
     ]);
   });
+
+  describe('version parameter', () => {
+    const values: CostCalculatorEstimationSubmitValues = {
+      currency: 'USD',
+      country: 'US',
+      salary: 100_000,
+    };
+
+    it('should include annual_gross_salary when version is "standard"', () => {
+      const payload = buildPayload(
+        values,
+        defaultEstimationOptions,
+        'standard',
+      );
+
+      expect(payload.employments[0]).toHaveProperty('annual_gross_salary');
+      expect(payload.employments[0].annual_gross_salary).toBe(100_000);
+      expect(payload.employments[0]).toHaveProperty(
+        'annual_gross_salary_in_employer_currency',
+      );
+      expect(
+        payload.employments[0].annual_gross_salary_in_employer_currency,
+      ).toBe(100_000);
+    });
+
+    it('should NOT include annual_gross_salary when version is "marketing"', () => {
+      const payload = buildPayload(
+        values,
+        defaultEstimationOptions,
+        'marketing',
+      );
+
+      expect(payload.employments[0]).not.toHaveProperty('annual_gross_salary');
+      expect(payload.employments[0]).toHaveProperty(
+        'annual_gross_salary_in_employer_currency',
+      );
+      expect(
+        payload.employments[0].annual_gross_salary_in_employer_currency,
+      ).toBe(100_000);
+    });
+
+    it('should default to "standard" behavior when version is not provided', () => {
+      const payload = buildPayload(values, defaultEstimationOptions);
+
+      expect(payload.employments[0]).toHaveProperty('annual_gross_salary');
+      expect(payload.employments[0].annual_gross_salary).toBe(100_000);
+      expect(payload.employments[0]).toHaveProperty(
+        'annual_gross_salary_in_employer_currency',
+      );
+      expect(
+        payload.employments[0].annual_gross_salary_in_employer_currency,
+      ).toBe(100_000);
+    });
+
+    it('should default to "standard" behavior when only values parameter is provided', () => {
+      const payload = buildPayload(values);
+
+      expect(payload.employments[0]).toHaveProperty('annual_gross_salary');
+      expect(payload.employments[0].annual_gross_salary).toBe(100_000);
+    });
+  });
 });

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -2,7 +2,7 @@ import type { CostCalculatorEstimateParams } from '@/src/client';
 
 import { $TSFixMe } from '@/src/types/remoteFlows';
 import { AnyObjectSchema, object } from 'yup';
-import { defaultEstimationOptions } from './hooks';
+import { CostCalculatorVersion, defaultEstimationOptions } from './hooks';
 import type {
   CostCalculatorEstimationOptions,
   CostCalculatorEstimationSubmitValues,
@@ -55,6 +55,7 @@ function formatBenefits(benefits: Record<string, string>) {
 export function buildPayload(
   values: CostCalculatorEstimationSubmitValues,
   estimationOptions: CostCalculatorEstimationOptions = defaultEstimationOptions,
+  version: CostCalculatorVersion = 'standard',
 ): CostCalculatorEstimateParams {
   return {
     employer_currency_slug: values.currency,
@@ -64,12 +65,14 @@ export function buildPayload(
     employments: [
       {
         region_slug: values.region || values.country,
-        annual_gross_salary: values.salary,
         annual_gross_salary_in_employer_currency: values.salary,
         employment_term: values.contract_duration_type ?? 'fixed',
         title: estimationOptions.title,
         age: values.age ?? undefined,
         ...(values.benefits && { benefits: formatBenefits(values.benefits) }),
+        ...(version === 'standard' && {
+          annual_gross_salary: values.salary,
+        }),
       },
     ],
   };


### PR DESCRIPTION
Introduced `version` prop with options `standard` and `marketing` and updated `buildPayload` function to conditionally include `annual_gross_salary` based on the version.