### PR TITLE
fix(onboarding) - add key to make form to clear when we navigate

### DIFF
--- a/src/flows/Onboarding/components/OnboardingForm.tsx
+++ b/src/flows/Onboarding/components/OnboardingForm.tsx
@@ -122,7 +122,7 @@ export function OnboardingForm({
   };
 
   return (
-    <Form {...form}>
+    <Form {...form} key={`form-${onboardingBag.stepState.currentStep.name}`}>
       <form
         id={formId}
         onSubmit={form.handleSubmit(handleSubmit)}


### PR DESCRIPTION
We had a report from a partner that the Austria form it's having some issues.

Basically it's like the form fields from a previous step shows for a while and then they disappear.

I haven't been able to reproduce it but with this what I am trying to cause it's making react-hook-form to get destroyed and cleared up when we do navigations