### PR TITLE
feat(money) - avoid big salaries that aren't supported by the API

### DIFF
--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -36,6 +36,7 @@ const Input = ({ field, fieldData, fieldState }: FieldComponentProps) => {
           <input
             id={field.name}
             className={`input input-with-currency-field ${hasError ? 'error' : ''}`}
+            maxLength={fieldData.maxLength}
             {...field}
           />
           <span className="currency-symbol">
@@ -46,6 +47,7 @@ const Input = ({ field, fieldData, fieldState }: FieldComponentProps) => {
         <input
           id={field.name}
           className={`input ${hasError ? 'error' : ''}`}
+          maxLength={fieldData.maxLength}
           {...field}
         />
       )}

--- a/src/components/form/fields/CurrencyConversionField.tsx
+++ b/src/components/form/fields/CurrencyConversionField.tsx
@@ -182,6 +182,7 @@ export const CurrencyConversionField = ({
         type="text"
         inputMode="decimal"
         pattern="^[0-9.]*$"
+        maxLength={15}
         onChange={handleMainFieldChange}
       />
       {showConversion && (
@@ -193,6 +194,7 @@ export const CurrencyConversionField = ({
           type="text"
           inputMode="decimal"
           pattern="^[0-9.]*$"
+          maxLength={15}
           onChange={handleConversionFieldChange}
         />
       )}

--- a/src/components/form/fields/MoneyField.tsx
+++ b/src/components/form/fields/MoneyField.tsx
@@ -1,0 +1,10 @@
+import {
+  NumberField,
+  NumberFieldProps,
+} from '@/src/components/form/fields/NumberField';
+
+// TODO: We use the number field and the the number type is what the partner overrides
+// TODO: this needs to be changed in the future with the changes from https://github.com/remoteoss/remote-flows/pull/128
+export const MoneyField = (props: NumberFieldProps) => {
+  return <NumberField maxLength={15} {...props} />;
+};

--- a/src/components/form/fields/NumberField.tsx
+++ b/src/components/form/fields/NumberField.tsx
@@ -5,7 +5,7 @@ import { FormField } from '../../ui/form';
 import { TextField, TextFieldProps } from './TextField';
 import { Components } from '@/src/types/remoteFlows';
 
-type NumberFieldProps = TextFieldProps & {
+export type NumberFieldProps = TextFieldProps & {
   component?: Components['number'];
 };
 

--- a/src/components/form/fields/TextField.tsx
+++ b/src/components/form/fields/TextField.tsx
@@ -54,6 +54,7 @@ export function TextField({
             type,
             onChange,
             metadata: additionalProps,
+            maxLength,
             ...rest,
           };
           return (

--- a/src/components/form/fields/TextField.tsx
+++ b/src/components/form/fields/TextField.tsx
@@ -34,6 +34,7 @@ export function TextField({
   component,
   includeErrorMessage = true,
   additionalProps = {},
+  maxLength,
   ...rest
 }: TextFieldProps) {
   const { components } = useFormFields();
@@ -90,6 +91,7 @@ export function TextField({
                 }}
                 className="RemoteFlows__TextField__Input"
                 placeholder={label}
+                maxLength={maxLength}
               />
             </FormControl>
             {description && (

--- a/src/components/form/fields/fieldsMapping.tsx
+++ b/src/components/form/fields/fieldsMapping.tsx
@@ -12,15 +12,16 @@ import { EmailField } from '@/src/components/form/fields/EmailField';
 import { SupportedTypes } from '@/src/components/form/fields/types';
 import { HiddenField } from '@/src/components/form/fields/HiddenField';
 import { WorkScheduleField } from '@/src/components/form/fields/WorkScheduleField';
+import { MultiSelectField } from '@/src/components/form/fields/MultiSelectField';
+import { MoneyField } from '@/src/components/form/fields/MoneyField';
 import React from 'react';
-import { MultiSelectField } from './MultiSelectField';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fieldsMap: Record<SupportedTypes, React.ComponentType<any>> = {
   checkbox: CheckBoxField,
   text: TextField,
   email: EmailField,
-  money: NumberField,
+  money: MoneyField,
   select: SelectField,
   'multi-select': MultiSelectField,
   radio: RadioGroupField,


### PR DESCRIPTION
We had a bug report that we very big salaries were a problem.

I decided to put a limit on how big the number is

To do this, I added the maxLength attribute to the AnnualGrossSalary fields and I created a MoneyField which wraps the NumberField

This change affects to the AnnualGrossSalary but also to the salary field in the cost calculator
