### PR TITLE
feat(zendesk-drawers) - replace zendesk drawers component

### DIFF
--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -247,5 +247,5 @@ export const components: Components = {
   radio: Radio,
   checkbox: Checkbox,
   countries: Countries,
-  //zendeskDialog: ZendeskDialog,
+  //zendeskDrawer: ZendeskDialog,
 };

--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -3,7 +3,7 @@ import type {
   Components,
   FieldComponentProps,
 } from '@remoteoss/remote-flows';
-import { ZendeskDialog } from './ZendeskDialog';
+//import { ZendeskDialog } from './ZendeskDialog';
 
 // you can define HTML button attributes or event props that exist in your Button like variant, size, etc.
 const Button = ({

--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -3,6 +3,7 @@ import type {
   Components,
   FieldComponentProps,
 } from '@remoteoss/remote-flows';
+import { ZendeskDialog } from './ZendeskDialog';
 
 // you can define HTML button attributes or event props that exist in your Button like variant, size, etc.
 const Button = ({
@@ -246,4 +247,5 @@ export const components: Components = {
   radio: Radio,
   checkbox: Checkbox,
   countries: Countries,
+  //zendeskDialog: ZendeskDialog,
 };

--- a/example/src/ZendeskDialog.tsx
+++ b/example/src/ZendeskDialog.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  DialogTrigger,
+} from '@remoteoss/remote-flows/internals';
+import type { ZendeskDialogComponentProps } from '@remoteoss/remote-flows';
+import { sanitizeHtml } from '@remoteoss/remote-flows';
+
+export function ZendeskDialog({
+  open,
+  onClose,
+  data,
+  isLoading,
+  error,
+  zendeskURL,
+  Trigger,
+}: ZendeskDialogComponentProps) {
+  const triggerElement = React.isValidElement(Trigger) ? (
+    Trigger
+  ) : (
+    <div>{Trigger}</div>
+  );
+  return (
+    <Dialog open={open} onOpenChange={(open) => !open && onClose()}>
+      <DialogTrigger asChild>{triggerElement}</DialogTrigger>
+      <DialogContent className='sm:max-w-[920px] max-h-[80vh]'>
+        <DialogHeader>
+          <DialogTitle>{data?.title}</DialogTitle>
+          <DialogDescription>
+            For more details see our{' '}
+            <a href={zendeskURL} target='_blank' rel='noopener noreferrer'>
+              help article
+            </a>{' '}
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className='h-[60vh] pr-4'>
+          <div className='space-y-6'>
+            {isLoading && <div>Loading...</div>}
+            {error && (
+              <div className='text-sm text-red-500'>Error loading article</div>
+            )}
+            <div
+              className='flex-1 overflow-y-auto'
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHtml(data?.body || ''),
+              }}
+            ></div>
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/example/src/ZendeskDialog.tsx
+++ b/example/src/ZendeskDialog.tsx
@@ -9,7 +9,6 @@ import {
   DialogTrigger,
 } from '@remoteoss/remote-flows/internals';
 import type { ZendeskDialogComponentProps } from '@remoteoss/remote-flows';
-import { sanitizeHtml } from '@remoteoss/remote-flows';
 
 export function ZendeskDialog({
   open,
@@ -48,7 +47,7 @@ export function ZendeskDialog({
             <div
               className='flex-1 overflow-y-auto'
               dangerouslySetInnerHTML={{
-                __html: sanitizeHtml(data?.body || ''),
+                __html: data?.body || '',
               }}
             ></div>
           </div>

--- a/example/src/ZendeskDialog.tsx
+++ b/example/src/ZendeskDialog.tsx
@@ -8,7 +8,7 @@ import {
   ScrollArea,
   DialogTrigger,
 } from '@remoteoss/remote-flows/internals';
-import type { ZendeskDialogComponentProps } from '@remoteoss/remote-flows';
+import type { ZendeskDrawerComponentProps } from '@remoteoss/remote-flows';
 
 export function ZendeskDialog({
   open,
@@ -18,7 +18,7 @@ export function ZendeskDialog({
   error,
   zendeskURL,
   Trigger,
-}: ZendeskDialogComponentProps) {
+}: ZendeskDrawerComponentProps) {
   const triggerElement = React.isValidElement(Trigger) ? (
     Trigger
   ) : (

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-radio-group": "^1.2.3",
-        "@radix-ui/react-scroll-area": "^1.2.3",
+        "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
@@ -4124,19 +4124,20 @@
       }
     },
     "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.3.tgz",
-      "integrity": "sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/number": "1.1.0",
-        "@radix-ui/primitive": "1.1.1",
-        "@radix-ui/react-compose-refs": "1.1.1",
-        "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-presence": "1.1.2",
-        "@radix-ui/react-primitive": "2.0.2",
-        "@radix-ui/react-use-callback-ref": "1.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.0"
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4149,6 +4150,158 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-radio-group": "^1.2.3",
-    "@radix-ui/react-scroll-area": "^1.2.3",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/src/components/shared/zendesk-drawer/ZendeskDrawer.tsx
+++ b/src/components/shared/zendesk-drawer/ZendeskDrawer.tsx
@@ -8,7 +8,6 @@ import {
   DrawerTitle,
 } from '@/src/components/ui/drawer';
 import { useFormFields } from '@/src/context';
-import { sanitizeHtml } from '@/src/lib/utils';
 
 export type ZendeskDrawerProps = {
   Trigger: React.ReactElement;
@@ -81,7 +80,7 @@ export const ZendeskDrawer = ({
           <div
             className='flex-1 overflow-y-auto p-4 RemoteFlows_ZendeskDrawer__Content'
             dangerouslySetInnerHTML={{
-              __html: sanitizeHtml(data?.body || ''),
+              __html: data?.body || '',
             }}
           ></div>
         </div>

--- a/src/components/shared/zendesk-drawer/ZendeskDrawer.tsx
+++ b/src/components/shared/zendesk-drawer/ZendeskDrawer.tsx
@@ -37,7 +37,7 @@ export const ZendeskDrawer = ({
     enabled: open,
   });
 
-  const CustomZendeskDrawer = components?.zendeskDialog;
+  const CustomZendeskDrawer = components?.zendeskDrawer;
 
   if (CustomZendeskDrawer) {
     return (

--- a/src/components/shared/zendesk-drawer/ZendeskDrawer.tsx
+++ b/src/components/shared/zendesk-drawer/ZendeskDrawer.tsx
@@ -7,10 +7,11 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/src/components/ui/drawer';
+import { useFormFields } from '@/src/context';
 import { sanitizeHtml } from '@/src/lib/utils';
 
 export type ZendeskDrawerProps = {
-  Trigger: React.ReactNode;
+  Trigger: React.ReactElement;
   zendeskId: number;
   open: boolean;
   onClose: () => void;
@@ -26,6 +27,7 @@ export const ZendeskDrawer = ({
   open,
   onClose,
 }: ZendeskDrawerProps) => {
+  const { components } = useFormFields();
   const zendeskURL = buildZendeskURL(zendeskId);
 
   const handleClose = () => {
@@ -35,6 +37,22 @@ export const ZendeskDrawer = ({
   const { data, isLoading, error } = useZendeskArticle(zendeskId, {
     enabled: open,
   });
+
+  const CustomZendeskDrawer = components?.zendeskDialog;
+
+  if (CustomZendeskDrawer) {
+    return (
+      <CustomZendeskDrawer
+        open={open}
+        onClose={handleClose}
+        data={data}
+        isLoading={isLoading}
+        error={error}
+        zendeskURL={zendeskURL}
+        Trigger={Trigger}
+      />
+    );
+  }
 
   return (
     <Drawer

--- a/src/components/shared/zendesk-drawer/api.ts
+++ b/src/components/shared/zendesk-drawer/api.ts
@@ -1,5 +1,6 @@
 import { getShowHelpCenterArticle } from '@/src/client';
 import { useClient } from '@/src/context';
+import { sanitizeHtml } from '@/src/lib/utils';
 import { Client } from '@hey-api/client-fetch';
 import { useQuery } from '@tanstack/react-query';
 
@@ -24,7 +25,16 @@ export const useZendeskArticle = (
 
       return response;
     },
-    select: (data) => data.data?.data.help_center_article,
+    select: (data) => {
+      const article = data.data?.data.help_center_article;
+      if (article) {
+        return {
+          ...article,
+          body: sanitizeHtml(article.body || ''),
+        };
+      }
+      return article;
+    },
     retry: false,
     ...queryOptions,
   });

--- a/src/components/shared/zendesk-drawer/tests/ZendeskDrawer.test.tsx
+++ b/src/components/shared/zendesk-drawer/tests/ZendeskDrawer.test.tsx
@@ -136,7 +136,7 @@ describe('ZendeskDrawer', () => {
       <QueryClientProvider client={queryClient}>
         <FormFieldsProvider
           components={{
-            zendeskDialog: CustomComponent,
+            zendeskDrawer: CustomComponent,
           }}
         >
           {children}
@@ -221,7 +221,7 @@ describe('ZendeskDrawer', () => {
       <QueryClientProvider client={queryClient}>
         <FormFieldsProvider
           components={{
-            zendeskDialog: CustomComponent,
+            zendeskDrawer: CustomComponent,
           }}
         >
           {children}

--- a/src/components/shared/zendesk-drawer/tests/ZendeskDrawer.test.tsx
+++ b/src/components/shared/zendesk-drawer/tests/ZendeskDrawer.test.tsx
@@ -1,0 +1,203 @@
+import { FormFieldsProvider } from '@/src/RemoteFlowsProvider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/src/tests/server';
+import { render, screen } from '@testing-library/react';
+import { ZendeskDrawer } from '../ZendeskDrawer';
+import userEvent from '@testing-library/user-event';
+
+describe('ZendeskDrawer', () => {
+  let queryClient: QueryClient;
+
+  const mockArticle = {
+    help_center_article: {
+      title: 'Test Article',
+      body: '<p>Test content</p>',
+    },
+  };
+
+  const defaultProps = {
+    Trigger: <button>Open Drawer</button>,
+    zendeskId: 123456,
+    open: false,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          // Disable retries to make tests faster and more predictable
+          retry: false,
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+
+    server.use(
+      http.get('*/v1/help-center-articles/*', () => {
+        return HttpResponse.json({ data: mockArticle });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Clear all queries after each test
+    queryClient.clear();
+  });
+
+  // Test wrapper with necessary providers
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>
+      <FormFieldsProvider components={{}}>{children}</FormFieldsProvider>
+    </QueryClientProvider>
+  );
+
+  it('renders trigger element correctly', () => {
+    render(<ZendeskDrawer {...defaultProps} />, { wrapper });
+    expect(
+      screen.getByRole('button', { name: 'Open Drawer' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClose when drawer is closed', async () => {
+    const onClose = vi.fn();
+    render(<ZendeskDrawer {...defaultProps} open={true} onClose={onClose} />, {
+      wrapper,
+    });
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('displays loading state', async () => {
+    // Simulate loading by delaying the response
+    server.use(
+      http.get('*/v1/help-center-articles/*', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return HttpResponse.json({ data: mockArticle });
+      }),
+    );
+
+    render(<ZendeskDrawer {...defaultProps} open={true} />, { wrapper });
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('displays error state', async () => {
+    server.use(
+      http.get('*/v1/help-center-articles/*', () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    render(<ZendeskDrawer {...defaultProps} open={true} />, { wrapper });
+
+    // Wait for the error message to appear
+    const errorMessage = await screen.findByText('Error loading article');
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('displays article content when loaded', async () => {
+    const mockArticle = {
+      help_center_article: {
+        title: 'Test Article',
+        body: '<p>Test content</p>',
+      },
+    };
+
+    server.use(
+      http.get('*/v1/help-center-articles/*', () => {
+        return HttpResponse.json({ data: mockArticle });
+      }),
+    );
+
+    render(<ZendeskDrawer {...defaultProps} open={true} />, { wrapper });
+
+    // Wait for the content to load
+    const title = await screen.findByText('Test Article');
+    expect(title).toBeInTheDocument();
+
+    // Check the help article link
+    const link = screen.getByRole('link', { name: /help article/i });
+    expect(link).toHaveAttribute(
+      'href',
+      `https://support.remote.com/hc/en-us/articles/${defaultProps.zendeskId}`,
+    );
+  });
+
+  it('renders custom zendesk dialog component when provided', () => {
+    const CustomComponent = vi.fn(() => null);
+    const customWrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>
+        <FormFieldsProvider
+          components={{
+            zendeskDialog: CustomComponent,
+          }}
+        >
+          {children}
+        </FormFieldsProvider>
+      </QueryClientProvider>
+    );
+
+    render(<ZendeskDrawer {...defaultProps} />, { wrapper: customWrapper });
+
+    expect(CustomComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        open: defaultProps.open,
+        onClose: expect.any(Function),
+        zendeskURL: expect.stringContaining(String(defaultProps.zendeskId)),
+        Trigger: defaultProps.Trigger,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('only fetches article data when drawer is open', async () => {
+    const fetchSpy = vi.fn();
+    server.use(
+      http.get('*/v1/help-center-articles/*', async () => {
+        fetchSpy();
+        return HttpResponse.json({ data: mockArticle });
+      }),
+    );
+
+    // First render with drawer closed
+    const { rerender } = render(
+      <ZendeskDrawer {...defaultProps} open={false} />,
+      { wrapper },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Rerender with drawer open
+    rerender(<ZendeskDrawer {...defaultProps} open={true} />);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('sanitizes HTML content', async () => {
+    const unsafeArticle = {
+      help_center_article: {
+        title: 'Test Article',
+        body: '<p>Safe content</p><script>alert("unsafe")</script>',
+      },
+    };
+
+    server.use(
+      http.get('*/v1/help-center-articles/*', () => {
+        return HttpResponse.json({ data: unsafeArticle });
+      }),
+    );
+
+    render(<ZendeskDrawer {...defaultProps} open={true} />, { wrapper });
+
+    // Wait for content to load and check sanitization
+    const content = await screen.findByText('Safe content');
+    const container = content.parentElement;
+    expect(container?.innerHTML).not.toContain('<script>');
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ export * from '@/src/flows/Onboarding';
 export type * from '@/src/flows/CostCalculator/types';
 export * from '@/src/common/api';
 
-export { transformYupErrorsIntoObject, sanitizeHtml } from '@/src/lib/utils';
+export { transformYupErrorsIntoObject } from '@/src/lib/utils';
 
 export { RemoteFlows } from '@/src/RemoteFlowsProvider';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ export type {
   FieldComponentProps,
   ButtonComponentProps,
   StatementComponentProps,
-  ZendeskDialogComponentProps,
+  ZendeskDrawerComponentProps,
 } from '@/src/types/remoteFlows';
 
 export type {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ export * from '@/src/flows/Onboarding';
 export type * from '@/src/flows/CostCalculator/types';
 export * from '@/src/common/api';
 
-export { transformYupErrorsIntoObject } from '@/src/lib/utils';
+export { transformYupErrorsIntoObject, sanitizeHtml } from '@/src/lib/utils';
 
 export { RemoteFlows } from '@/src/RemoteFlowsProvider';
 
@@ -33,6 +33,7 @@ export type {
   FieldComponentProps,
   ButtonComponentProps,
   StatementComponentProps,
+  ZendeskDialogComponentProps,
 } from '@/src/types/remoteFlows';
 
 export type {

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -64,5 +64,5 @@ export {
   SelectTrigger,
   SelectValue,
 } from './components/ui/select';
-
+export { ScrollArea } from './components/ui/scroll-area';
 export * from './components/shared/zendesk-drawer/ZendeskTriggerButton';

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -1,15 +1,15 @@
-import { ThemeProviderProps } from '@/src/types/theme';
 import {
   ControllerFieldState,
   ControllerRenderProps,
   FieldValues,
 } from 'react-hook-form';
+import { ReactNode } from 'react';
 import { AnySchema } from 'yup';
+import { ThemeProviderProps } from '@/src/types/theme';
+import { HelpCenterArticle } from '@/src/client';
 import { SupportedTypes } from '../components/form/fields/types';
 import { StatementProps } from '../components/form/Statement';
-import { ReactNode } from 'react';
 import { ENVIRONMENTS } from '../environments';
-import { HelpCenterArticle } from '@/src/client';
 
 type AuthResponse = {
   accessToken: string;

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -9,6 +9,7 @@ import { SupportedTypes } from '../components/form/fields/types';
 import { StatementProps } from '../components/form/Statement';
 import { ReactNode } from 'react';
 import { ENVIRONMENTS } from '../environments';
+import { HelpCenterArticle } from '@/src/client';
 
 type AuthResponse = {
   accessToken: string;
@@ -88,6 +89,16 @@ export type ButtonComponentProps = {
 } & React.ButtonHTMLAttributes<HTMLButtonElement> &
   Record<string, unknown>;
 
+export type ZendeskDialogComponentProps = {
+  open: boolean;
+  onClose: () => void;
+  data?: HelpCenterArticle;
+  isLoading: boolean;
+  error: Error | null;
+  zendeskURL: string;
+  Trigger: React.ReactElement;
+};
+
 /**
  * Props for custom statement components.
  */
@@ -100,6 +111,7 @@ export type Components = {
 } & {
   statement?: React.ComponentType<StatementComponentProps>;
   button?: React.ComponentType<ButtonComponentProps>;
+  zendeskDialog?: React.ComponentType<ZendeskDialogComponentProps>;
 };
 
 export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -89,7 +89,7 @@ export type ButtonComponentProps = {
 } & React.ButtonHTMLAttributes<HTMLButtonElement> &
   Record<string, unknown>;
 
-export type ZendeskDialogComponentProps = {
+export type ZendeskDrawerComponentProps = {
   open: boolean;
   onClose: () => void;
   data?: HelpCenterArticle;
@@ -111,7 +111,7 @@ export type Components = {
 } & {
   statement?: React.ComponentType<StatementComponentProps>;
   button?: React.ComponentType<ButtonComponentProps>;
-  zendeskDialog?: React.ComponentType<ZendeskDialogComponentProps>;
+  zendeskDrawer?: React.ComponentType<ZendeskDrawerComponentProps>;
 };
 
 export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {


### PR DESCRIPTION
We want to provide consumers with a way to override the drawers for example with modals.

I added a demo but is commented to not break the premium benefits deployed app

<img width="997" height="875" alt="image" src="https://github.com/user-attachments/assets/dea7b207-63eb-4510-9a59-3ec3711ab47c" />
