### PR TITLE
fix(FieldSetField): add support for multiple select fields based on inputType

### DIFF
--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -12,6 +12,8 @@ type FieldBase = {
   name: string;
   description: string;
   Component?: React.ComponentType<any>;
+  inputType: SupportedTypes;
+  multiple?: boolean;
 };
 
 type FieldWithOptions = FieldBase & {
@@ -105,7 +107,7 @@ export function FieldSetField({
       ) : null}
       <div className="grid gap-4">
         {fields.map((field) => {
-          const FieldComponent = fieldsMap[field.type];
+          let FieldComponent = fieldsMap[field.type];
 
           // @ts-expect-error - TODO: use types from json-schema-form v1
           if (field.isVisible === false || field.deprecated) {
@@ -117,6 +119,10 @@ export function FieldSetField({
               Component: React.ComponentType<any>;
             };
             return <Component key={field.name} {...field} />;
+          }
+
+          if (field.inputType === 'select' && field.multiple) {
+            FieldComponent = fieldsMap['multi-select'];
           }
 
           return (


### PR DESCRIPTION
While testing the onboarding flow for the Dominican Republic, I found that `multi-select` (example in the screenshot) was not rendering properly (it was rendered as a single select) inside fieldsets. This PR resolves this issue.

<img width="694" height="819" alt="SCR-20250721-lzzq" src="https://github.com/user-attachments/assets/37f00a9e-5733-4f65-90e8-0ff974057613" />

