### PR TITLE
feat(cost-calculator) - call new conversion endpoints

### DIFF
--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -221,8 +221,9 @@ const AddEstimateForm = ({
             },
             salary: {
               title: "Employee's annual salary",
-              description:
-                "We will use your selected billing currency, but you can also convert it to the employee's local currency.",
+              description: '',
+              // TODO: We'll include it later
+              // "We will use your selected billing currency, but you can also convert it to the employee's local currency.",
             },
           },
         },

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -277,8 +277,9 @@ const OnboardingWithProps = ({
 export const OnboardingForm = () => {
   const [formData, setFormData] = useState<OnboardingFormData>({
     type: 'employee',
-    employmentId: '',
-    companyId: 'c3c22940-e118-425c-9e31-f2fd4d43c6d8', // use your own company ID
+    employmentId: import.meta.env.VITE_EMPLOYMENT_ID || '', // use your own employment ID
+    companyId:
+      import.meta.env.VITE_COMPANY_ID || 'c3c22940-e118-425c-9e31-f2fd4d43c6d8', // use your own company ID
     externalId: '',
   });
   const [showOnboarding, setShowOnboarding] = useState(false);

--- a/src/client/sdk.gen.ts
+++ b/src/client/sdk.gen.ts
@@ -39,6 +39,9 @@ import type {
   GetShowContractorInvoiceData,
   GetShowContractorInvoiceResponse,
   GetShowContractorInvoiceError,
+  PostConvertRawCurrencyConverterData,
+  PostConvertRawCurrencyConverterResponse,
+  PostConvertRawCurrencyConverterError,
   GetIndexEmploymentData,
   GetIndexEmploymentResponse,
   GetIndexEmploymentError,
@@ -322,6 +325,9 @@ import type {
   GetDownloadPayslipPayslipData,
   GetDownloadPayslipPayslipResponse,
   GetDownloadPayslipPayslipError,
+  PostConvertWithSpreadCurrencyConverterData,
+  PostConvertWithSpreadCurrencyConverterResponse,
+  PostConvertWithSpreadCurrencyConverterError,
   GetShowTimeoffData,
   GetShowTimeoffResponse,
   GetShowTimeoffError,
@@ -454,9 +460,9 @@ import type {
   GetIndexEmploymentContractData,
   GetIndexEmploymentContractResponse,
   GetIndexEmploymentContractError,
-  PostConvertCurrencyConverterData,
-  PostConvertCurrencyConverterResponse,
-  PostConvertCurrencyConverterError,
+  PostConvertWithSpreadCurrencyConverter2Data,
+  PostConvertWithSpreadCurrencyConverter2Response,
+  PostConvertWithSpreadCurrencyConverter2Error,
   GetIndexCompanyData,
   GetIndexCompanyResponse,
   GetIndexCompanyError,
@@ -825,6 +831,36 @@ export const getShowContractorInvoice = <ThrowOnError extends boolean = false>(
     ],
     url: '/v1/contractor-invoices/{id}',
     ...options,
+  });
+};
+
+/**
+ * Convert currency using flat rates
+ * Convert currency using FX rates used in Remote’s estimation tools.
+ * These rates are not guaranteed to match final onboarding or contract rates.
+ */
+export const postConvertRawCurrencyConverter = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<PostConvertRawCurrencyConverterData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    PostConvertRawCurrencyConverterResponse,
+    PostConvertRawCurrencyConverterError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/v1/currency-converter/raw',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
   });
 };
 
@@ -3764,6 +3800,35 @@ export const getDownloadPayslipPayslip = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * Convert currency using dynamic rates
+ * Convert currency using the rates Remote applies during employment creation and invoicing.
+ */
+export const postConvertWithSpreadCurrencyConverter = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<PostConvertWithSpreadCurrencyConverterData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    PostConvertWithSpreadCurrencyConverterResponse,
+    PostConvertWithSpreadCurrencyConverterError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/v1/currency-converter/effective',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+};
+
+/**
  * Show Time Off
  * Shows a single Time Off record
  */
@@ -5096,17 +5161,17 @@ export const getIndexEmploymentContract = <
 };
 
 /**
- * Convert currency
- * Convert currency
+ * Convert currency using dynamic rates
+ * Convert currency using the rates Remote applies during employment creation and invoicing.
  */
-export const postConvertCurrencyConverter = <
+export const postConvertWithSpreadCurrencyConverter2 = <
   ThrowOnError extends boolean = false,
 >(
-  options: Options<PostConvertCurrencyConverterData, ThrowOnError>,
+  options: Options<PostConvertWithSpreadCurrencyConverter2Data, ThrowOnError>,
 ) => {
   return (options.client ?? _heyApiClient).post<
-    PostConvertCurrencyConverterResponse,
-    PostConvertCurrencyConverterError,
+    PostConvertWithSpreadCurrencyConverter2Response,
+    PostConvertWithSpreadCurrencyConverter2Error,
     ThrowOnError
   >({
     security: [

--- a/src/components/form/fields/CurrencyConversionField.tsx
+++ b/src/components/form/fields/CurrencyConversionField.tsx
@@ -70,7 +70,7 @@ export const CurrencyConversionField = ({
   conversionProperties,
   classNamePrefix,
   description,
-  conversionType = 'no_spread',
+  conversionType = 'spread',
   ...props
 }: CurrencyConversionFieldProps) => {
   const [showConversion, setShowConversion] = useState(false);

--- a/src/components/form/fields/CurrencyConversionField.tsx
+++ b/src/components/form/fields/CurrencyConversionField.tsx
@@ -60,6 +60,7 @@ export type CurrencyConversionFieldProps = JSFField & {
   };
   useProxy?: boolean;
   classNamePrefix: string;
+  conversionType?: 'spread' | 'no_spread';
 };
 
 export const CurrencyConversionField = ({
@@ -69,6 +70,7 @@ export const CurrencyConversionField = ({
   conversionProperties,
   classNamePrefix,
   description,
+  conversionType = 'no_spread',
   ...props
 }: CurrencyConversionFieldProps) => {
   const [showConversion, setShowConversion] = useState(false);
@@ -83,7 +85,9 @@ export const CurrencyConversionField = ({
   const canShowConversion =
     sourceCurrency && targetCurrency && sourceCurrency !== targetCurrency;
 
-  const { mutateAsync: convertCurrency } = useConvertCurrency();
+  const { mutateAsync: convertCurrency } = useConvertCurrency({
+    type: conversionType,
+  });
 
   useEffect(() => {
     if (isFirstRender.current) {

--- a/src/components/form/fields/tests/CurrencyConversionField.test.tsx
+++ b/src/components/form/fields/tests/CurrencyConversionField.test.tsx
@@ -95,7 +95,7 @@ describe('CurrencyFieldWithConversion', () => {
     vi.clearAllMocks();
 
     server.use(
-      http.post('*/v1/currency-converter', async ({ request }) => {
+      http.post('*/v1/currency-converter/effective', async ({ request }) => {
         const body = (await request.json()) as {
           source_currency: string;
           target_currency: string;
@@ -199,7 +199,7 @@ describe('CurrencyFieldWithConversion', () => {
       return HttpResponse.json({});
     });
 
-    server.use(http.post('*/v1/currency-converter', mockHandler));
+    server.use(http.post('*/v1/currency-converter/effective', mockHandler));
 
     const props = {
       ...defaultProps,

--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -5,8 +5,10 @@ import {
   defaultEstimationOptions,
   useCostCalculator,
 } from '@/src/flows/CostCalculator/hooks';
-import { CostCalculatorEstimationOptions } from '@/src/flows/CostCalculator/types';
-import { JSFModify } from '@/src/flows/types';
+import {
+  CostCalculatorEstimationOptions,
+  UseCostCalculatorOptions,
+} from '@/src/flows/CostCalculator/types';
 import React, { useId } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -32,9 +34,7 @@ export type CostCalculatorFlowProps = {
      */
     salary: string;
   }>;
-  options?: {
-    jsfModify?: JSFModify;
-  };
+  options?: UseCostCalculatorOptions;
   render: (
     costCalculatorBag: ReturnType<typeof useCostCalculator>,
   ) => React.ReactNode;

--- a/src/flows/CostCalculator/components/SalaryField.tsx
+++ b/src/flows/CostCalculator/components/SalaryField.tsx
@@ -12,11 +12,13 @@ type SalaryFieldProps = JSFField & {
     label?: string;
     description?: string;
   };
+  conversionType?: 'spread' | 'no_spread';
 };
 
 export const SalaryField = ({
   currencies: { from, to },
   salary_conversion_properties,
+  conversionType = 'no_spread',
   ...props
 }: SalaryFieldProps) => {
   const conversionProperties = {
@@ -42,6 +44,7 @@ export const SalaryField = ({
       conversionFieldName="salary_conversion"
       conversionProperties={conversionProperties}
       classNamePrefix="RemoteFlows-Salary"
+      conversionType={conversionType}
     />
   );
 };

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -157,10 +157,10 @@ export const useCostCalculator = (
             ) => {
               return (
                 <SalaryField
+                  {...props}
                   conversionType={
                     version === 'marketing' ? 'no_spread' : 'spread'
                   }
-                  {...props}
                 />
               );
             },

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -9,6 +9,7 @@ import type {
   CostCalculatorEstimationOptions,
   CostCalculatorEstimationSubmitValues,
   EstimationError,
+  UseCostCalculatorOptions,
 } from '@/src/flows/CostCalculator/types';
 import type { JSFModify, Result } from '@/src/flows/types';
 
@@ -66,9 +67,7 @@ type UseCostCalculatorParams = {
    * The estimation options.
    */
   estimationOptions: CostCalculatorEstimationOptions;
-  options?: {
-    jsfModify?: JSFModify;
-  };
+  options?: UseCostCalculatorOptions;
   version?: CostCalculatorVersion;
 };
 
@@ -156,7 +155,12 @@ export const useCostCalculator = (
             Component: (
               props: JSFField & { currencies: { from: string; to: string } },
             ) => {
-              return <SalaryField {...props} />;
+              return (
+                <SalaryField
+                  conversionType={options?.salaryField?.conversionType}
+                  {...props}
+                />
+              );
             },
           },
         },

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -157,7 +157,9 @@ export const useCostCalculator = (
             ) => {
               return (
                 <SalaryField
-                  conversionType={options?.salaryField?.conversionType}
+                  conversionType={
+                    version === 'marketing' ? 'no_spread' : 'spread'
+                  }
                   {...props}
                 />
               );

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -3,6 +3,7 @@ import type {
   PostCreateEstimationError,
   ValidationError,
 } from '@/src/client';
+import { JSFModify } from '@/src/flows/types';
 
 export type CostCalculatorEstimationSubmitValues = {
   currency: string;
@@ -50,3 +51,10 @@ export type CostCalculatorEstimationOptions = Partial<{
 }>;
 
 export type EstimationError = PostCreateEstimationError | ValidationError;
+
+export type UseCostCalculatorOptions = {
+  jsfModify?: JSFModify;
+  salaryField?: {
+    conversionType?: 'spread' | 'no_spread';
+  };
+};

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -54,7 +54,4 @@ export type EstimationError = PostCreateEstimationError | ValidationError;
 
 export type UseCostCalculatorOptions = {
   jsfModify?: JSFModify;
-  salaryField?: {
-    conversionType?: 'spread' | 'no_spread';
-  };
 };

--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -502,23 +502,14 @@ export const useConvertCurrency = ({
   const { client } = useClient();
   return useMutation({
     mutationFn: (payload: ConvertCurrencyParams) => {
-      if (type === 'no_spread') {
-        return postConvertRawCurrencyConverter({
-          client: client as Client,
-          headers: {
-            Authorization: ``,
-          },
-          body: payload,
-        });
-      } else {
-        return postConvertWithSpreadCurrencyConverter({
-          client: client as Client,
-          headers: {
-            Authorization: ``,
-          },
-          body: payload,
-        });
-      }
+      const apiFn =
+        type === 'no_spread'
+          ? postConvertRawCurrencyConverter
+          : postConvertWithSpreadCurrencyConverter;
+      return apiFn({
+        client: client as Client,
+        body: payload,
+      });
     },
   });
 };

--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -11,7 +11,8 @@ import {
   getSupportedCountry,
   MagicLinkParams,
   patchUpdateEmployment2,
-  postConvertCurrencyConverter,
+  postConvertRawCurrencyConverter,
+  postConvertWithSpreadCurrencyConverter,
   postCreateContractEligibility,
   postCreateEmployment2,
   postCreateRiskReserve,
@@ -502,8 +503,7 @@ export const useConvertCurrency = ({
   return useMutation({
     mutationFn: (payload: ConvertCurrencyParams) => {
       if (type === 'no_spread') {
-        // TODO: We need to implement a new endpoint in the BE that returns correctly the conversion rate
-        return postConvertCurrencyConverter({
+        return postConvertRawCurrencyConverter({
           client: client as Client,
           headers: {
             Authorization: ``,
@@ -511,7 +511,7 @@ export const useConvertCurrency = ({
           body: payload,
         });
       } else {
-        return postConvertCurrencyConverter({
+        return postConvertWithSpreadCurrencyConverter({
           client: client as Client,
           headers: {
             Authorization: ``,

--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -493,17 +493,32 @@ export const useCountriesSchemaField = (
   };
 };
 
-export const useConvertCurrency = () => {
+export const useConvertCurrency = ({
+  type = 'spread',
+}: {
+  type?: 'spread' | 'no_spread';
+}) => {
   const { client } = useClient();
   return useMutation({
     mutationFn: (payload: ConvertCurrencyParams) => {
-      return postConvertCurrencyConverter({
-        client: client as Client,
-        headers: {
-          Authorization: ``,
-        },
-        body: payload,
-      });
+      if (type === 'no_spread') {
+        // TODO: We need to implement a new endpoint in the BE that returns correctly the conversion rate
+        return postConvertCurrencyConverter({
+          client: client as Client,
+          headers: {
+            Authorization: ``,
+          },
+          body: payload,
+        });
+      } else {
+        return postConvertCurrencyConverter({
+          client: client as Client,
+          headers: {
+            Authorization: ``,
+          },
+          body: payload,
+        });
+      }
     },
   });
 };

--- a/src/flows/Onboarding/components/AnnualGrossSalary.tsx
+++ b/src/flows/Onboarding/components/AnnualGrossSalary.tsx
@@ -29,6 +29,7 @@ export const AnnualGrossSalary = ({
           'Estimated amount. This is an estimation. We calculate conversions based on spot rates that are subject to fluctuation over time.',
       }}
       classNamePrefix="RemoteFlows-AnnualGrossSalary"
+      conversionType="no_spread"
     />
   );
 };

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -381,7 +381,7 @@ describe('OnboardingFlow', () => {
       http.patch('*/v1/employments/*', async () => {
         return HttpResponse.json(employmentUpdatedResponse);
       }),
-      http.post('*/v1/currency-converter', () => {
+      http.post('*/v1/currency-converter/effective', () => {
         return HttpResponse.json(conversionFromEURToUSD);
       }),
     );


### PR DESCRIPTION
We want that our platform and the SDK will be more similar when doing conversions.

The raw endpoint supports a similar conversion and it's supposed to work for the Onboarding and Marketing Cost Calculator

The effective endpoint is a replacement of the previous endpoint used