### PR TITLE
fix(onboarding): enable ack when an employment id exists

### DIFF
--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -760,7 +760,7 @@ export function enableAckFields(
 ) {
   let result = values;
   fields.forEach((field) => {
-    if (typeof field === 'object' && field !== null && 'const' in field) {
+    if ('const' in field) {
       result = Object.fromEntries(
         Object.entries(values).map(([k, v]) => {
           if (k === field.name) {

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -745,3 +745,25 @@ export function getFieldsWithFlatFieldsets({
 
   return filteredFields;
 }
+
+export function enableAckFields(
+  fields: Fields,
+  values: Record<string, unknown>,
+) {
+  let result = values;
+  Object.keys(fields).forEach((key) => {
+    const field = fields[key as keyof Fields];
+
+    if (typeof field === 'object' && field !== null && 'const' in field) {
+      result = Object.fromEntries(
+        Object.entries(values).map(([k, v]) => {
+          if (k === field.name) {
+            return [k, field.const];
+          }
+          return [k, v];
+        }),
+      );
+    }
+  });
+  return result;
+}

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -759,9 +759,7 @@ export function enableAckFields(
   values: Record<string, unknown>,
 ) {
   let result = values;
-  Object.keys(fields).forEach((key) => {
-    const field = fields[key as keyof Fields];
-
+  fields.forEach((field) => {
     if (typeof field === 'object' && field !== null && 'const' in field) {
       result = Object.fromEntries(
         Object.entries(values).map(([k, v]) => {

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/src/flows/Onboarding/utils';
 import {
   getInitialValues,
+  enableAckFields,
   parseJSFToValidate,
 } from '@/src/components/form/utils';
 import { mutationToPromise } from '@/src/lib/mutations';
@@ -349,13 +350,21 @@ export const useOnboarding = ({
     fieldValues,
   ]);
 
-  const stepFields: Record<keyof typeof STEPS, Fields> = {
-    select_country: selectCountryForm?.fields || [],
-    basic_information: basicInformationForm?.fields || [],
-    contract_details: contractDetailsForm?.fields || [],
-    benefits: benefitOffersSchema?.fields || [],
-    review: [],
-  };
+  const stepFields: Record<keyof typeof STEPS, Fields> = useMemo(
+    () => ({
+      select_country: selectCountryForm?.fields || [],
+      basic_information: basicInformationForm?.fields || [],
+      contract_details: contractDetailsForm?.fields || [],
+      benefits: benefitOffersSchema?.fields || [],
+      review: [],
+    }),
+    [
+      selectCountryForm?.fields,
+      basicInformationForm?.fields,
+      contractDetailsForm?.fields,
+      benefitOffersSchema?.fields,
+    ],
+  );
 
   const stepFieldsWithFlatFieldsets: Record<
     keyof typeof STEPS,
@@ -407,20 +416,41 @@ export const useOnboarding = ({
     [stepFields.benefits, initialValuesBenefitOffers],
   );
 
-  const initialValues = useMemo(
-    () => ({
+  const initialValues = useMemo(() => {
+    if (employment) {
+      return {
+        select_country: selectCountryInitialValues,
+        // We don't store ack fields in the db, eg "ack_start_date_ammendment" for Argentina, and therefore is not returned in the employment response
+        // So when an employmentId exists, it means that the user has already started the onboarding process, and we need to enable the ack fields
+        basic_information: enableAckFields(
+          stepFields['basic_information'],
+          basicInformationInitialValues,
+        ),
+        contract_details:
+          // if contract details is null, it means it has not been filled yet, so we can't enable the ack fields
+          employment?.contract_details !== null
+            ? enableAckFields(
+                stepFields['contract_details'],
+                contractDetailsInitialValues,
+              )
+            : contractDetailsInitialValues,
+        benefits: benefitsInitialValues,
+      };
+    }
+    return {
       select_country: selectCountryInitialValues,
       basic_information: basicInformationInitialValues,
       contract_details: contractDetailsInitialValues,
       benefits: benefitsInitialValues,
-    }),
-    [
-      selectCountryInitialValues,
-      basicInformationInitialValues,
-      contractDetailsInitialValues,
-      benefitsInitialValues,
-    ],
-  );
+    };
+  }, [
+    selectCountryInitialValues,
+    basicInformationInitialValues,
+    contractDetailsInitialValues,
+    benefitsInitialValues,
+    employment,
+    stepFields,
+  ]);
 
   const { isLoading, isNavigatingToReview, isEmploymentReadOnly } = useMemo(
     () =>


### PR DESCRIPTION
Some ack fields are not stored in the database, such as "ack_start_date_ammendment" for Argentina, and therefore are not returned in the employment response. Ideally, the solution should be implemented on the backend, with the employment response including these fields. For now, the solution is to enable the ack fields whenever an employmentId exists (for example, when an onboarding is saved as a draft), as this indicates that the user has already started the onboarding process.