### PR TITLE
feat: add hiring budget option

### DIFF
--- a/example/e2e/hiring-budget.spec.ts
+++ b/example/e2e/hiring-budget.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { fillEstimationForm } from './helpers';
+
+test.describe('hiring budget', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?demo=with-premium-benefits-cost-calculator');
+  });
+
+  test('shows the hiring budget option', async ({ page }) => {
+    await page.locator('#my_hiring_budget').click();
+
+    await expect(page.locator('[for=salary]')).toHaveText('Hiring budget');
+
+    await fillEstimationForm(page, {
+      country: 'Sweden',
+      currency: 'USD',
+      salary: '100000',
+    });
+
+    const headerAmount = page.getByText(
+      /Employee annual gross salary: kr\d{1,3}(,\d{3})*\.\d{2}/,
+    );
+
+    await expect(headerAmount).toBeVisible();
+  });
+});

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -298,11 +298,14 @@ const AddEstimateForm = ({
   onSuccess: (response: CostCalculatorEstimateResponse) => void;
   defaultValues?: CostCalculatorFlowProps['defaultValues'];
 }) => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
   return (
     <CostCalculatorFlow
       estimationOptions={estimationOptions}
       defaultValues={defaultValues}
       options={{
+        onValidation: () => setErrorMessage(null),
         jsfModify: {
           fields: {
             country: {
@@ -326,7 +329,6 @@ const AddEstimateForm = ({
               ),
             },
             salary: {
-              title: "Employee's annual salary",
               description:
                 "We will use your selected billing currency, but you can also convert it to the employee's local currency.",
             },
@@ -352,9 +354,21 @@ const AddEstimateForm = ({
           <Card>
             <CostCalculatorForm
               onSubmit={onSubmit}
-              onError={onError}
+              onError={(error) => {
+                setErrorMessage(
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (error as any)?.error?.error?.message || 'An error occurred',
+                );
+                onError(error);
+              }}
               onSuccess={onSuccess}
             />
+            {errorMessage && (
+              <div className='flex justify-center mt-10 text-red-600 text-center mb-4'>
+                {errorMessage}
+              </div>
+            )}
+
             <div className='flex justify-center mt-10'>
               <CostCalculatorSubmitButton
                 className='submit-button'

--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -122,6 +122,7 @@ export const CostCalculatorFlow = ({
       salary: defaultValues?.salary,
       salary_conversion: '',
       salary_converted: '',
+      hiring_budget: 'employee_annual_salary',
       management: {
         management_fee: defaultManagementFee,
       },

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -80,18 +80,24 @@ export function CostCalculatorForm({
   ]);
 
   const handleSubmit = async (values: CostCalculatorEstimationFormValues) => {
-    const parsedValues = costCalculatorBag?.parseFormValues(
-      values,
-    ) as CostCalculatorEstimationSubmitValues;
-    const costCalculatorResults =
-      await costCalculatorBag?.onSubmit(parsedValues);
+    try {
+      const parsedValues = costCalculatorBag?.parseFormValues(
+        values,
+      ) as CostCalculatorEstimationSubmitValues;
 
-    await onSubmit?.(parsedValues);
+      const costCalculatorResults =
+        await costCalculatorBag?.onSubmit(parsedValues);
 
-    if (costCalculatorResults?.error) {
-      onError?.(costCalculatorResults.error);
-    } else if (costCalculatorResults?.data) {
-      await onSuccess?.(costCalculatorResults?.data);
+      // if this rejects, catch will handle it
+      await onSubmit?.(parsedValues);
+
+      if (costCalculatorResults?.error) {
+        onError?.(costCalculatorResults.error);
+      } else if (costCalculatorResults?.data) {
+        await onSuccess?.(costCalculatorResults.data);
+      }
+    } catch (err) {
+      onError?.(err as EstimationError);
     }
   };
 

--- a/src/flows/CostCalculator/jsonSchema.ts
+++ b/src/flows/CostCalculator/jsonSchema.ts
@@ -31,6 +31,24 @@ export const jsonSchema = {
             inputType: 'select',
           },
         },
+        hiring_budget: {
+          title: 'How would you like to estimate the cost of hiring?',
+          enum: ['employee_annual_salary', 'my_hiring_budget'],
+          type: 'string',
+          oneOf: [
+            {
+              title: "With the employee's annual salary",
+              const: 'employee_annual_salary',
+            },
+            {
+              title: 'With my hiring budget for this role',
+              const: 'my_hiring_budget',
+            },
+          ],
+          'x-jsf-presentation': {
+            inputType: 'radio',
+          },
+        },
         salary: {
           description: '',
           title: 'Salary',

--- a/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
+++ b/src/flows/CostCalculator/tests/CostCalculatorFlow.test.tsx
@@ -145,6 +145,7 @@ describe('CostCalculatorFlow', () => {
         country: 'POL',
         currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
         salary: 5_000_000,
+        hiring_budget: 'employee_annual_salary',
         salary_converted: 'salary_conversion',
         salary_conversion: 5000000,
       });
@@ -291,6 +292,7 @@ describe('CostCalculatorFlow', () => {
         country: 'POL',
         currency: 'usd-1dee66d1-9c32-4ef8-93c6-6ae1ee6308c8',
         salary: 5_000_000,
+        hiring_budget: 'employee_annual_salary',
         salary_converted: 'salary_conversion',
         salary_conversion: 5000000,
       });

--- a/src/flows/CostCalculator/tests/utils.test.ts
+++ b/src/flows/CostCalculator/tests/utils.test.ts
@@ -12,6 +12,7 @@ describe('buildPayload', () => {
       currency: 'USD',
       country: 'US',
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       salary: 100_000,
     };
 
@@ -38,6 +39,7 @@ describe('buildPayload', () => {
     const values: CostCalculatorEstimationSubmitValues = {
       currency: 'USD',
       country: 'US',
+      hiring_budget: 'employee_annual_salary',
       salary_converted: 'salary_conversion',
       salary: 100_000,
     };
@@ -61,10 +63,67 @@ describe('buildPayload', () => {
     });
   });
 
+  it('should build a payload with minimal values when salary converted is true and hiring_budget is my_hiring_budget', () => {
+    const values: CostCalculatorEstimationSubmitValues = {
+      currency: 'USD',
+      country: 'US',
+      hiring_budget: 'my_hiring_budget',
+      salary_converted: 'salary_conversion',
+      salary: 100_000,
+    };
+
+    const payload = buildPayload(values);
+
+    expect(payload).toEqual({
+      employer_currency_slug: 'USD',
+      include_benefits: defaultEstimationOptions.includeBenefits,
+      include_cost_breakdowns: defaultEstimationOptions.includeCostBreakdowns,
+      include_premium_benefits: defaultEstimationOptions.includePremiumBenefits,
+      include_management_fee: defaultEstimationOptions.includeManagementFee,
+      employments: [
+        {
+          region_slug: 'US',
+          annual_total_cost_in_employer_currency: 100_000,
+          employment_term: 'fixed',
+          title: defaultEstimationOptions.title,
+        },
+      ],
+    });
+  });
+
+  it('should build a payload with minimal values when hiring_budget is my_hiring_budget ', () => {
+    const values: CostCalculatorEstimationSubmitValues = {
+      currency: 'USD',
+      country: 'US',
+      salary_converted: 'salary',
+      hiring_budget: 'my_hiring_budget',
+      salary: 100_000,
+    };
+
+    const payload = buildPayload(values);
+
+    expect(payload).toEqual({
+      employer_currency_slug: 'USD',
+      include_benefits: defaultEstimationOptions.includeBenefits,
+      include_cost_breakdowns: defaultEstimationOptions.includeCostBreakdowns,
+      include_premium_benefits: defaultEstimationOptions.includePremiumBenefits,
+      include_management_fee: defaultEstimationOptions.includeManagementFee,
+      employments: [
+        {
+          region_slug: 'US',
+          annual_total_cost: 100_000,
+          employment_term: 'fixed',
+          title: defaultEstimationOptions.title,
+        },
+      ],
+    });
+  });
+
   it('should use region if provided', () => {
     const values: CostCalculatorEstimationSubmitValues = {
       currency: 'USD',
       country: 'US',
+      hiring_budget: 'employee_annual_salary',
       region: 'CA',
       salary: 100_000,
       salary_converted: 'salary',
@@ -81,6 +140,7 @@ describe('buildPayload', () => {
       country: 'US',
       salary: 100_000,
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       benefits: {
         'benefit-health': 'premium',
         'benefit-dental': 'basic',
@@ -101,6 +161,7 @@ describe('buildPayload', () => {
       country: 'US',
       salary: 100_000,
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       age: 30,
     };
 
@@ -115,6 +176,7 @@ describe('buildPayload', () => {
       country: 'US',
       salary: 100_000,
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       contract_duration_type: 'fixed',
     };
 
@@ -128,6 +190,7 @@ describe('buildPayload', () => {
       currency: 'USD',
       country: 'US',
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       salary: 100_000,
     };
 
@@ -149,6 +212,7 @@ describe('buildPayload', () => {
       currency: 'USD',
       country: 'US',
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       salary: 100_000,
       benefits: {
         'benefit-health': 'whatever',
@@ -172,6 +236,7 @@ describe('buildPayload', () => {
       country: 'US',
       salary: 100_000,
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       management: {
         management_fee: '59900',
       },
@@ -194,6 +259,7 @@ describe('buildPayload', () => {
       currency: 'USD',
       country: 'US',
       salary_converted: 'salary',
+      hiring_budget: 'employee_annual_salary',
       salary: 100_000,
     };
 
@@ -246,12 +312,14 @@ describe('buildPayload', () => {
           currency: 'USD',
           country: 'US',
           salary_converted: 'salary',
+          hiring_budget: 'employee_annual_salary',
           salary: 100_000,
         },
         {
           currency: 'USD', // Note: currency from first item is used
           country: 'UK',
           salary_converted: 'salary',
+          hiring_budget: 'employee_annual_salary',
           salary: 80_000,
         },
       ];
@@ -290,6 +358,7 @@ describe('buildPayload', () => {
           region: 'Berlin',
           salary: 90_000,
           salary_converted: 'salary',
+          hiring_budget: 'employee_annual_salary',
           age: 25,
           benefits: {
             'benefit-health': 'premium',
@@ -326,6 +395,7 @@ describe('buildPayload', () => {
           country: 'US',
           salary: 100_000,
           salary_converted: 'salary',
+          hiring_budget: 'employee_annual_salary',
         },
         {
           currency: 'USD',

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -10,6 +10,7 @@ export type CostCalculatorEstimationSubmitValues = {
   currency: string;
   country: string;
   salary_converted: 'salary' | 'salary_conversion';
+  hiring_budget: string;
   salary: number;
 } & Partial<{
   region: string;
@@ -30,6 +31,7 @@ export type CostCalculatorEstimationFormValues = {
 } & Partial<{
   region: string;
   age: number;
+  hiring_budget: string;
   contract_duration_type: EmploymentTermType;
   benefits: Record<string, string>;
   management: {
@@ -74,6 +76,7 @@ export type EstimationError = PostCreateEstimationError | ValidationError;
 export type UseCostCalculatorOptions = {
   jsfModify?: JSFModify;
   onCurrencyChange?: (currency: string) => void;
+  onValidation?: (values: CostCalculatorEstimationFormValues) => void;
 };
 
 export type CurrencyKey = keyof typeof BASE_RATES;

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -91,21 +91,51 @@ function mapValueToEmployment(
   estimationOptions: CostCalculatorEstimationOptions,
   version: CostCalculatorVersion,
 ): CostCalculatorEmploymentParam {
-  return {
+  const base: CostCalculatorEmploymentParam = {
     region_slug: value.region || value.country,
     employment_term: value.contract_duration_type ?? 'fixed',
     title: estimationOptions.title,
     age: value.age ?? undefined,
     ...(value.benefits && { benefits: formatBenefits(value.benefits) }),
-    ...((version == 'marketing' ||
-      value.salary_converted === 'salary_conversion') && {
-      annual_gross_salary_in_employer_currency: value.salary,
-    }),
-    ...(version === 'standard' &&
-      value.salary_converted === 'salary' && {
-        annual_gross_salary: value.salary,
-      }),
   };
+
+  return {
+    ...base,
+    ...getSalaryFields(value, version),
+  };
+}
+
+function getSalaryFields(
+  value: CostCalculatorEstimationSubmitValues,
+  version: CostCalculatorVersion,
+): Partial<CostCalculatorEmploymentParam> {
+  const isMarketing =
+    version === 'marketing' || value.salary_converted === 'salary_conversion';
+  const isStandard =
+    version === 'standard' && value.salary_converted === 'salary';
+  const useHiringBudget = value.hiring_budget === 'my_hiring_budget';
+
+  if (isMarketing) {
+    return useHiringBudget
+      ? {
+          annual_total_cost_in_employer_currency: value.salary,
+        }
+      : {
+          annual_gross_salary_in_employer_currency: value.salary,
+        };
+  }
+
+  if (isStandard) {
+    return useHiringBudget
+      ? {
+          annual_total_cost: value.salary,
+        }
+      : {
+          annual_gross_salary: value.salary,
+        };
+  }
+
+  return {};
 }
 
 /**
@@ -135,7 +165,6 @@ export function buildPayload(
       );
     }
   }
-
   const managementFee = Number(employments[0].management?.management_fee);
 
   return {


### PR DESCRIPTION
This PR adds an option to specify whether you want to use your budget or the employee's annual salary (default).

It also surfaces the error from the API in case an error is returned.

A couple of things:
- I have tried to use JSON schema to change the title of the field, but that didn't work, the same JSON schema works in the playground. To accommodate for that, I am setting it when the value is selected.
- I have added an onChange callback so that I can clear the error whenever any form field changes.
- I have surfaced the error in the UI if the request failed, I could not get the type right though unfortunately.