### PR TITLE
feat: use annual_gross_salary_in_employer_currency

### DIFF
--- a/src/components/form/fields/CurrencyConversionField.tsx
+++ b/src/components/form/fields/CurrencyConversionField.tsx
@@ -163,8 +163,12 @@ export const CurrencyConversionField = ({
       ),
     500,
   );
+  // we keep track of the last input the user used, so we can make sure
+  // we keep consistent currency rates
+  const lastInputFieldName = `${props.name}_converted`;
 
   const handleMainFieldChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(lastInputFieldName, false);
     if (showConversion) {
       debouncedConvertCurrency(evt.target.value);
     }
@@ -173,6 +177,7 @@ export const CurrencyConversionField = ({
   const handleConversionFieldChange = (
     evt: React.ChangeEvent<HTMLInputElement>,
   ) => {
+    setValue(lastInputFieldName, true);
     debouncedConvertCurrencyReverse(evt.target.value);
   };
 
@@ -222,6 +227,11 @@ export const CurrencyConversionField = ({
           onChange={handleConversionFieldChange}
         />
       )}
+      <input
+        type="hidden"
+        name={lastInputFieldName}
+        value={watch(lastInputFieldName) || false}
+      />
     </>
   );
 };

--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -74,6 +74,7 @@ export const CostCalculatorFlow = ({
       currency: defaultValues?.currencySlug,
       region: '',
       salary: defaultValues?.salary,
+      salary_converted: false,
     },
     shouldUnregister: false,
     mode: 'onBlur',

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -6,8 +6,10 @@ import { useCostCalculatorContext } from '@/src/flows/CostCalculator/context';
 import {
   CostCalculatorEstimationFormValues,
   CostCalculatorEstimationSubmitValues,
+  CostCalculatorInternalEstimationSubmitValues,
   EstimationError,
 } from '@/src/flows/CostCalculator/types';
+import omit from 'lodash/omit';
 
 type CostCalculatorFormProps = Partial<{
   /**
@@ -82,11 +84,11 @@ export function CostCalculatorForm({
   const handleSubmit = async (values: CostCalculatorEstimationFormValues) => {
     const parsedValues = costCalculatorBag?.parseFormValues(
       values,
-    ) as CostCalculatorEstimationSubmitValues;
+    ) as CostCalculatorInternalEstimationSubmitValues;
     const costCalculatorResults =
       await costCalculatorBag?.onSubmit(parsedValues);
-
-    await onSubmit?.(parsedValues);
+    const cleanValues = omit(parsedValues, ['salary_converted']);
+    await onSubmit?.(cleanValues);
 
     if (costCalculatorResults?.error) {
       onError?.(costCalculatorResults.error);

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -6,10 +6,8 @@ import { useCostCalculatorContext } from '@/src/flows/CostCalculator/context';
 import {
   CostCalculatorEstimationFormValues,
   CostCalculatorEstimationSubmitValues,
-  CostCalculatorInternalEstimationSubmitValues,
   EstimationError,
 } from '@/src/flows/CostCalculator/types';
-import omit from 'lodash/omit';
 
 type CostCalculatorFormProps = Partial<{
   /**
@@ -84,11 +82,11 @@ export function CostCalculatorForm({
   const handleSubmit = async (values: CostCalculatorEstimationFormValues) => {
     const parsedValues = costCalculatorBag?.parseFormValues(
       values,
-    ) as CostCalculatorInternalEstimationSubmitValues;
+    ) as CostCalculatorEstimationSubmitValues;
     const costCalculatorResults =
       await costCalculatorBag?.onSubmit(parsedValues);
-    const cleanValues = omit(parsedValues, ['salary_converted']);
-    await onSubmit?.(cleanValues);
+
+    await onSubmit?.(parsedValues);
 
     if (costCalculatorResults?.error) {
       onError?.(costCalculatorResults.error);

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -80,13 +80,13 @@ export function CostCalculatorForm({
   ]);
 
   const handleSubmit = async (values: CostCalculatorEstimationFormValues) => {
-    const cleanedValues = costCalculatorBag?.parseFormValues(
+    const parsedValues = costCalculatorBag?.parseFormValues(
       values,
     ) as CostCalculatorEstimationSubmitValues;
     const costCalculatorResults =
-      await costCalculatorBag?.onSubmit(cleanedValues);
+      await costCalculatorBag?.onSubmit(parsedValues);
 
-    await onSubmit?.(cleanedValues);
+    await onSubmit?.(parsedValues);
 
     if (costCalculatorResults?.error) {
       onError?.(costCalculatorResults.error);

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -174,7 +174,6 @@ export const useCostCalculator = (
     salaryField,
     salaryFieldPresentation?.salary_conversion_properties?.description,
     salaryFieldPresentation?.salary_conversion_properties?.label,
-    version,
   ]);
 
   const fieldsJSONSchema = useStaticSchema({

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -381,13 +381,22 @@ export const useCostCalculator = (
     parseFormValues: (
       values: CostCalculatorEstimationFormValues,
     ): CostCalculatorEstimationSubmitValues => {
-      const { country, region, salary, currency, ...rest } = values;
+      const { country, region, currency, salary_converted, ...rest } = values;
+
+      // If the salary has been converted, we take the one the user has inputted
+      let salary = values.salary;
+      if (salary_converted) {
+        salary = values.salary_conversion;
+      }
+
       const jsonSchemaStaticFieldValues = {
         country,
         region,
         salary,
+        salary_converted,
         currency,
       };
+
       const parsedStaticFields = parseJSFToValidate(
         jsonSchemaStaticFieldValues,
         fieldsJSONSchema.fields,

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -174,6 +174,7 @@ export const useCostCalculator = (
     salaryField,
     salaryFieldPresentation?.salary_conversion_properties?.description,
     salaryFieldPresentation?.salary_conversion_properties?.label,
+    version,
   ]);
 
   const fieldsJSONSchema = useStaticSchema({

--- a/src/flows/CostCalculator/jsonSchema.ts
+++ b/src/flows/CostCalculator/jsonSchema.ts
@@ -42,8 +42,17 @@ export const jsonSchema = {
             required: 'Salary is required',
           },
         },
+        salary_converted: {
+          description:
+            'Whether the salary is expressed in regional or employer currency',
+          title: 'Salary in employer currency',
+          type: 'boolean',
+          'x-jsf-presentation': {
+            inputType: 'hidden',
+          },
+        },
       },
-      required: ['country', 'currency', 'salary'],
+      required: ['country', 'currency', 'salary', 'salary_converted'],
       type: 'object',
       'x-jsf-order': ['country', 'region', 'currency', 'salary'],
     },

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -126,7 +126,6 @@ describe('CostCalculatorFlow', () => {
         country: 'POL',
         currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
         salary: 5_000_000,
-        salary_converted: false,
       });
     });
   });
@@ -271,7 +270,6 @@ describe('CostCalculatorFlow', () => {
         country: 'POL',
         currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
         salary: 5_000_000,
-        salary_converted: false,
       });
     });
   });

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -126,6 +126,7 @@ describe('CostCalculatorFlow', () => {
         country: 'POL',
         currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
         salary: 5_000_000,
+        salary_converted: false,
       });
     });
   });
@@ -270,6 +271,7 @@ describe('CostCalculatorFlow', () => {
         country: 'POL',
         currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
         salary: 5_000_000,
+        salary_converted: false,
       });
     });
   });

--- a/src/flows/CostCalculator/tests/utils.test.ts
+++ b/src/flows/CostCalculator/tests/utils.test.ts
@@ -8,6 +8,7 @@ describe('buildPayload', () => {
     const values: CostCalculatorEstimationSubmitValues = {
       currency: 'USD',
       country: 'US',
+      salary_converted: false,
       salary: 100_000,
     };
 
@@ -22,6 +23,31 @@ describe('buildPayload', () => {
         {
           region_slug: 'US',
           annual_gross_salary: 100_000,
+          employment_term: 'fixed',
+          title: defaultEstimationOptions.title,
+        },
+      ],
+    });
+  });
+
+  it('should build a payload with minimal values when salary converted is true', () => {
+    const values: CostCalculatorEstimationSubmitValues = {
+      currency: 'USD',
+      country: 'US',
+      salary_converted: true,
+      salary: 100_000,
+    };
+
+    const payload = buildPayload(values);
+
+    expect(payload).toEqual({
+      employer_currency_slug: 'USD',
+      include_benefits: defaultEstimationOptions.includeBenefits,
+      include_cost_breakdowns: defaultEstimationOptions.includeCostBreakdowns,
+      include_premium_benefits: defaultEstimationOptions.includePremiumBenefits,
+      employments: [
+        {
+          region_slug: 'US',
           annual_gross_salary_in_employer_currency: 100_000,
           employment_term: 'fixed',
           title: defaultEstimationOptions.title,
@@ -92,6 +118,7 @@ describe('buildPayload', () => {
     const values: CostCalculatorEstimationSubmitValues = {
       currency: 'USD',
       country: 'US',
+      salary_converted: false,
       salary: 100_000,
     };
 
@@ -112,6 +139,7 @@ describe('buildPayload', () => {
     const values: CostCalculatorEstimationSubmitValues = {
       currency: 'USD',
       country: 'US',
+      salary_converted: false,
       salary: 100_000,
       benefits: {
         'benefit-health': 'whatever',
@@ -133,6 +161,7 @@ describe('buildPayload', () => {
     const values: CostCalculatorEstimationSubmitValues = {
       currency: 'USD',
       country: 'US',
+      salary_converted: false,
       salary: 100_000,
     };
 
@@ -145,12 +174,6 @@ describe('buildPayload', () => {
 
       expect(payload.employments[0]).toHaveProperty('annual_gross_salary');
       expect(payload.employments[0].annual_gross_salary).toBe(100_000);
-      expect(payload.employments[0]).toHaveProperty(
-        'annual_gross_salary_in_employer_currency',
-      );
-      expect(
-        payload.employments[0].annual_gross_salary_in_employer_currency,
-      ).toBe(100_000);
     });
 
     it('should NOT include annual_gross_salary when version is "marketing"', () => {
@@ -174,9 +197,6 @@ describe('buildPayload', () => {
 
       expect(payload.employments[0]).toHaveProperty('annual_gross_salary');
       expect(payload.employments[0].annual_gross_salary).toBe(100_000);
-      expect(
-        payload.employments[0].annual_gross_salary_in_employer_currency,
-      ).toBe(100_000);
     });
 
     it('should default to "standard" behavior when only values parameter is provided', () => {
@@ -193,11 +213,13 @@ describe('buildPayload', () => {
         {
           currency: 'USD',
           country: 'US',
+          salary_converted: false,
           salary: 100_000,
         },
         {
           currency: 'USD', // Note: currency from first item is used
           country: 'UK',
+          salary_converted: false,
           salary: 80_000,
         },
       ];
@@ -214,14 +236,12 @@ describe('buildPayload', () => {
           {
             region_slug: 'US',
             annual_gross_salary: 100_000,
-            annual_gross_salary_in_employer_currency: 100_000,
             employment_term: 'fixed',
             title: defaultEstimationOptions.title,
           },
           {
             region_slug: 'UK',
             annual_gross_salary: 80_000,
-            annual_gross_salary_in_employer_currency: 80_000,
             employment_term: 'fixed',
             title: defaultEstimationOptions.title,
           },
@@ -236,6 +256,7 @@ describe('buildPayload', () => {
           country: 'DE',
           region: 'Berlin',
           salary: 90_000,
+          salary_converted: false,
           age: 25,
           benefits: {
             'benefit-health': 'premium',
@@ -246,6 +267,7 @@ describe('buildPayload', () => {
           country: 'FR',
           salary: 85_000,
           contract_duration_type: 'indefinite',
+          salary_converted: false,
         },
       ];
 
@@ -266,8 +288,18 @@ describe('buildPayload', () => {
 
     it('should apply version parameter to all employments in array', () => {
       const values: CostCalculatorEstimationSubmitValues[] = [
-        { currency: 'USD', country: 'US', salary: 100_000 },
-        { currency: 'USD', country: 'UK', salary: 80_000 },
+        {
+          currency: 'USD',
+          country: 'US',
+          salary: 100_000,
+          salary_converted: false,
+        },
+        {
+          currency: 'USD',
+          country: 'UK',
+          salary: 80_000,
+          salary_converted: false,
+        },
       ];
 
       const payload = buildPayload(

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -8,6 +8,7 @@ import { JSFModify } from '@/src/flows/types';
 export type CostCalculatorEstimationSubmitValues = {
   currency: string;
   country: string;
+  salary_converted: boolean;
   salary: number;
 } & Partial<{
   region: string;
@@ -15,11 +16,6 @@ export type CostCalculatorEstimationSubmitValues = {
   contract_duration_type: EmploymentTermType;
   benefits: Record<string, string>;
 }>;
-
-export type CostCalculatorInternalEstimationSubmitValues =
-  CostCalculatorEstimationSubmitValues & {
-    salary_converted: boolean;
-  };
 
 export type CostCalculatorEstimationFormValues = {
   currency: string;

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -8,6 +8,7 @@ import { JSFModify } from '@/src/flows/types';
 export type CostCalculatorEstimationSubmitValues = {
   currency: string;
   country: string;
+  salary_converted: boolean;
   salary: number;
 } & Partial<{
   region: string;
@@ -20,6 +21,8 @@ export type CostCalculatorEstimationFormValues = {
   currency: string;
   country: string;
   salary: string;
+  salary_converted: boolean;
+  salary_conversion: string;
 } & Partial<{
   region: string;
   age: number;

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -8,7 +8,6 @@ import { JSFModify } from '@/src/flows/types';
 export type CostCalculatorEstimationSubmitValues = {
   currency: string;
   country: string;
-  salary_converted: boolean;
   salary: number;
 } & Partial<{
   region: string;
@@ -16,6 +15,11 @@ export type CostCalculatorEstimationSubmitValues = {
   contract_duration_type: EmploymentTermType;
   benefits: Record<string, string>;
 }>;
+
+export type CostCalculatorInternalEstimationSubmitValues =
+  CostCalculatorEstimationSubmitValues & {
+    salary_converted: boolean;
+  };
 
 export type CostCalculatorEstimationFormValues = {
   currency: string;

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -53,14 +53,17 @@ function mapValueToEmployment(
 ) {
   return {
     region_slug: value.region || value.country,
-    annual_gross_salary_in_employer_currency: value.salary,
     employment_term: value.contract_duration_type ?? 'fixed',
     title: estimationOptions.title,
     age: value.age ?? undefined,
     ...(value.benefits && { benefits: formatBenefits(value.benefits) }),
-    ...(version === 'standard' && {
-      annual_gross_salary: value.salary,
+    ...((version == 'marketing' || value.salary_converted) && {
+      annual_gross_salary_in_employer_currency: value.salary,
     }),
+    ...(version === 'standard' &&
+      !value.salary_converted && {
+        annual_gross_salary: value.salary,
+      }),
   };
 }
 


### PR DESCRIPTION
When the user types the salary into the employer currency, we should use that one instead of the converted amount when estimating on the backend, so that the results are consistent.

To do that:
- We keep track of whether the user has typed into the conversion input
- We surface that information to the submit value, and we set either annual_gross_salary or annual_gross_salary_in_employer_currency based on whether the user has inputted in one or the other currency.