### PR TITLE
feat(onboarding): support minimum onboarding date (mot)

### DIFF
--- a/src/components/form/fields/DatePickerField.tsx
+++ b/src/components/form/fields/DatePickerField.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CalendarIcon } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
+import { PopoverClose } from '@radix-ui/react-popover';
 
 import { Button } from '@/src/components/ui/button';
 import { Calendar } from '@/src/components/ui/calendar';
@@ -20,7 +21,7 @@ import {
 import { useFormFields } from '@/src/context';
 import { cn } from '@/src/lib/utils';
 import { Components, JSFField } from '@/src/types/remoteFlows';
-import { PopoverClose } from '@radix-ui/react-popover';
+import { getMinStartDate } from '@/src/components/form/utils';
 import { format } from 'date-fns';
 
 export type DatePickerFieldProps = JSFField & {
@@ -39,6 +40,14 @@ export function DatePickerField({
 }: DatePickerFieldProps) {
   const { components } = useFormFields();
   const { control } = useFormContext();
+
+  let minDateValue: Date;
+  if (rest.meta?.mot && typeof rest.meta.mot === 'number') {
+    minDateValue = getMinStartDate(rest.meta.mot);
+  } else if (minDate) {
+    minDateValue = new Date(minDate);
+  }
+
   return (
     <FormField
       control={control}
@@ -51,8 +60,8 @@ export function DatePickerField({
             description,
             label,
             name,
-            minDate,
             onChange,
+            ...(minDateValue && { minDate: minDateValue.toISOString() }),
             ...rest,
           };
           return (
@@ -108,7 +117,7 @@ export function DatePickerField({
                     field.onChange(date ? format(date, 'yyyy-MM-dd') : null);
                     onChange?.(date);
                   }}
-                  defaultMonth={minDate ? new Date(minDate) : undefined}
+                  defaultMonth={minDateValue}
                   components={{
                     DayContent: (props) => {
                       return (
@@ -116,8 +125,8 @@ export function DatePickerField({
                       );
                     },
                   }}
-                  {...(minDate && {
-                    disabled: (date: Date) => date < new Date(minDate),
+                  {...(minDateValue && {
+                    disabled: (date: Date) => date < minDateValue,
                   })}
                 />
               </PopoverContent>

--- a/src/components/form/fields/tests/DatePickerField.test.tsx
+++ b/src/components/form/fields/tests/DatePickerField.test.tsx
@@ -3,12 +3,21 @@ import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
+import { addBusinessDays } from 'date-fns';
 import { DatePickerField, DatePickerFieldProps } from '../DatePickerField';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
   useFormFields: vi.fn(),
 }));
+
+vi.mock('date-fns', async () => {
+  const actual = await vi.importActual('date-fns');
+  return {
+    ...actual,
+    addBusinessDays: vi.fn(),
+  };
+});
 
 describe('DatePickerField Component', () => {
   const mockOnChange = vi.fn();
@@ -46,6 +55,7 @@ describe('DatePickerField Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (useFormFields as any).mockReturnValue({ components: {} });
+    (addBusinessDays as any).mockClear();
   });
 
   it('renders the default implementation correctly', () => {
@@ -165,5 +175,53 @@ describe('DatePickerField Component', () => {
     expect(
       screen.queryByTestId('context-date-picker-field'),
     ).not.toBeInTheDocument();
+  });
+
+  it.only('calculates minDateValue using addBusinessDays when rest.meta.mot is provided', () => {
+    const propsWithMot = {
+      ...defaultProps,
+      meta: { mot: 20 },
+    };
+
+    renderWithFormContext(propsWithMot);
+
+    // Verify addBusinessDays was called with a date and mot value
+    expect(addBusinessDays).toHaveBeenCalledWith(expect.any(Date), 21);
+    expect(addBusinessDays).toHaveBeenCalledTimes(1);
+
+    // Verify the component renders without errors
+    expect(screen.getByText('Test Field')).toBeInTheDocument();
+  });
+
+  it('falls back to minDate when rest.meta.mot is not a number', () => {
+    const propsWithMinDate = {
+      ...defaultProps,
+      minDate: '2024-01-10',
+      meta: { mot: 'invalid' },
+    };
+
+    renderWithFormContext(propsWithMinDate);
+
+    // Verify addBusinessDays was not called
+    expect(addBusinessDays).not.toHaveBeenCalled();
+
+    // Verify the component renders without errors
+    expect(screen.getByText('Test Field')).toBeInTheDocument();
+  });
+
+  it('handles undefined meta.mot gracefully', () => {
+    const propsWithoutMot = {
+      ...defaultProps,
+      minDate: '2024-01-10',
+      meta: {},
+    };
+
+    renderWithFormContext(propsWithoutMot);
+
+    // Verify addBusinessDays was not called
+    expect(addBusinessDays).not.toHaveBeenCalled();
+
+    // The component should still render correctly
+    expect(screen.getByText('Test Field')).toBeInTheDocument();
   });
 });

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Field } from '@/src/flows/types';
 import { $TSFixMe, Fields } from '@remoteoss/json-schema-form';
+import { addBusinessDays, isWeekend, nextMonday } from 'date-fns';
 import get from 'lodash.get';
 
 const textInputTypes = {
@@ -674,6 +675,13 @@ export function getInitialValues(
   return initialValues;
 }
 
+/**
+ * Wraps fields listed in fieldsets with a fieldset field.
+ * @param fields - Complete fields list.
+ * @param fieldsets - fields list to be wrapped in a fieldset field.
+ * @param values - Values for each field.
+ * @returns The fields with the fieldsets wrapped.
+ */
 export function getFieldsWithFlatFieldsets({
   fields = [],
   fieldsets = {},
@@ -744,4 +752,22 @@ export function getFieldsWithFlatFieldsets({
   );
 
   return filteredFields;
+}
+
+/**
+ * Get the minimum start date for the onboarding process.
+ * @param minOnBoardingTime
+ * @returns Date
+ */
+export function getMinStartDate(minOnBoardingTime: number) {
+  const today = new Date();
+
+  // Make sure our base date is UTC and set the time to 00:00:00
+  today.setDate(today.getUTCDate());
+  today.setHours(0, 0, 0, 0);
+
+  // The + 1 ensures you get the full preparation time before the employee can actually start working.
+  // It's the difference between "preparation completes on this day" vs "earliest possible start date after preparation".
+  const minDate = addBusinessDays(today, minOnBoardingTime + 1);
+  return isWeekend(minDate) ? nextMonday(minDate) : minDate;
 }

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -40,6 +40,7 @@ export type JSFField = {
   minDate?: string;
   maxLength?: number;
   multiple?: boolean;
+  meta?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
A discrepancy existed between minimum onboarding date at Remote and on the SDK. This happened because the SDK wasn't considering the `mot` property that comes in this field.

This PR adds support for minimum onboarding data. When a field includes a `mot` value:

```
{
    meta: {
        mot: 20
    }
}
```

the minimum onboarding data cannot be the date minDate.