### PR TITLE
fix(cost-calculator)- Correct initialization state

### DIFF
--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -58,6 +58,7 @@ export const CostCalculatorFlow = ({
   const formId = useId();
   const costCalculatorBag = useCostCalculator({
     defaultRegion: defaultValues.countryRegionSlug,
+    defaultCurrency: defaultValues.currencySlug,
     estimationOptions,
     version,
     options,

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -15,7 +15,7 @@ import type { JSFModify, Result } from '@/src/flows/types';
 import { parseJSFToValidate } from '@/src/components/form/utils';
 import { iterateErrors } from '@/src/components/form/yupValidationResolver';
 import { createHeadlessForm, modify } from '@remoteoss/json-schema-form';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { string, ValidationError } from 'yup';
 import { buildPayload, buildValidationSchema } from './utils';
 import {
@@ -63,6 +63,10 @@ type UseCostCalculatorParams = {
    */
   defaultRegion?: string;
   /**
+   * The default currency slug to preselect a currency.
+   */
+  defaultCurrency?: string;
+  /**
    * The estimation options.
    */
   estimationOptions: CostCalculatorEstimationOptions;
@@ -87,6 +91,7 @@ const useStaticSchema = (options?: { jsfModify?: JSFModify }) => {
 export const useCostCalculator = (
   {
     defaultRegion,
+    defaultCurrency,
     estimationOptions,
     options,
     version,
@@ -178,6 +183,30 @@ export const useCostCalculator = (
       },
     },
   });
+
+  useEffect(() => {
+    // Initialize selectedCountry from defaultRegion
+    if (defaultRegion && countries) {
+      const defaultCountry = countries.find(
+        ({ value }) => value === defaultRegion,
+      );
+      if (defaultCountry) {
+        setSelectedCountry(defaultCountry);
+      }
+    }
+  }, [defaultRegion, countries]);
+
+  useEffect(() => {
+    // Initialize selectedCurrency from defaultCurrency
+    if (defaultCurrency && currencies) {
+      const defaultCurrencyObj = currencies.find(
+        ({ value }) => value === defaultCurrency,
+      );
+      if (defaultCurrencyObj) {
+        setEmployerBillingCurrency(defaultCurrencyObj.label);
+      }
+    }
+  }, [defaultCurrency, currencies]);
 
   /**
    * Submit the estimation form with the given values.

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -114,6 +114,19 @@ describe('CostCalculatorFlow', () => {
     expect(screen.getByText(/Show USD conversion/i)).toBeInTheDocument();
   });
 
+  it('should render the 3 comboboxes when selecting a country with region', async () => {
+    renderComponent({
+      defaultValues: {
+        ...defaultProps.defaultValues,
+        countryRegionSlug: 'ESP',
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox')).toHaveLength(3);
+    });
+  });
+
   it('should submit the form with default values', async () => {
     renderComponent();
     await waitFor(() => {

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -111,6 +111,7 @@ describe('CostCalculatorFlow', () => {
 
     expect(currencyDropdown).toHaveTextContent(/USD/i);
     expect(salaryInput).toHaveValue('50000');
+    expect(screen.getByText(/Show USD conversion/i)).toBeInTheDocument();
   });
 
   it('should submit the form with default values', async () => {

--- a/src/flows/CostCalculator/tests/fixtures.ts
+++ b/src/flows/CostCalculator/tests/fixtures.ts
@@ -10,15 +10,30 @@ export const countries = {
         slug: 'pln-33441af1-a601-4a22-8f52-1ec090f10b4a',
       },
       region_slug: 'POL',
+      child_regions: [],
+      has_additional_fields: false,
+      availability: 'active',
+      original_country_slug: 'poland-d3f6d510-2fdf-4b9d-8520-2b581a862411',
+    },
+    {
+      code: 'ESP',
+      name: 'Spain',
+      currency: {
+        code: 'EUR',
+        name: 'Euro',
+        symbol: '€',
+        slug: 'eur-33441af1-a601-4a22-8f52-1ec090f10b4a',
+      },
+      region_slug: 'ESP',
       child_regions: [
         {
-          slug: 'POL',
+          slug: 'ESP',
           name: '',
         },
       ],
       has_additional_fields: true,
       availability: 'active',
-      original_country_slug: 'poland-d3f6d510-2fdf-4b9d-8520-2b581a862411',
+      original_country_slug: 'spain-d3f6d510-2fdf-4b9d-8520-2b581a862411',
     },
   ],
 };

--- a/src/flows/CostCalculator/tests/hooks.test.tsx
+++ b/src/flows/CostCalculator/tests/hooks.test.tsx
@@ -48,7 +48,7 @@ describe('useCostCalculator', () => {
     );
 
     act(() => {
-      countryField?.onChange?.('POL');
+      countryField?.onChange?.('ESP');
     });
 
     await waitFor(() => {


### PR DESCRIPTION
When we pass defaultValues I discover that the internal state was not getting set correctly, detected this while I was coding 

https://github.com/remoteoss/remote-flows/pull/406

Once I fix the behavior tests started to fail, because we weren't considering that POL had regions mocked

I fix the tests and add some