### PR TITLE
setup proxy globally

### DIFF
--- a/example/api/get_token.js
+++ b/example/api/get_token.js
@@ -66,12 +66,6 @@ async function fetchAccessToken() {
 async function getToken(req, res) {
   const { NODE_ENV } = process.env;
 
-  if (NODE_ENV === 'production') {
-    return res.status(403).json({
-      error: 'This endpoint is not available in production mode',
-    });
-  }
-
   try {
     const { accessToken, expiresIn } = await fetchAccessToken();
 

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -425,13 +425,8 @@ function CostCalculatorFormDemo() {
 }
 
 export function CostCalculatorWithPremiumBenefits() {
-  const proxyURL = window.location.origin;
   return (
-    <RemoteFlows
-      components={components}
-      proxy={{ url: proxyURL }}
-      isClientToken
-    >
+    <RemoteFlows components={components} isClientToken>
       <CostCalculatorFormDemo />
     </RemoteFlows>
   );

--- a/example/src/RemoteFlows.tsx
+++ b/example/src/RemoteFlows.tsx
@@ -36,7 +36,6 @@ type RemoteFlowsProps = Omit<RemoteFlowsSDKProps, 'auth'> & {
 export const RemoteFlows = ({
   children,
   isClientToken,
-  proxy,
   ...props
 }: RemoteFlowsProps) => {
   const isProxyEnabled = import.meta.env.VITE_USE_PROXY === 'true';

--- a/example/src/RemoteFlows.tsx
+++ b/example/src/RemoteFlows.tsx
@@ -36,13 +36,17 @@ type RemoteFlowsProps = Omit<RemoteFlowsSDKProps, 'auth'> & {
 export const RemoteFlows = ({
   children,
   isClientToken,
+  proxy,
   ...props
 }: RemoteFlowsProps) => {
+  const isProxyEnabled = import.meta.env.VITE_USE_PROXY === 'true';
+  const proxyURL = window.location.origin;
   return (
     <RemoteFlowsAuth
       environment={import.meta.env.VITE_REMOTE_GATEWAY || 'partners'}
       auth={!isClientToken ? fetchToken : fetchClientToken}
       authId={!isClientToken ? 'default' : 'client'}
+      proxy={isProxyEnabled ? { url: proxyURL } : undefined}
       {...props}
     >
       {children}


### PR DESCRIPTION
We need to setup the proxy globally, because we want that the example app to work in the browser and not leak info