### PR TITLE
fix(form) - bundle dependencies to avoid duplicated dependencies

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -24,4 +24,6 @@ export const tsup: Options = {
     REMOTE_GATEWAY_URL:
       env === 'production' ? ENVIRONMENTS.production : ENVIRONMENTS.staging,
   },
+  external: ['react', 'react-dom'],
+  noExternal: ['react-hook-form', '@hookform/resolvers'],
 };


### PR DESCRIPTION
After I saw that if you fix in the consumer app the react-hook-form version, I decided to bundle the dependencies and that way, I hope the bug gets solved

We can create a prerelease to check if everything works as expected