### PR TITLE
feat(cost-calculator) - remove unused property

### DIFF
--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -37,7 +37,6 @@ const estimationOptions = {
   includeBenefits: true,
   includeCostBreakdowns: true,
   includePremiumBenefits: true,
-  enableCurrencyConversion: true,
 };
 
 const Layout = ({

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -55,7 +55,6 @@ export const defaultEstimationOptions: CostCalculatorEstimationOptions = {
   includeBenefits: false,
   includeCostBreakdowns: false,
   includePremiumBenefits: false,
-  enableCurrencyConversion: false,
 };
 
 type UseCostCalculatorParams = {

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -47,10 +47,6 @@ export type CostCalculatorEstimationOptions = Partial<{
    * Include premium benefits in the estimation. Default is false.
    */
   includePremiumBenefits: boolean;
-  /**
-   * Enable currency conversion. Default is false.
-   */
-  enableCurrencyConversion: boolean;
 }>;
 
 export type EstimationError = PostCreateEstimationError | ValidationError;


### PR DESCRIPTION
This property doesn't have an effect, it doesn't matter that you use it, it won't work.

Conversion will appear always for marketing and product cost calculators, so this won't be a breaking change