### PR TITLE
fix(JSONSchemaForm): Hidden fields support

### DIFF
--- a/src/components/form/JSONSchemaForm.tsx
+++ b/src/components/form/JSONSchemaForm.tsx
@@ -76,13 +76,13 @@ export const JSONSchemaFormFields = ({
           return <Component key={field.name as string} {...field} />;
         }
 
-        let FieldComponent = fieldsMap[field.inputType as SupportedTypes];
+        let FieldComponent = fieldsMap[field.type as SupportedTypes];
 
-        if (field.inputType === 'select' && field.multiple) {
+        if (field.type === 'select' && field.multiple) {
           FieldComponent = fieldsMap['multi-select'];
         }
 
-        if (field.inputType === 'fieldset') {
+        if (field.type === 'fieldset') {
           return (
             <FieldComponent
               key={field.name}
@@ -92,7 +92,7 @@ export const JSONSchemaFormFields = ({
           );
         }
 
-        if (field.inputType === 'fieldset-flat') {
+        if (field.type === 'fieldset-flat') {
           return (
             <FieldComponent
               key={field.name}
@@ -107,9 +107,7 @@ export const JSONSchemaFormFields = ({
           <Fragment key={field.name as string}>
             <FieldComponent
               {...field}
-              component={
-                components && components[field.inputType as SupportedTypes]
-              }
+              component={components && components[field.type as SupportedTypes]}
             />
             {field.statement ? (
               <Statement {...(field.statement as StatementProps)} />
@@ -118,7 +116,7 @@ export const JSONSchemaFormFields = ({
           </Fragment>
         ) : (
           <p className="error">
-            Field type {field.inputType as string} not supported
+            Field type {field.type as string} not supported
           </p>
         );
       })}

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -129,7 +129,7 @@ export function FieldSetField({
             return <Component key={field.name} {...field} />;
           }
 
-          if (field.inputType === 'select' && field.multiple) {
+          if (field.type === 'select' && field.multiple) {
             FieldComponent = fieldsMap['multi-select'];
           }
 

--- a/src/flows/utils.ts
+++ b/src/flows/utils.ts
@@ -39,7 +39,7 @@ export function findFieldsByType(
 ) {
   const fieldsNames = [];
   for (const [key, value] of Object.entries(fields)) {
-    if (value['x-jsf-presentation'].inputType === type) {
+    if (value['x-jsf-presentation'].type === type) {
       fieldsNames.push(key);
     }
   }


### PR DESCRIPTION
The `JSONSchemaForm` component was using `inputType` when it should have been using `type`. These properties are usually the same, but they differ when `type` is hidden. This caused a bug in the UK onboarding contract details, where the pension scheme was incorrectly displayed.

**Fix**

Update `JSONSchemaForm` component to use `type` instead of `inputType`.