### PR TITLE
fix types json-schema-version

### DIFF
--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -75,7 +75,7 @@ export type FlowOptions = {
   jsonSchemaVersion?: {
     contract_amendments?: number;
     form_schema?: {
-      [key in JSONSchemaFormType]: number;
+      [key in JSONSchemaFormType]?: number;
     };
     benefit_offers_form_schema?: number;
   };


### PR DESCRIPTION
Fix types json-schema-version, we were requiring all json-schemas inside form-schema which doesn't make sense