### PR TITLE
feat(cost-calculator) - filter countries if they aren't avalaible

### DIFF
--- a/src/flows/CostCalculator/api.ts
+++ b/src/flows/CostCalculator/api.ts
@@ -34,14 +34,16 @@ export const useCostCalculatorCountries = ({
       });
     },
     select: (data) =>
-      data.data?.data.map((country) => ({
-        value: country.region_slug,
-        label: country.name,
-        childRegions: country.child_regions,
-        hasAdditionalFields: country.has_additional_fields,
-        regionSlug: country.region_slug,
-        currency: country.currency.code,
-      })),
+      data.data?.data
+        .filter((country) => country.availability === 'active')
+        .map((country) => ({
+          value: country.region_slug,
+          label: country.name,
+          childRegions: country.child_regions,
+          hasAdditionalFields: country.has_additional_fields,
+          regionSlug: country.region_slug,
+          currency: country.currency.code,
+        })),
   });
 };
 

--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -444,12 +444,14 @@ const useCountries = (queryOptions?: { enabled?: boolean }) => {
     },
     select: ({ data }) => {
       return (
-        data?.data?.map((country) => {
-          return {
-            label: country.name,
-            value: country.code,
-          };
-        }) || []
+        data?.data
+          ?.filter((country) => country.eor_onboarding)
+          .map((country) => {
+            return {
+              label: country.name,
+              value: country.code,
+            };
+          }) || []
       );
     },
   });

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -349,10 +349,12 @@ describe('OnboardingFlow', () => {
             {
               code: 'PRT',
               name: 'Portugal',
+              eor_onboarding: true,
             },
             {
               code: 'ESP',
               name: 'Spain',
+              eor_onboarding: true,
             },
           ],
         });


### PR DESCRIPTION
If countries aren't active, don't show it as they aren't ready to onboard

I detected twelve countries that we were showing like Barbados that we are not able to hire today