### PR TITLE
fix(forced-value) - fix description which isn't rendered

### DIFF
--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -4,7 +4,7 @@ import { CostCalculatorWithPremiumBenefits } from './CostCalculatorWithPremiumBe
 import App from './App.tsx';
 
 const RenderPremiumBenefits = () => {
-  if (import.meta.env.VITE_NEW_PREMIUM_BENEFITS) {
+  if (import.meta.env.VITE_NEW_PREMIUM_BENEFITS === 'true') {
     return <CostCalculatorWithPremiumBenefits />;
   }
   return <App />;

--- a/src/components/form/fields/ForcedValueField.tsx
+++ b/src/components/form/fields/ForcedValueField.tsx
@@ -2,13 +2,13 @@ import { sanitizeHtml } from '@/src/lib/utils';
 import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-type ForcedValueFieldProps = {
+export type ForcedValueFieldProps = {
   name: string;
   value: string;
   description: string;
   statement?: {
     title?: string;
-    description: string;
+    description?: string;
   };
   label: string;
 };
@@ -41,7 +41,7 @@ export function ForcedValueField({
           <p
             className={`text-xs RemoteFlows__ForcedValue__Description__${name}`}
             dangerouslySetInnerHTML={{
-              __html: sanitizeHtml(statement?.description),
+              __html: sanitizeHtml(statement?.description || description),
             }}
           />
         </>

--- a/src/components/form/fields/tests/ForcedValueField.test.tsx
+++ b/src/components/form/fields/tests/ForcedValueField.test.tsx
@@ -1,17 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { ForcedValueField } from '../ForcedValueField';
-
-type ForcedValueFieldProps = {
-  name: string;
-  value: string;
-  description: string;
-  statement?: {
-    title?: string;
-    description: string;
-  };
-  label: string;
-};
+import { ForcedValueField, ForcedValueFieldProps } from '../ForcedValueField';
 
 describe('ForcedValueField Component', () => {
   const defaultProps: ForcedValueFieldProps = {
@@ -101,6 +90,25 @@ describe('ForcedValueField Component', () => {
 
       expect(screen.getByText('Test Label')).toBeInTheDocument();
       expect(screen.getByText('Statement Description')).toBeInTheDocument();
+    });
+  });
+
+  describe('when statement is provided but description is undefined', () => {
+    const propsWithUndefinedDescription: ForcedValueFieldProps = {
+      ...defaultProps,
+      statement: {
+        title: 'Test Label',
+        description: undefined,
+      },
+    };
+
+    it('falls back to description', () => {
+      renderWithFormContext(propsWithUndefinedDescription);
+
+      expect(screen.getByText('Test Label')).toBeInTheDocument();
+      expect(
+        screen.getByText('This is a test description'),
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
We had a report for the croatia contract details that we weren't rendering a description.

This was due to that the statement.description was undefined but the description contained the value

It feels similar to this [bug](https://github.com/remoteoss/remote-flows/pull/377)

<img width="561" height="147" alt="image" src="https://github.com/user-attachments/assets/94d3ca91-be4c-4753-8286-2f5aa61b19d9" />
