### PR TITLE
feat(onboarding)- add external_id as an option

### DIFF
--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -254,12 +254,14 @@ type OnboardingFormData = {
   companyId: string;
   type: 'employee' | 'contractor';
   employmentId: string;
+  externalId?: string;
 };
 
 const OnboardingWithProps = ({
   companyId,
   type,
   employmentId,
+  externalId,
 }: OnboardingFormData) => (
   <RemoteFlows>
     <OnboardingFlow
@@ -267,6 +269,7 @@ const OnboardingWithProps = ({
       type={type}
       render={OnBoardingRender}
       employmentId={employmentId}
+      externalId={externalId}
     />
   </RemoteFlows>
 );
@@ -276,6 +279,7 @@ export const OnboardingForm = () => {
     type: 'employee',
     employmentId: '',
     companyId: 'c3c22940-e118-425c-9e31-f2fd4d43c6d8', // use your own company ID
+    externalId: '',
   });
   const [showOnboarding, setShowOnboarding] = useState(false);
 
@@ -338,6 +342,21 @@ export const OnboardingForm = () => {
             setFormData((prev) => ({ ...prev, employmentId: e.target.value }))
           }
           placeholder="Enter employment ID"
+          className="onboarding-form-input"
+        />
+      </div>
+      <div className="onboarding-form-group">
+        <label htmlFor="externalId" className="onboarding-form-label">
+          External ID:
+        </label>
+        <input
+          id="externalId"
+          type="text"
+          value={formData.externalId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, externalId: e.target.value }))
+          }
+          placeholder="Enter External ID"
           className="onboarding-form-input"
         />
       </div>

--- a/example/src/OnboardingWithoutSelectCountryStep.tsx
+++ b/example/src/OnboardingWithoutSelectCountryStep.tsx
@@ -269,6 +269,7 @@ type OnboardingFormData = {
   countryCode: string;
   type: 'employee' | 'contractor';
   employmentId: string;
+  externalId?: string;
 };
 
 const OnboardingWithProps = ({
@@ -276,6 +277,7 @@ const OnboardingWithProps = ({
   type,
   employmentId,
   countryCode,
+  externalId,
 }: OnboardingFormData) => (
   <RemoteFlows>
     <OnboardingFlow
@@ -285,6 +287,7 @@ const OnboardingWithProps = ({
       employmentId={employmentId}
       countryCode={countryCode}
       skipSteps={['select_country']}
+      externalId={externalId}
     />
   </RemoteFlows>
 );
@@ -295,6 +298,7 @@ export const OnboardingForm = () => {
     employmentId: '',
     companyId: 'c3c22940-e118-425c-9e31-f2fd4d43c6d8', // use your own company ID
     countryCode: 'PRT',
+    externalId: '',
   });
   const [showOnboarding, setShowOnboarding] = useState(false);
 
@@ -373,6 +377,21 @@ export const OnboardingForm = () => {
             setFormData((prev) => ({ ...prev, employmentId: e.target.value }))
           }
           placeholder="Enter employment ID"
+          className="onboarding-form-input"
+        />
+      </div>
+      <div className="onboarding-form-group">
+        <label htmlFor="externalId" className="onboarding-form-label">
+          External ID:
+        </label>
+        <input
+          id="externalId"
+          type="text"
+          value={formData.externalId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, externalId: e.target.value }))
+          }
+          placeholder="Enter External ID"
           className="onboarding-form-input"
         />
       </div>

--- a/src/flows/Onboarding/OnboardingFlow.tsx
+++ b/src/flows/Onboarding/OnboardingFlow.tsx
@@ -59,6 +59,7 @@ export const OnboardingFlow = ({
   companyId,
   countryCode,
   type = 'employee',
+  externalId,
   skipSteps,
   render,
   options,
@@ -71,6 +72,7 @@ export const OnboardingFlow = ({
     type,
     options,
     skipSteps,
+    externalId,
   });
 
   const [creditScore, setCreditScore] = useState<{

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -132,6 +132,7 @@ export const useOnboarding = ({
   type,
   options,
   skipSteps,
+  externalId,
 }: OnboardingHookProps) => {
   const fieldsMetaRef = useRef<{
     select_country: Meta;
@@ -634,6 +635,7 @@ export const useOnboarding = ({
             basic_information: parsedValues,
             type: type,
             country_code: internalCountryCode,
+            external_id: externalId,
           };
           try {
             const response = await createEmploymentMutationAsync(payload);
@@ -658,6 +660,7 @@ export const useOnboarding = ({
             pricing_plan_details: {
               frequency: 'monthly',
             },
+            external_id: externalId,
           });
         }
 
@@ -672,6 +675,7 @@ export const useOnboarding = ({
         };
         return updateEmploymentMutationAsync({
           employmentId: internalEmploymentId as string,
+          external_id: externalId,
           ...payload,
         });
       }

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -1839,4 +1839,256 @@ describe('OnboardingFlow', () => {
     // Verify we stay on the same step (don't advance)
     await screen.findByText(/Step: Benefits/i);
   });
+
+  it('should send external_id when creating employment for the first time', async () => {
+    const postSpy = vi.fn();
+    const testExternalId = 'test-external-id-123';
+
+    server.use(
+      http.post('*/v1/employments', async ({ request }) => {
+        const requestBody = await request.json();
+        postSpy(requestBody);
+        return HttpResponse.json(employmentCreatedResponse);
+      }),
+    );
+
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        {...defaultProps}
+        countryCode="PRT"
+        skipSteps={['select_country']}
+        externalId={testExternalId}
+      />,
+      { wrapper },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+
+    // Fill basic information and submit
+    await fillBasicInformation();
+    const nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+
+    // Verify POST was called with external_id
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    const requestPayload = postSpy.mock.calls[0][0];
+
+    expect(requestPayload).toMatchObject({
+      basic_information: expect.any(Object),
+      type: 'employee',
+      country_code: 'PRT',
+      external_id: testExternalId,
+    });
+  });
+
+  it('should send external_id when updating employment in basic information step', async () => {
+    const patchSpy = vi.fn();
+    const testExternalId = 'test-external-id-456';
+    const uniqueEmploymentId = generateUniqueEmploymentId();
+
+    server.use(
+      http.get(`*/v1/employments/${uniqueEmploymentId}`, () => {
+        return HttpResponse.json({
+          ...employmentResponse,
+          data: {
+            ...employmentResponse.data,
+            employment: {
+              ...employmentResponse.data.employment,
+              id: uniqueEmploymentId,
+              status: 'created', // Ensure it's not a readonly status
+            },
+          },
+        });
+      }),
+      http.patch('*/v1/employments/*', async ({ request }) => {
+        const requestBody = await request.json();
+        patchSpy(requestBody);
+        return HttpResponse.json(employmentUpdatedResponse);
+      }),
+    );
+
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        {...defaultProps}
+        employmentId={uniqueEmploymentId}
+        skipSteps={['select_country']}
+        externalId={testExternalId}
+      />,
+      { wrapper },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    // Modify a field and submit to trigger update
+    const personalEmailInput = screen.getByLabelText(/Personal email/i);
+    fireEvent.change(personalEmailInput, { target: { value: '' } });
+    fireEvent.change(personalEmailInput, {
+      target: { value: 'updated@email.com' },
+    });
+
+    const nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+
+    // Verify PATCH was called with external_id
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const requestPayload = patchSpy.mock.calls[0][0];
+
+    expect(requestPayload).toMatchObject({
+      basic_information: expect.any(Object),
+      pricing_plan_details: {
+        frequency: 'monthly',
+      },
+      external_id: testExternalId, // ✅ Verify external_id is sent
+    });
+  });
+
+  it('should send external_id when updating employment in contract details step', async () => {
+    const patchSpy = vi.fn();
+    const testExternalId = 'test-external-id-789';
+    const uniqueEmploymentId = generateUniqueEmploymentId();
+    let patchCallCount = 0;
+
+    server.use(
+      http.get(`*/v1/employments/${uniqueEmploymentId}`, () => {
+        return HttpResponse.json({
+          ...employmentResponse,
+          data: {
+            ...employmentResponse.data,
+            employment: {
+              ...employmentResponse.data.employment,
+              id: uniqueEmploymentId,
+              status: 'created', // Ensure it's not a readonly status
+            },
+          },
+        });
+      }),
+      http.patch('*/v1/employments/*', async ({ request }) => {
+        const requestBody = await request.json();
+        patchCallCount++;
+
+        // Only spy on the contract details call (second PATCH)
+        if (patchCallCount === 2) {
+          patchSpy(requestBody);
+        }
+
+        return HttpResponse.json(employmentUpdatedResponse);
+      }),
+    );
+
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        {...defaultProps}
+        employmentId={uniqueEmploymentId}
+        skipSteps={['select_country']}
+        externalId={testExternalId}
+      />,
+      { wrapper },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    // Navigate to contract details step
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+
+    // Wait for the form to be populated
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Role description/i)).toBeInTheDocument();
+    });
+
+    // Submit contract details
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Benefits/i);
+
+    // Verify PATCH was called with external_id for contract details
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const requestPayload = patchSpy.mock.calls[0][0];
+
+    expect(requestPayload).toMatchObject({
+      contract_details: expect.any(Object),
+      pricing_plan_details: {
+        frequency: 'monthly',
+      },
+      external_id: testExternalId, // ✅ Verify external_id is sent
+    });
+  });
 });

--- a/src/flows/Onboarding/types.ts
+++ b/src/flows/Onboarding/types.ts
@@ -17,6 +17,12 @@ export type OnboardingFlowParams = {
    * The company id to use for the onboarding.
    */
   companyId: string;
+
+  /**
+   * Unique reference code for the employment record in a non-Remote system. This optional field links to external data sources.
+   * If not provided, it defaults to null. While uniqueness is recommended, it is not strictly enforced within Remote's system.
+   */
+  externalId?: string;
   /**
    * The steps to skip for the onboarding. We only support skipping the select_country step for now.
    */


### PR DESCRIPTION
Adds external_id to the OnboardingFlow

The external_id is sent when we create an employment or we update it

Tests have been added to check this behavior