### PR TITLE
feat(cost-calculator) - do edit functionality but partially

### DIFF
--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -457,7 +457,7 @@ function CostCalculatorFormDemo() {
     estimationIndex: number;
     payload: CostCalculatorEstimationSubmitValues | null;
   }>({
-    isDrawerOpen: false, // TODO: probably we can get rid of this later and rely on the estimationIndex or estimation
+    isDrawerOpen: false,
     estimationIndex: -1,
     payload: null,
   });

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -4,6 +4,7 @@ import type {
   CostCalculatorEstimationOptions,
   CostCalculatorEstimationSubmitValues,
   EstimationError,
+  CostCalculatorFlowProps,
 } from '@remoteoss/remote-flows';
 import {
   buildCostCalculatorEstimationPayload,
@@ -107,12 +108,7 @@ const DrawerEstimationForm = ({
   isDrawerOpen: boolean;
   setIsDrawerOpen: (isOpen: boolean) => void;
   Trigger?: React.ReactElement;
-  defaultValues?: Partial<{
-    countryRegionSlug: string;
-    currencySlug: string;
-    salary: string;
-    benefits?: Record<string, string>;
-  }>;
+  defaultValues?: CostCalculatorFlowProps['defaultValues'];
   header: {
     title: string;
     description: string;
@@ -291,11 +287,7 @@ const AddEstimateForm = ({
   onSubmit: (payload: CostCalculatorEstimationSubmitValues) => void;
   onError: (error: EstimationError) => void;
   onSuccess: (response: CostCalculatorEstimateResponse) => void;
-  defaultValues?: Partial<{
-    countryRegionSlug: string;
-    currencySlug: string;
-    salary: string;
-  }>;
+  defaultValues?: CostCalculatorFlowProps['defaultValues'];
 }) => {
   return (
     <CostCalculatorFlow

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -14,6 +14,7 @@ import {
   EstimationResults,
   zendeskArticles,
   SummaryResults,
+  convertFromCents,
 } from '@remoteoss/remote-flows';
 import {
   Drawer,
@@ -98,6 +99,7 @@ const DrawerEstimationForm = ({
   setIsDrawerOpen,
   Trigger,
   header,
+  defaultValues,
   onSubmit,
   onError,
   onSuccess,
@@ -105,6 +107,11 @@ const DrawerEstimationForm = ({
   isDrawerOpen: boolean;
   setIsDrawerOpen: (isOpen: boolean) => void;
   Trigger?: React.ReactElement;
+  defaultValues?: Partial<{
+    countryRegionSlug: string;
+    currencySlug: string;
+    salary: string;
+  }>;
   header: {
     title: string;
     description: string;
@@ -131,6 +138,7 @@ const DrawerEstimationForm = ({
               <Header title={header.title} description={header.description} />
             </div>
             <AddEstimateForm
+              defaultValues={defaultValues}
               onSubmit={onSubmit}
               onError={onError}
               onSuccess={onSuccess}
@@ -145,7 +153,7 @@ const DrawerEstimationForm = ({
 const EditEstimationForm = ({
   isDrawerOpen,
   estimationIndex,
-  estimation,
+  payload,
   setIsDrawerOpen,
   onSubmit,
   onError,
@@ -153,7 +161,7 @@ const EditEstimationForm = ({
 }: {
   isDrawerOpen: boolean;
   estimationIndex: number;
-  estimation: CostCalculatorEmployment | null;
+  payload: CostCalculatorEstimationSubmitValues | null;
   setIsDrawerOpen: (isOpen: boolean) => void;
   onSubmit: (payload: CostCalculatorEstimationSubmitValues) => void;
   onError: (error: EstimationError) => void;
@@ -164,6 +172,11 @@ const EditEstimationForm = ({
       header={{
         title: 'Edit estimate',
         description: `Estimate #${estimationIndex + 1}`,
+      }}
+      defaultValues={{
+        countryRegionSlug: payload?.country,
+        currencySlug: payload?.currency,
+        salary: convertFromCents(payload?.salary)?.toString() ?? '',
       }}
       isDrawerOpen={isDrawerOpen}
       setIsDrawerOpen={setIsDrawerOpen}
@@ -271,14 +284,21 @@ const AddEstimateForm = ({
   onSubmit,
   onError,
   onSuccess,
+  defaultValues,
 }: {
   onSubmit: (payload: CostCalculatorEstimationSubmitValues) => void;
   onError: (error: EstimationError) => void;
   onSuccess: (response: CostCalculatorEstimateResponse) => void;
+  defaultValues?: Partial<{
+    countryRegionSlug: string;
+    currencySlug: string;
+    salary: string;
+  }>;
 }) => {
   return (
     <CostCalculatorFlow
       estimationOptions={estimationOptions}
+      defaultValues={defaultValues}
       options={{
         jsfModify: {
           fields: {
@@ -441,11 +461,11 @@ function CostCalculatorFormDemo() {
   const [editProps, setEditProps] = useState<{
     isDrawerOpen: boolean;
     estimationIndex: number;
-    estimation: CostCalculatorEmployment | null;
+    payload: CostCalculatorEstimationSubmitValues | null;
   }>({
     isDrawerOpen: false, // TODO: probably we can get rid of this later and rely on the estimationIndex or estimation
     estimationIndex: -1,
-    estimation: null,
+    payload: null,
   });
 
   const onReset = () => {
@@ -509,11 +529,11 @@ function CostCalculatorFormDemo() {
   };
 
   const onEditEstimate = (index: number) => {
-    const estimation = estimations[index];
+    const savedPayload = payload[index];
     setEditProps({
       isDrawerOpen: true,
       estimationIndex: index,
-      estimation,
+      payload: savedPayload,
     });
   };
 
@@ -548,7 +568,7 @@ function CostCalculatorFormDemo() {
           <EditEstimationForm
             isDrawerOpen={editProps.isDrawerOpen}
             estimationIndex={editProps.estimationIndex}
-            estimation={editProps.estimation}
+            payload={editProps.payload}
             setIsDrawerOpen={setIsDrawerOpen}
             onSubmit={(payload) => console.log(payload)}
             onError={(error) => console.error({ error })}

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -111,6 +111,7 @@ const DrawerEstimationForm = ({
     countryRegionSlug: string;
     currencySlug: string;
     salary: string;
+    benefits?: Record<string, string>;
   }>;
   header: {
     title: string;
@@ -177,6 +178,7 @@ const EditEstimationForm = ({
         countryRegionSlug: payload?.country,
         currencySlug: payload?.currency,
         salary: convertFromCents(payload?.salary)?.toString() ?? '',
+        benefits: payload?.benefits,
       }}
       isDrawerOpen={isDrawerOpen}
       setIsDrawerOpen={setIsDrawerOpen}
@@ -599,6 +601,7 @@ function CostCalculatorFormDemo() {
             onSubmit={(payload) =>
               onEditPayload(payload, editProps.estimationIndex)
             }
+            onError={() => {}}
             onSuccess={(response) =>
               onEditSuccess(response, editProps.estimationIndex)
             }

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -487,6 +487,32 @@ function CostCalculatorFormDemo() {
     setPayload([...payload, estimation]);
   };
 
+  const onEditPayload = (
+    estimation: CostCalculatorEstimationSubmitValues,
+    index: number,
+  ) => {
+    const newPayload = [...payload];
+    newPayload[index] = estimation;
+    setPayload(newPayload);
+  };
+
+  const onEditSuccess = (
+    response: CostCalculatorEstimateResponse,
+    index: number,
+  ) => {
+    if (response.data.employments?.[0]) {
+      const newEstimations = [...estimations];
+      newEstimations[index] = response.data.employments?.[0];
+      setEstimations(newEstimations);
+    }
+
+    setEditProps({
+      isDrawerOpen: false,
+      estimationIndex: -1,
+      payload: null,
+    });
+  };
+
   const exportPdfMutation = useCostCalculatorEstimationPdf();
 
   function exportPdf(
@@ -570,9 +596,12 @@ function CostCalculatorFormDemo() {
             estimationIndex={editProps.estimationIndex}
             payload={editProps.payload}
             setIsDrawerOpen={setIsDrawerOpen}
-            onSubmit={(payload) => console.log(payload)}
-            onError={(error) => console.error({ error })}
-            onSuccess={(response) => console.log({ response })}
+            onSubmit={(payload) =>
+              onEditPayload(payload, editProps.estimationIndex)
+            }
+            onSuccess={(response) =>
+              onEditSuccess(response, editProps.estimationIndex)
+            }
           />
         </>
       )}

--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -35,6 +35,10 @@ export type CostCalculatorFlowProps = {
      * Default value for the salary field.
      */
     salary: string;
+    /**
+     * Default value for the benefits field.
+     */
+    benefits: Record<string, string>;
   }>;
   options?: UseCostCalculatorOptions;
   render: (
@@ -66,6 +70,7 @@ export const CostCalculatorFlow = ({
     countryRegionSlug: '',
     currencySlug: '',
     salary: '',
+    benefits: {},
   },
   options,
   render,
@@ -120,6 +125,7 @@ export const CostCalculatorFlow = ({
       management: {
         management_fee: defaultManagementFee,
       },
+      benefits: defaultValues?.benefits,
     },
     shouldUnregister: false,
     mode: 'onBlur',

--- a/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
+++ b/src/flows/CostCalculator/EstimationResults/EstimationResults.tsx
@@ -26,6 +26,7 @@ const EstimationResultsHeader = ({
   annualGrossSalary,
   onDelete,
   onExportPdf,
+  onEdit,
 }: {
   title: string;
   country: MinimalCountry;
@@ -33,12 +34,12 @@ const EstimationResultsHeader = ({
   annualGrossSalary: string;
   onDelete: () => void;
   onExportPdf: () => void;
+  onEdit: () => void;
 }) => {
   const actions = [
     {
       label: 'Edit',
-      onClick: () => {},
-      disabled: true,
+      onClick: onEdit,
     },
     {
       label: 'Export',
@@ -553,6 +554,7 @@ type EstimationResultsProps = {
   components?: EstimationResultsComponents;
   onDelete: () => void;
   onExportPdf: () => void;
+  onEdit: () => void;
 };
 
 export const EstimationResults = ({
@@ -561,6 +563,7 @@ export const EstimationResults = ({
   components,
   onDelete,
   onExportPdf,
+  onEdit,
 }: EstimationResultsProps) => {
   const CustomHiringSection = components?.HiringSection || HiringSection;
   const CustomOnboardingTimeline =
@@ -594,6 +597,7 @@ export const EstimationResults = ({
           country={estimation.country}
           onDelete={onDelete}
           onExportPdf={onExportPdf}
+          onEdit={onEdit}
         />
       </div>
       <div className='RemoteFlows__Separator'>

--- a/src/flows/CostCalculator/index.ts
+++ b/src/flows/CostCalculator/index.ts
@@ -11,3 +11,4 @@ export { SummaryResults } from './SummaryResults/SummaryResults';
 export { CostCalculatorResults } from './Results/CostCalculatorResults';
 export { buildPayload as buildCostCalculatorEstimationPayload } from './utils';
 export type { EstimationError } from './types';
+export type { CostCalculatorFlowProps } from './CostCalculatorFlow';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,8 @@ export { transformYupErrorsIntoObject } from '@/src/lib/utils';
 
 export { RemoteFlows } from '@/src/RemoteFlowsProvider';
 
+export { convertFromCents } from '@/src/components/form/utils';
+
 export type {
   Components,
   RemoteFlowsSDKProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,8 @@ export {
   SummaryResults,
 } from '@/src/flows/CostCalculator';
 
+export type { CostCalculatorFlowProps } from '@/src/flows/CostCalculator';
+
 export * from '@/src/flows/ContractAmendment';
 export * from '@/src/flows/Termination';
 export * from '@/src/flows/Onboarding';


### PR DESCRIPTION
We have some missing pieces of the edit functionality such as 

* not render the employer currency
* render an textfield to change the estimation title

I tried to the edit functionality to what we have now and we can do separated PRs addressing the missing functionality

In the [deployed review app](https://remote-flows-219159v49-remotecom.vercel.app/), you can check the functionality

