### PR TITLE
fix(cost-calculator) - send correct value when using conversions when version is marketing

### DIFF
--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -581,6 +581,36 @@ This configuration includes management fees in the estimation using Remote's bas
 
 This configuration shows management fees in both the estimation results and provides a UI input field for customizing the fee.
 
+##### Version prop
+
+The `version` prop (`'standard' | 'marketing'`) controls three key behaviors in the cost calculator:
+
+1. Currency Conversion:
+
+   - `marketing`: Uses `no_spread` (raw exchange rate without additional fees/risk margins)
+   - `standard`: Uses `spread` (includes forex risk and service fees in exchange rate)
+
+2. UI/Form Elements:
+
+   - `marketing`: Hiring budget radio option is hidden
+   - `standard`: Hiring budget radio option is shown
+
+3. Salary Field Behavior:
+
+   - Marketing Version:
+     - Based on last input field used:
+       - If last input was in country's currency → `annual_gross_salary`
+       - If last input was in employer's currency → `annual_gross_salary_in_employer_currency`
+   - Standard Version:
+     - When hiring budget is NOT selected:
+       - If country currency matches selected currency → `annual_gross_salary`
+       - If currencies are different → `annual_gross_salary_in_employer_currency`
+     - When hiring budget IS selected:
+       - If country currency matches selected currency → `annual_total_cost`
+       - If currencies are different → `annual_total_cost_in_employer_currency`
+
+Note: The spread in currency conversion accounts for foreign exchange risk (currency fluctuations), transaction costs, and service fees.
+
 #### defaultValues Properties
 
 | Property            | Type     | Description                 |

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -134,14 +134,6 @@ function getSalaryFields(
     version === 'standard' && value.salary_converted === 'salary';
   const useHiringBudget = value.hiring_budget === 'my_hiring_budget';
 
-  console.log({
-    version,
-    isMarketing,
-    isStandard,
-    useHiringBudget,
-    salary_converted: value.salary_converted,
-  });
-
   if (isMarketing) {
     const useEmployerCurrency = value.salary_converted === 'salary_conversion';
     return useHiringBudget

--- a/src/flows/CostCalculator/utils.ts
+++ b/src/flows/CostCalculator/utils.ts
@@ -134,13 +134,24 @@ function getSalaryFields(
     version === 'standard' && value.salary_converted === 'salary';
   const useHiringBudget = value.hiring_budget === 'my_hiring_budget';
 
+  console.log({
+    version,
+    isMarketing,
+    isStandard,
+    useHiringBudget,
+    salary_converted: value.salary_converted,
+  });
+
   if (isMarketing) {
+    const useEmployerCurrency = value.salary_converted === 'salary_conversion';
     return useHiringBudget
       ? {
           annual_total_cost_in_employer_currency: value.salary,
         }
       : {
-          annual_gross_salary_in_employer_currency: value.salary,
+          [useEmployerCurrency
+            ? 'annual_gross_salary_in_employer_currency'
+            : 'annual_gross_salary']: value.salary,
         };
   }
 


### PR DESCRIPTION
I noticed a bug if you selected for example spain, usd and then fill the converted amount in euros for example 50k, you get the transformed values in usd but the quantity sent to the BE was in USD instead of euros

This fixes that