### PR TITLE
fix(cost-calculator) - add extra statuory payments and indirect tax

### DIFF
--- a/src/flows/CostCalculator/Results/CostCalculatorExtraStatutoryPaymentsBreakdown.tsx
+++ b/src/flows/CostCalculator/Results/CostCalculatorExtraStatutoryPaymentsBreakdown.tsx
@@ -1,0 +1,65 @@
+import { Info } from 'lucide-react';
+
+import { Button } from '@/src/components/ui/button';
+import { Separator } from '@/src/components/ui/separator';
+import {
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  Tooltip as UITooltip,
+} from '@/src/components/ui/tooltip';
+import { formatCurrency } from '@/src/lib/utils';
+
+type CostCalculatorExtraStatutoryPaymentsBreakdownProps = {
+  extraStatutoryPaymentsTotal: number | null;
+  extraStatutoryPaymentsBreakdown: {
+    name: string;
+    description: string | null;
+    amount: number;
+  }[];
+  currency: string;
+};
+
+export function CostCalculatorExtraStatutoryPaymentsBreakdown({
+  extraStatutoryPaymentsTotal,
+  extraStatutoryPaymentsBreakdown,
+  currency,
+}: CostCalculatorExtraStatutoryPaymentsBreakdownProps) {
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-medium text-primary-foreground-800">
+          Extra Statutory Payments
+        </h3>
+        <span className="font-semibold text-lg">
+          {formatCurrency(extraStatutoryPaymentsTotal, currency)}
+        </span>
+      </div>
+      <Separator className="mb-3" />
+
+      <div className="space-y-3 pl-2">
+        {extraStatutoryPaymentsBreakdown.map((payment, index) => (
+          <div key={index} className="flex justify-between items-start text-sm">
+            <div className="flex items-start gap-2">
+              <span>{payment.name}</span>
+              <TooltipProvider>
+                <UITooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-4 w-4 p-0">
+                      <Info className="h-3 w-3 text-gray-400" />
+                      <span className="sr-only">Info</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="max-w-xs">{payment.description}</p>
+                  </TooltipContent>
+                </UITooltip>
+              </TooltipProvider>
+            </div>
+            <span>{formatCurrency(payment.amount, currency)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/flows/CostCalculator/Results/CostCalculatorIndirectTax.tsx
+++ b/src/flows/CostCalculator/Results/CostCalculatorIndirectTax.tsx
@@ -1,0 +1,24 @@
+import { Separator } from '@/src/components/ui/separator';
+import { formatCurrency } from '@/src/lib/utils';
+
+type CostCalculatorIndirectTaxProps = {
+  indirectTax: number;
+  currency: string;
+};
+
+export function CostCalculatorIndirectTax({
+  indirectTax,
+  currency,
+}: CostCalculatorIndirectTaxProps) {
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-medium text-primary-foreground">Indirect Tax</h3>
+        <span className="font-semibold text-lg">
+          {formatCurrency(indirectTax, currency)}
+        </span>
+      </div>
+      <Separator />
+    </div>
+  );
+}

--- a/src/flows/CostCalculator/Results/CostCalculatorResults.tsx
+++ b/src/flows/CostCalculator/Results/CostCalculatorResults.tsx
@@ -52,8 +52,6 @@ export function CostCalculatorResults({
       ? employment.employer_currency_costs
       : employment.employer_currency_costs;
 
-  console.log({ costs });
-
   const currency = costs.currency.symbol;
   const grossSalary =
     view === 'monthly' ? costs.monthly_gross_salary : costs.annual_gross_salary;
@@ -76,12 +74,6 @@ export function CostCalculatorResults({
 
   const indirectTax =
     view === 'monthly' ? costs.monthly_indirect_tax : costs.annual_indirect_tax;
-
-  console.log({
-    extraStatutoryPaymentsTotal,
-    extraStatutoryPaymentsBreakdown,
-    indirectTax,
-  });
 
   const benefitsBreakdown =
     view === 'monthly'

--- a/src/flows/CostCalculator/Results/CostCalculatorResults.tsx
+++ b/src/flows/CostCalculator/Results/CostCalculatorResults.tsx
@@ -15,6 +15,8 @@ import { CostCalculatorBenefitsBreakdown } from './CostCalculatorBenefitsBreakdo
 import { CostCalculatorContributionsBreakdown } from './CostCalculatorContributionsBreakdown';
 import { CostCalculatorGrossSalary } from './CostCalculatorGrossSalary';
 import { CostCalculatorTotalCost } from './CostCalculatorTotalCost';
+import { CostCalculatorExtraStatutoryPaymentsBreakdown } from '@/src/flows/CostCalculator/Results/CostCalculatorExtraStatutoryPaymentsBreakdown';
+import { CostCalculatorIndirectTax } from '@/src/flows/CostCalculator/Results/CostCalculatorIndirectTax';
 
 const CostCalculatorResultsChart = lazy(
   () => import('./CostCalculatorResultsChart'),
@@ -50,6 +52,8 @@ export function CostCalculatorResults({
       ? employment.employer_currency_costs
       : employment.employer_currency_costs;
 
+  console.log({ costs });
+
   const currency = costs.currency.symbol;
   const grossSalary =
     view === 'monthly' ? costs.monthly_gross_salary : costs.annual_gross_salary;
@@ -63,6 +67,21 @@ export function CostCalculatorResults({
       : costs.annual_contributions_total;
   const totalCost =
     view === 'monthly' ? costs.monthly_total : costs.annual_total;
+
+  const extraStatutoryPaymentsBreakdown =
+    view === 'monthly' ? null : costs.extra_statutory_payments_breakdown;
+
+  const extraStatutoryPaymentsTotal =
+    view === 'monthly' ? null : costs.extra_statutory_payments_total;
+
+  const indirectTax =
+    view === 'monthly' ? costs.monthly_indirect_tax : costs.annual_indirect_tax;
+
+  console.log({
+    extraStatutoryPaymentsTotal,
+    extraStatutoryPaymentsBreakdown,
+    indirectTax,
+  });
 
   const benefitsBreakdown =
     view === 'monthly'
@@ -157,6 +176,23 @@ export function CostCalculatorResults({
                 contributionsTotal={contributionsTotal}
                 currency={currency}
               />
+              {/* Extra Statutory Payments Section */}
+              {extraStatutoryPaymentsBreakdown ? (
+                <CostCalculatorExtraStatutoryPaymentsBreakdown
+                  extraStatutoryPaymentsBreakdown={
+                    extraStatutoryPaymentsBreakdown
+                  }
+                  extraStatutoryPaymentsTotal={extraStatutoryPaymentsTotal}
+                  currency={currency}
+                />
+              ) : null}
+              {/* Indirect Tax Section */}
+              {indirectTax ? (
+                <CostCalculatorIndirectTax
+                  indirectTax={indirectTax}
+                  currency={currency}
+                />
+              ) : null}
               {/* Total */}
               <CostCalculatorTotalCost
                 totalCost={totalCost}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatCurrency(
-  amount: number | undefined,
+  amount: number | undefined | null,
   symbol = '€',
 ): string {
   if (!amount) {


### PR DESCRIPTION
We want to add extra statuory payments and indirect tax sections to the cost calculator results

You can do this by using Bolivia as a country

<img width="724" height="793" alt="image" src="https://github.com/user-attachments/assets/8275591d-1410-47c8-bf03-1b7c3b1ed9c0" />

BTW: tooltips doesn't work but in the entire cost calculator, I am trying to fix in a separated PR