### PR TITLE
fix(cost-calculator) - fix discount title by not adding anything

### DIFF
--- a/src/flows/CostCalculator/tests/utils.test.ts
+++ b/src/flows/CostCalculator/tests/utils.test.ts
@@ -185,7 +185,7 @@ describe('buildPayload', () => {
 
     expect(payload.global_discount).toEqual({
       quoted_amount: 59900,
-      text: 'New Management fee',
+      text: '',
     });
   });
 

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -148,7 +148,7 @@ export function buildPayload(
       managementFee && {
         global_discount: {
           quoted_amount: managementFee,
-          text: 'New Management fee',
+          text: '',
         },
       }),
     employments: employments.map((value) =>


### PR DESCRIPTION
As I haven't released into a new version, we can still modify the discount that we send

The management fee was appearing in the pdf and we don't want that for now