### PR TITLE
feat(results) - able to customize different sections

### DIFF
--- a/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
+++ b/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
@@ -499,6 +499,7 @@ type EstimationResultsComponents = {
     onDelete: () => void;
     onExportPdf: () => void;
   }>;
+  Footer?: React.ComponentType;
 };
 
 type EstimationResultsProps = {
@@ -521,6 +522,7 @@ export const EstimationResults = ({
     components?.OnboardingTimeline || OnboardingTimeline;
   const CustomEstimationResultsHeader =
     components?.EstimationResultsHeader || EstimationResultsHeader;
+  const CustomFooter = components?.Footer;
 
   const onboardingTimelineData = getOnboardingTimelineData();
 
@@ -784,6 +786,8 @@ export const EstimationResults = ({
         countryGuideUrl={estimation.country_guide_url as string}
         country={estimation.country.name}
       />
+
+      {CustomFooter && <CustomFooter />}
     </Card>
   );
 };


### PR DESCRIPTION
There is a need from partners to customize different sections for example header, onboarding timeline or hiring.

We open the door like we did in RemoteFlows and make consumers able to customize these sections adding their own html && css

We don't open the door for the content of the results EstimationRow and EstimationBreakdown
