### PR TITLE
fix(select): Fix onchange value in a custom select

### DIFF
--- a/src/components/form/fields/SelectField.tsx
+++ b/src/components/form/fields/SelectField.tsx
@@ -63,7 +63,9 @@ export function SelectField({
                 ...field,
                 onChange: (value: string | number) => {
                   const maybeCastValue =
-                    !isNaN(Number(value)) && typeof value !== 'boolean';
+                    !isNaN(Number(value)) && typeof value !== 'boolean'
+                      ? Number(value)
+                      : value;
                   field.onChange(maybeCastValue);
                   onChange?.(maybeCastValue);
                 },


### PR DESCRIPTION
A regression happened in the value passed to the onChange callback of the select component. This PR fixes the issue.