### PR TITLE
bug: hide "Days" if minimum onboarding time is missing

### DIFF
--- a/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
+++ b/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
@@ -154,9 +154,11 @@ function OnboardingTimeline({
             <span className='RemoteFlows__OnboardingTimeline__Title text-base font-medium text-[#0F172A]'>
               Onboarding timeline
             </span>
-            <span className='RemoteFlows__OnboardingTimeline__Description text-base text-muted-foreground mr-4'>
-              {minimumOnboardingDays} days
-            </span>
+            {minimumOnboardingDays != null && (
+              <span className='RemoteFlows__OnboardingTimeline__Description text-base text-muted-foreground mr-4'>
+                {minimumOnboardingDays} days
+              </span>
+            )}
           </div>
         </AccordionTrigger>
         <AccordionContent className='px-0 pb-4'>


### PR DESCRIPTION
Sometimes the information is not avaiable, so we hide "Days" (we could also at some point make it singular/plural depending on the length, but i would thave to check if there's any mot that is 1)