### PR TITLE
feat(cost-calculator) - reset form fields explicitly

### DIFF
--- a/example/src/CostCalculatorWithResults.tsx
+++ b/example/src/CostCalculatorWithResults.tsx
@@ -35,7 +35,7 @@ export function CostCalculatorWithResults() {
               <CostCalculatorForm
                 onSubmit={(payload) => console.log(payload)}
                 onError={(error) => console.error({ error })}
-                shouldResetForm
+                shouldResetFormFields={['country']}
                 onSuccess={(response) => {
                   setEstimations(response);
                 }}

--- a/example/src/CostCalculatorWithResults.tsx
+++ b/example/src/CostCalculatorWithResults.tsx
@@ -35,7 +35,7 @@ export function CostCalculatorWithResults() {
               <CostCalculatorForm
                 onSubmit={(payload) => console.log(payload)}
                 onError={(error) => console.error({ error })}
-                shouldResetFormFields={['country']}
+                resetFields={['country']}
                 onSuccess={(response) => {
                   setEstimations(response);
                 }}

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -30,6 +30,11 @@ type CostCalculatorFormProps = Partial<{
    * Whether to reset the form when the form is successfully submitted.
    */
   shouldResetForm?: boolean;
+
+  /**
+   * Fields to reset when the form is successfully submitted.
+   */
+  shouldResetFormFields?: string[];
 }>;
 
 export function CostCalculatorForm({
@@ -37,6 +42,7 @@ export function CostCalculatorForm({
   onError,
   onSuccess,
   shouldResetForm,
+  shouldResetFormFields,
 }: CostCalculatorFormProps) {
   const { form, formId, costCalculatorBag } = useCostCalculatorContext();
 
@@ -54,9 +60,23 @@ export function CostCalculatorForm({
     } else {
       if (costCalculatorResults?.data) {
         await onSuccess?.(costCalculatorResults?.data);
+        // Reset the form completely
         if (shouldResetForm) {
           costCalculatorBag?.resetForm();
           form.reset();
+          return;
+        }
+
+        // Reset only the form fields
+        if (shouldResetFormFields) {
+          const currentValues = form.getValues();
+          const resetValues = { ...currentValues };
+          shouldResetFormFields.forEach((field) => {
+            resetValues[field] = '';
+          });
+
+          costCalculatorBag?.resetForm();
+          form.reset(resetValues);
         }
       }
     }

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -47,17 +47,29 @@ export function CostCalculatorForm({
 }: CostCalculatorFormProps) {
   const { form, formId, costCalculatorBag } = useCostCalculatorContext();
 
+  if (
+    process.env.NODE_ENV === 'development' &&
+    shouldResetForm &&
+    resetFields
+  ) {
+    console.warn(
+      'CostCalculatorForm: Both "shouldResetForm" and "resetFields" were provided. Using "shouldResetForm" and ignoring "resetFields".',
+    );
+    resetFields = undefined;
+  }
+
   const {
     formState: { isSubmitSuccessful },
   } = form;
 
   useEffect(() => {
+    // resets the entire form if the form is successfully submitted and the shouldResetForm prop is true
     if (isSubmitSuccessful && shouldResetForm) {
-      // Reset the form state after a successful submission
       costCalculatorBag?.resetForm();
       form.reset();
     }
 
+    // resets the specified fields if the form is successfully submitted and the resetFields prop is provided
     if (isSubmitSuccessful && resetFields) {
       // Reset only the specified fields
       const currentValues = form.getValues();

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -555,12 +555,13 @@ The options.jsfModify props accepts the same props that the [modify](https://jso
 
 It renders the form and the fields of the cost calculator
 
-| Prop              | Type                                                 | Required | Description                                                                                  |
-| ----------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `onSubmit`        | `(payload: CostCalculatorEstimateParams) => void`    | No       | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
-| `onSuccess`       | `(response: CostCalculatorEstimateResponse) => void` | No       | Callback with the successful estimation data                                                 |
-| `onError`         | `(error: Error) => void`                             | No       | Error handling callback                                                                      |
-| `shouldResetForm` | `boolean`                                            | No       | If true, the form will be reset after a successful submission. Default is `false`.           |
+| Prop                    | Type                                                 | Required | Description                                                                                  |
+| ----------------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `onSubmit`              | `(payload: CostCalculatorEstimateParams) => void`    | No       | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
+| `onSuccess`             | `(response: CostCalculatorEstimateResponse) => void` | No       | Callback with the successful estimation data                                                 |
+| `onError`               | `(error: Error) => void`                             | No       | Error handling callback                                                                      |
+| `shouldResetForm`       | `boolean`                                            | No       | If true, the form will be reset after a successful submission. Default is `false`.           |
+| `shouldResetFormFields` | `string[]`                                           | No       | You can pass an array like ['country'] and only country and the region will be cleared       |
 
 ### CostCalculatorSubmitButton
 

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -563,6 +563,10 @@ It renders the form and the fields of the cost calculator
 | `shouldResetForm` | `boolean`                                            | No         | If true, the form will be reset after a successful submission. Default is `false`.           |
 | `resetFields`     | `'country'                                           | 'currency' | 'salary'[]`                                                                                  | No  | You can pass an array like ['country'] and only country and the region will be cleared |
 
+#### About `shouldResetForm` and `resetFields`
+
+If used both at the same time, shouldResetForm will take precedence
+
 ### CostCalculatorSubmitButton
 
 It renders the submit button for the form and supports all standard `<button>` element props. This component must be used within the render prop of the CostCalculatorFlow component to ensure proper functionality

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -555,15 +555,15 @@ The options.jsfModify props accepts the same props that the [modify](https://jso
 
 It renders the form and the fields of the cost calculator
 
-| Prop              | Type                                                 | Required   | Description                                                                                  |
-| ----------------- | ---------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------- | --- | -------------------------------------------------------------------------------------- |
-| `onSubmit`        | `(payload: CostCalculatorEstimateParams) => void`    | No         | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
-| `onSuccess`       | `(response: CostCalculatorEstimateResponse) => void` | No         | Callback with the successful estimation data                                                 |
-| `onError`         | `(error: Error) => void`                             | No         | Error handling callback                                                                      |
-| `shouldResetForm` | `boolean`                                            | No         | If true, the form will be reset after a successful submission. Default is `false`.           |
-| `resetFields`     | `'country'                                           | 'currency' | 'salary'[]`                                                                                  | No  | You can pass an array like ['country'] and only country and the region will be cleared |
+| Prop              | Type                                                 | Required | Description                                                                                  |
+| ----------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `onSubmit`        | `(payload: CostCalculatorEstimateParams) => void`    | No       | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
+| `onSuccess`       | `(response: CostCalculatorEstimateResponse) => void` | No       | Callback with the successful estimation data                                                 |
+| `onError`         | `(error: Error) => void`                             | No       | Error handling callback                                                                      |
+| `shouldResetForm` | `boolean`                                            | No       | If true, the form will be reset after a successful submission. Default is `false`.           |
+| `resetFields`     | `Array<'country' or 'currency' or 'salary'>`         | No       | You can pass an array like ['country'] and only country and the region will be cleared       |
 
-#### About `shouldResetForm` and `resetFields`
+#### About `shouldResetForm` and `resetFields`
 
 If used both at the same time, shouldResetForm will take precedence
 

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -555,13 +555,13 @@ The options.jsfModify props accepts the same props that the [modify](https://jso
 
 It renders the form and the fields of the cost calculator
 
-| Prop                    | Type                                                 | Required | Description                                                                                  |
-| ----------------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `onSubmit`              | `(payload: CostCalculatorEstimateParams) => void`    | No       | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
-| `onSuccess`             | `(response: CostCalculatorEstimateResponse) => void` | No       | Callback with the successful estimation data                                                 |
-| `onError`               | `(error: Error) => void`                             | No       | Error handling callback                                                                      |
-| `shouldResetForm`       | `boolean`                                            | No       | If true, the form will be reset after a successful submission. Default is `false`.           |
-| `shouldResetFormFields` | `string[]`                                           | No       | You can pass an array like ['country'] and only country and the region will be cleared       |
+| Prop              | Type                                                 | Required   | Description                                                                                  |
+| ----------------- | ---------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------- | --- | -------------------------------------------------------------------------------------- |
+| `onSubmit`        | `(payload: CostCalculatorEstimateParams) => void`    | No         | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
+| `onSuccess`       | `(response: CostCalculatorEstimateResponse) => void` | No         | Callback with the successful estimation data                                                 |
+| `onError`         | `(error: Error) => void`                             | No         | Error handling callback                                                                      |
+| `shouldResetForm` | `boolean`                                            | No         | If true, the form will be reset after a successful submission. Default is `false`.           |
+| `resetFields`     | `'country'                                           | 'currency' | 'salary'[]`                                                                                  | No  | You can pass an array like ['country'] and only country and the region will be cleared |
 
 ### CostCalculatorSubmitButton
 

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -555,13 +555,13 @@ The options.jsfModify props accepts the same props that the [modify](https://jso
 
 It renders the form and the fields of the cost calculator
 
-| Prop              | Type                                                 | Required | Description                                                                                  |
-| ----------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `onSubmit`        | `(payload: CostCalculatorEstimateParams) => void`    | No       | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote |
-| `onSuccess`       | `(response: CostCalculatorEstimateResponse) => void` | No       | Callback with the successful estimation data                                                 |
-| `onError`         | `(error: Error) => void`                             | No       | Error handling callback                                                                      |
-| `shouldResetForm` | `boolean`                                            | No       | If true, the form will be reset after a successful submission. Default is `false`.           |
-| `resetFields`     | `Array<'country' or 'currency' or 'salary'>`         | No       | You can pass an array like ['country'] and only country and the region will be cleared       |
+| Prop              | Type                                                 | Required | Description                                                                                                                                                                                              |
+| ----------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onSubmit`        | `(payload: CostCalculatorEstimateParams) => void`    | No       | Callback with the form payload sent to Remote API. Runs before submitting the form to Remote                                                                                                             |
+| `onSuccess`       | `(response: CostCalculatorEstimateResponse) => void` | No       | Callback with the successful estimation data                                                                                                                                                             |
+| `onError`         | `(error: Error) => void`                             | No       | Error handling callback                                                                                                                                                                                  |
+| `shouldResetForm` | `boolean`                                            | No       | If true, the form will be reset after a successful submission. Default is `false`.                                                                                                                       |
+| `resetFields`     | `Array<'country' or 'currency' or 'salary'>`         | No       | Clears specified form fields. Pass field names as an array (e.g., ['country']). When resetting nested fields like 'country', related dependent fields (e.g., region) will also be cleared automatically. |
 
 #### About `shouldResetForm` and `resetFields`
 

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -437,7 +437,7 @@ describe('CostCalculatorFlow', () => {
     });
   });
 
-  it("should reset form the country and region when the 'shouldResetFormFields' is passed", async () => {
+  it("should reset form the country and region when the 'resetFields' is passed", async () => {
     const user = userEvent.setup();
     server.use(
       http.get('*/v1/cost-calculator/regions/*/fields', () => {
@@ -458,7 +458,7 @@ describe('CostCalculatorFlow', () => {
                 onSubmit={mockOnSubmit}
                 onError={mockOnError}
                 onSuccess={mockOnSuccess}
-                shouldResetFormFields={['country']}
+                resetFields={['country']}
               />
               <CostCalculatorSubmitButton>
                 Get estimate


### PR DESCRIPTION
I did a new feature in the CostCalculator to only reset certain fields

In this case, we want to reset only country but not salary or currency

