### PR TITLE
feat(cost-calculator) - Improve fieldsets for demo

### DIFF
--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -229,6 +229,11 @@ const AddEstimateForm = ({
               description:
                 "We will use your selected billing currency, but you can also convert it to the employee's local currency.",
             },
+            benefits: {
+              'x-jsf-presentation': {
+                variant: 'inset',
+              },
+            },
           },
         },
       }}

--- a/example/src/css/main.css
+++ b/example/src/css/main.css
@@ -906,3 +906,22 @@ button.reset-button {
     margin-bottom: 0;
   }
 }
+
+.RemoteFlows__FieldSetField {
+  border: 1px solid #e5e5e5;
+  background: #fff;
+  border-radius: 10px;
+  padding: 40px 56px;
+}
+
+.RemoteFlows__FieldSetField__Title {
+  color: #000000;
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.RemoteFlows__FieldSetField__Header {
+  padding-bottom: 24px;
+  border-bottom: 1px solid #e4e4e7;
+  margin-bottom: 24px;
+}

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -37,6 +37,7 @@ type FieldSetProps = {
   statement?: StatementProps;
   isFlatFieldset: boolean;
   extra?: React.ReactNode;
+  variant: 'outset' | 'inset';
 };
 
 export function FieldSetField({
@@ -48,6 +49,7 @@ export function FieldSetField({
   statement,
   isFlatFieldset,
   extra,
+  variant = 'outset',
 }: FieldSetProps) {
   const { watch, trigger, formState } = useFormContext();
   const fieldNames = fields.map(
@@ -98,10 +100,23 @@ export function FieldSetField({
     <fieldset
       className={cn(
         'border-1 border-input p-4 rounded-xl',
+        `RemoteFlows__FieldSetField`,
         `RemoteFlows__FieldSetField__${name}`,
       )}
     >
-      <legend className="text-sm font-semibold px-2">{label}</legend>
+      <legend
+        className={cn(
+          'text-sm font-semibold px-2',
+          variant === 'inset' && 'hidden',
+        )}
+      >
+        {label}
+      </legend>
+      {variant === 'inset' && (
+        <div className="RemoteFlows__FieldSetField__Header">
+          <h3 className={cn('RemoteFlows__FieldSetField__Title')}>{label}</h3>
+        </div>
+      )}
       {description ? (
         <div
           className="mb-5 RemoteFlows__FieldSetField__Description"

--- a/src/components/form/fields/tests/FieldSetField.test.tsx
+++ b/src/components/form/fields/tests/FieldSetField.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { FieldSetField, FieldSetProps } from '../FieldSetField';
+import { FormProvider, useForm } from 'react-hook-form';
+
+vi.mock('@/src/context', () => ({
+  useFormFields: vi.fn(),
+}));
+
+const defaultProps = {
+  name: 'test-fieldset',
+  title: 'Test Fieldset',
+  fields: [],
+  label: 'Test Fieldset',
+  description: 'Test Description',
+  components: {},
+  isFlatFieldset: false,
+  variant: 'outset' as const,
+};
+
+const renderWithFormContext = (
+  props: Partial<FieldSetProps> = defaultProps,
+) => {
+  const TestComponent = () => {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <FieldSetField {...defaultProps} {...props} />
+      </FormProvider>
+    );
+  };
+
+  return render(<TestComponent />);
+};
+
+describe('FieldSetField', () => {
+  it('renders with default variant (outset)', () => {
+    renderWithFormContext();
+
+    // Title should be in legend
+    expect(screen.getByRole('group')).toBeInTheDocument();
+    expect(screen.getByRole('group')).toHaveTextContent('Test Fieldset');
+  });
+
+  it('renders with inset variant', () => {
+    renderWithFormContext({
+      variant: 'inset',
+    });
+
+    // Title should be inside fieldset as heading
+    expect(screen.getByRole('group')).toBeInTheDocument();
+    expect(screen.getByRole('group')).toHaveTextContent('Test Fieldset');
+    expect(screen.getByRole('heading')).toHaveTextContent('Test Fieldset');
+  });
+});


### PR DESCRIPTION
I did an improvement on the fieldsets to allow them to have variants.

This allow us to improve the styling without affecting partners style, if they wanted fieldsets with the inset variant, they could migrate to it

<img width="583" height="589" alt="image" src="https://github.com/user-attachments/assets/b8c27d93-cfa4-4549-bb93-ad0e9bc4f97d" />
