### PR TITLE
feat(onboarding) - improve onboarding button disabled status

### DIFF
--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -179,7 +179,6 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
           </div>
         </>
       );
-
     case 'benefits':
       return (
         <div className="benefits-container">

--- a/example/src/ReviewStep.tsx
+++ b/example/src/ReviewStep.tsx
@@ -38,6 +38,15 @@ const CreditRiskSections = ({
   employment?: Employment;
 }) => {
   switch (creditRiskState) {
+    case 'referred':
+      return (
+        <InviteSection
+          title={`Confirm ${employment?.basic_information?.name} Profile`}
+          description="Once your account is approved, you can invite your employees to Remote."
+        >
+          <OnboardingAlertStatuses creditRiskStatus={creditRiskStatus} />
+        </InviteSection>
+      );
     case 'deposit_required':
       return (
         <InviteSection
@@ -127,16 +136,11 @@ function Review({ meta }: { meta: Meta }) {
   );
 }
 
-const DISABLED_BUTTON_EMPLOYMENT_STATUS: Employment['status'][] = [
-  'created_awaiting_reserve',
-  'invited',
-];
-
 export const MyOnboardingInviteButton = ({
   creditRiskStatus,
   Component,
   setErrors,
-  employment,
+  canInvite,
 }: {
   creditRiskStatus?: CreditRiskStatus;
   Component: React.ComponentType<OnboardingInviteProps>;
@@ -144,15 +148,12 @@ export const MyOnboardingInviteButton = ({
     apiError: string;
     fieldErrors: NormalizedFieldError[];
   }) => void;
-  employment?: Employment;
+  canInvite?: boolean;
 }) => {
-  const isDisabled =
-    employment &&
-    DISABLED_BUTTON_EMPLOYMENT_STATUS.includes(employment?.status);
   if (creditRiskStatus !== 'referred') {
     return (
       <Component
-        disabled={isDisabled}
+        disabled={!canInvite}
         className="submit-button"
         onSuccess={() => {
           console.log(
@@ -235,24 +236,13 @@ export const ReviewStep = ({
         Edit Benefits
       </button>
       <h2 className="title">Review</h2>
-      {onboardingBag.creditRiskStatus === 'referred' && (
-        <InviteSection
-          title={`Confirm ${onboardingBag.employment?.basic_information?.name} Profile`}
-          description="Once your account is approved, you can invite your employees to Remote."
-        >
-          <OnboardingAlertStatuses
-            creditRiskStatus={onboardingBag.creditRiskStatus}
-          />
-        </InviteSection>
-      )}
       <ReviewStepCreditRisk
-        // @ts-expect-error - TODO: fix this
         render={({
           creditRiskState,
           creditRiskStatus,
         }: {
           creditRiskState: CreditRiskState;
-          creditRiskStatus: CreditRiskStatus;
+          creditRiskStatus?: CreditRiskStatus;
         }) => {
           return (
             <>
@@ -269,10 +259,10 @@ export const ReviewStep = ({
                   Back
                 </BackButton>
                 <MyOnboardingInviteButton
-                  creditRiskStatus={onboardingBag.creditRiskStatus}
+                  creditRiskStatus={creditRiskStatus}
                   Component={OnboardingInvite}
                   setErrors={setErrors}
-                  employment={onboardingBag.employment}
+                  canInvite={onboardingBag.canInvite}
                 />
               </div>
               <AlertError errors={errors} />

--- a/src/flows/Onboarding/components/ReviewStep.tsx
+++ b/src/flows/Onboarding/components/ReviewStep.tsx
@@ -11,6 +11,7 @@ type ReviewStepProps = {
    *
    * @param props - Object containing credit risk information
    * @param props.creditRiskState - Current state of the credit risk flow
+   *   - 'referred': Company has been referred for manual review
    *   - 'deposit_required': Deposit payment is required but not yet paid
    *   - 'deposit_required_successful': Deposit payment has been successfully processed
    *   - 'invite': Regular invite flow is available (no deposit required)
@@ -51,6 +52,8 @@ export function ReviewStep({ render }: ReviewStepProps) {
   const isDepositRequiredCreditRisk =
     onboardingBag.creditRiskStatus === 'deposit_required';
 
+  const isReferred = onboardingBag.creditRiskStatus === 'referred';
+
   const hasEmploymentStatusThatHidesDeposit =
     onboardingBag.employment?.status &&
     statusesToNotShowDeposit.includes(onboardingBag.employment.status);
@@ -69,14 +72,19 @@ export function ReviewStep({ render }: ReviewStepProps) {
     (onboardingBag.employment?.status && hasEmploymentStatusThatHidesDeposit);
 
   const getCreditRiskState = (): CreditRiskState => {
-    // Priority 1: Deposit required flow
+    // check if the company is referred
+    if (isReferred) {
+      return 'referred';
+    }
+
+    // Deposit required flow
     if (shouldShowDepositFlow) {
       return creditScore.showReserveInvoice
         ? 'deposit_required_successful'
         : 'deposit_required';
     }
 
-    // Priority 2: Invite flow
+    // Invite flow
     if (shouldShowInviteFlow) {
       return creditScore.showInviteSuccessful ? 'invite_successful' : 'invite';
     }
@@ -86,6 +94,8 @@ export function ReviewStep({ render }: ReviewStepProps) {
   };
 
   const creditRiskState = getCreditRiskState();
+
+  console.log('review step credit risk state:', creditRiskState);
 
   return render({
     creditRiskState,

--- a/src/flows/Onboarding/components/ReviewStep.tsx
+++ b/src/flows/Onboarding/components/ReviewStep.tsx
@@ -95,8 +95,6 @@ export function ReviewStep({ render }: ReviewStepProps) {
 
   const creditRiskState = getCreditRiskState();
 
-  console.log('review step credit risk state:', creditRiskState);
-
   return render({
     creditRiskState,
     creditRiskStatus: onboardingBag.creditRiskStatus,

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -7,6 +7,7 @@ import { Fields } from '@remoteoss/json-schema-form';
 
 import { useStepState, Step } from '@/src/flows/useStepState';
 import {
+  disabledInviteButtonEmploymentStatus,
   prettifyFormValues,
   reviewStepAllowedEmploymentStatus,
   STEPS,
@@ -98,6 +99,10 @@ const getLoadingStates = ({
     employmentStatus &&
     reviewStepAllowedEmploymentStatus.includes(employmentStatus);
 
+  const canInvite =
+    employmentStatus &&
+    !disabledInviteButtonEmploymentStatus.includes(employmentStatus);
+
   const shouldHandleReadOnlyEmployment = Boolean(
     employmentId && isEmploymentReadOnly && currentStepName !== 'review',
   );
@@ -111,7 +116,12 @@ const getLoadingStates = ({
       contractDetailsFields.length > 0,
   );
 
-  return { isLoading, isNavigatingToReview, isEmploymentReadOnly };
+  return {
+    isLoading,
+    isNavigatingToReview,
+    isEmploymentReadOnly,
+    canInvite,
+  };
 };
 
 export const useOnboarding = ({
@@ -459,9 +469,24 @@ export const useOnboarding = ({
     stepFields,
   ]);
 
-  const { isLoading, isNavigatingToReview, isEmploymentReadOnly } = useMemo(
-    () =>
-      getLoadingStates({
+  const { isLoading, isNavigatingToReview, isEmploymentReadOnly, canInvite } =
+    useMemo(
+      () =>
+        getLoadingStates({
+          isLoadingBasicInformationForm,
+          isLoadingContractDetailsForm,
+          isLoadingEmployment,
+          isLoadingBenefitsOffersSchema,
+          isLoadingBenefitOffers,
+          isLoadingCompany,
+          isLoadingCountries,
+          employmentId,
+          employmentStatus: employmentStatus,
+          basicInformationFields: stepFields.basic_information,
+          contractDetailsFields: stepFields.contract_details,
+          currentStepName: currentStepName,
+        }),
+      [
         isLoadingBasicInformationForm,
         isLoadingContractDetailsForm,
         isLoadingEmployment,
@@ -470,26 +495,12 @@ export const useOnboarding = ({
         isLoadingCompany,
         isLoadingCountries,
         employmentId,
-        employmentStatus: employmentStatus,
-        basicInformationFields: stepFields.basic_information,
-        contractDetailsFields: stepFields.contract_details,
-        currentStepName: currentStepName,
-      }),
-    [
-      isLoadingBasicInformationForm,
-      isLoadingContractDetailsForm,
-      isLoadingEmployment,
-      isLoadingBenefitsOffersSchema,
-      isLoadingBenefitOffers,
-      isLoadingCompany,
-      isLoadingCountries,
-      employmentId,
-      employmentStatus,
-      stepFields.basic_information,
-      stepFields.contract_details,
-      currentStepName,
-    ],
-  );
+        employmentStatus,
+        stepFields.basic_information,
+        stepFields.contract_details,
+        currentStepName,
+      ],
+    );
 
   useEffect(() => {
     if (isNavigatingToReview) {
@@ -806,5 +817,11 @@ export const useOnboarding = ({
      * @returns {boolean}
      */
     isEmploymentReadOnly,
+
+    /**
+     * let's the user know if the company can invite employees
+     * @returns {boolean}
+     */
+    canInvite,
   };
 };

--- a/src/flows/Onboarding/tests/ReviewStep.test.tsx
+++ b/src/flows/Onboarding/tests/ReviewStep.test.tsx
@@ -143,27 +143,22 @@ describe('ReviewStep Component', () => {
     });
   });
 
-  describe('edge cases and null scenarios', () => {
-    it('should render with creditRiskState null when no conditions are met', () => {
+  describe('referred scenarios', () => {
+    it('should render with creditRiskState "referred" when creditRiskStatus is "referred"', () => {
       (useOnboardingContext as any).mockReturnValue({
-        onboardingBag: {
-          creditRiskStatus: 'referred',
-          employment: { status: 'created' },
-        },
-        creditScore: {
-          showReserveInvoice: false,
-          showInviteSuccessful: false,
-        },
+        onboardingBag: { creditRiskStatus: 'referred' },
       });
 
       render(<ReviewStep render={mockRender} />);
 
       expect(mockRender).toHaveBeenCalledWith({
-        creditRiskState: null,
+        creditRiskState: 'referred',
         creditRiskStatus: 'referred',
       });
     });
+  });
 
+  describe('edge cases and null scenarios', () => {
     it('should handle missing employment gracefully', () => {
       (useOnboardingContext as any).mockReturnValue({
         onboardingBag: {
@@ -297,7 +292,7 @@ describe('ReviewStep Component', () => {
         if (status === 'deposit_required') {
           expectedcreditRiskState = 'deposit_required';
         } else if (status === 'referred') {
-          expectedcreditRiskState = null;
+          expectedcreditRiskState = 'referred';
         } else {
           expectedcreditRiskState = 'invite';
         }

--- a/src/flows/Onboarding/types.ts
+++ b/src/flows/Onboarding/types.ts
@@ -93,6 +93,7 @@ export type CreditRiskState =
   | 'deposit_required_successful'
   | 'invite'
   | 'invite_successful'
+  | 'referred'
   | null;
 
 type MetaValues = {

--- a/src/flows/Onboarding/utils.ts
+++ b/src/flows/Onboarding/utils.ts
@@ -148,3 +148,8 @@ export const reviewStepAllowedEmploymentStatus: Employment['status'][] = [
   'created_awaiting_reserve',
   'created_reserve_paid',
 ];
+
+export const disabledInviteButtonEmploymentStatus: Employment['status'][] = [
+  'created_awaiting_reserve',
+  'invited',
+];


### PR DESCRIPTION
I did several improvements based on feedback for the review step

* Add referred status to the review step to have the different sections better organised
* Add canInvite property that let's the consumer know when the employee can be invited


The second point moves code from the example app to the SDK, with this maybe it's easier for consumers to understand what's happening