### PR TITLE
fix minimumOnboardingTime

### DIFF
--- a/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
+++ b/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
@@ -153,9 +153,11 @@ function OnboardingTimeline({
             <span className='RemoteFlows__OnboardingTimeline__Title text-base font-medium text-[#0F172A]'>
               Onboarding timeline
             </span>
-            <span className='RemoteFlows__OnboardingTimeline__Description text-base text-muted-foreground mr-4'>
-              {minimumOnboardingDays} days
-            </span>
+            {minimumOnboardingDays && (
+              <span className='RemoteFlows__OnboardingTimeline__Description text-base text-muted-foreground mr-4'>
+                {minimumOnboardingDays} days
+              </span>
+            )}
           </div>
         </AccordionTrigger>
         <AccordionContent className='px-0 pb-4'>


### PR DESCRIPTION
For countries like barbados we don't provide a minimumOnboardingTime.

This avoids showing the content if there isn't one