### PR TITLE
fix(onboarding) - Fix keys warnings

### DIFF
--- a/src/components/form/JSONSchemaForm.tsx
+++ b/src/components/form/JSONSchemaForm.tsx
@@ -83,12 +83,23 @@ export const JSONSchemaFormFields = ({
         }
 
         if (field.inputType === 'fieldset') {
-          return <FieldComponent {...field} components={components} />;
+          return (
+            <FieldComponent
+              key={field.name}
+              {...field}
+              components={components}
+            />
+          );
         }
 
         if (field.inputType === 'fieldset-flat') {
           return (
-            <FieldComponent {...field} components={components} isFlatFieldset />
+            <FieldComponent
+              key={field.name}
+              {...field}
+              components={components}
+              isFlatFieldset
+            />
           );
         }
 

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -134,7 +134,9 @@ export function FieldSetField({
           }
 
           return (
-            <Fragment key={field.name}>
+            <Fragment
+              key={`${isFlatFieldset ? field.name : `${name}.${field.name}`}`}
+            >
               <FieldComponent
                 {...field}
                 name={`${isFlatFieldset ? field.name : `${name}.${field.name}`}`}

--- a/src/components/form/fields/RadioGroupField.tsx
+++ b/src/components/form/fields/RadioGroupField.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Fragment } from 'react';
 import {
   FormControl,
   FormDescription,
@@ -81,9 +82,8 @@ export function RadioGroupField({
                 className="flex flex-col space-y-3"
               >
                 {options?.map((option) => (
-                  <>
+                  <Fragment key={option.value}>
                     <FormItem
-                      key={option.value}
                       data-field={name}
                       className="flex items-start space-x-3 space-y-0 gap-0 RemoteFlows__RadioField__Item"
                     >
@@ -105,7 +105,7 @@ export function RadioGroupField({
                         )}
                       </div>
                     </FormItem>
-                  </>
+                  </Fragment>
                 ))}
               </RadioGroup>
             </FormControl>

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -713,7 +713,7 @@ export function getFieldsWithFlatFieldsets({
 
     return {
       ...rest,
-      id: flatFieldsetKey,
+      name: flatFieldsetKey,
       type: 'fieldset-flat',
       inputType: 'fieldset-flat',
       fields: childFields,


### PR DESCRIPTION
There were fix warnings related to the fieldsets as you pointed out yesterday.

Besides I saw a key not being assigned correctly to the RadioGroups

FlatFieldsets were returning id, I changed it to name instead

All warnings related to keys while you navigate the onboarding have now dissapeared