### PR TITLE
fix(cost-calculator) - remove proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Run Playwright tests
         env:
           BASE_URL: ${{ env.REMOTE_FLOWS_URL }}
-          #VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
+          VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
           DEBUG: pw:api
         working-directory: ./example
         run: npx playwright test --project=chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,8 @@ jobs:
       - name: Run Playwright tests
         env:
           BASE_URL: ${{ env.REMOTE_FLOWS_URL }}
-          VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
+          #VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
+          DEBUG: pw:api
         working-directory: ./example
         run: npx playwright test --project=chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 .env
 coverage
 example/public/
+.cursor

--- a/example/e2e/add-estimation.spec.ts
+++ b/example/e2e/add-estimation.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { fillEstimationForm } from './helpers';
+import { fillEstimationForm, setupVercelBypass } from './helpers';
 
 test.describe('add estimation from drawer', () => {
   test.beforeEach(async ({ page }) => {
+    await setupVercelBypass(page);
     await page.goto('/?demo=with-premium-benefits-cost-calculator');
   });
 

--- a/example/e2e/annual-gross-salary.spec.ts
+++ b/example/e2e/annual-gross-salary.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { fillEstimationForm } from './helpers';
+import { fillEstimationForm, setupVercelBypass } from './helpers';
 
 test.describe('annual gross salary', () => {
   test.beforeEach(async ({ page }) => {
+    await setupVercelBypass(page);
     await page.goto('/?demo=with-premium-benefits-cost-calculator');
   });
 

--- a/example/e2e/edit-estimation.spec.ts
+++ b/example/e2e/edit-estimation.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { fillEstimationForm } from './helpers';
+import { fillEstimationForm, setupVercelBypass } from './helpers';
 
 test.describe('edit estimation', () => {
   test.beforeEach(async ({ page }) => {
+    await setupVercelBypass(page);
     await page.goto('/?demo=with-premium-benefits-cost-calculator');
   });
 

--- a/example/e2e/hiring-budget.spec.ts
+++ b/example/e2e/hiring-budget.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { fillEstimationForm } from './helpers';
+import { fillEstimationForm, setupVercelBypass } from './helpers';
 
 test.describe('hiring budget', () => {
   test.beforeEach(async ({ page }) => {
+    await setupVercelBypass(page);
     await page.goto('/?demo=with-premium-benefits-cost-calculator');
   });
 

--- a/example/playwright.config.ts
+++ b/example/playwright.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
     baseURL:
       process.env.BASE_URL ||
       'http://localhost:3001/?demo=with-premium-benefits-cost-calculator',
+    extraHTTPHeaders: {
+      'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_TOKEN || '',
+      'x-vercel-set-bypass-cookie': 'true',
+    },
   },
 
   /* Configure projects for major browsers */

--- a/example/playwright.config.ts
+++ b/example/playwright.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
       process.env.BASE_URL ||
       'http://localhost:3001/?demo=with-premium-benefits-cost-calculator',
     extraHTTPHeaders: {
-      'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_TOKEN || '',
-      'x-vercel-set-bypass-cookie': 'true',
+      //'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_TOKEN || '',
+      //'x-vercel-set-bypass-cookie': 'true',
     },
   },
 

--- a/example/playwright.config.ts
+++ b/example/playwright.config.ts
@@ -33,10 +33,6 @@ export default defineConfig({
     baseURL:
       process.env.BASE_URL ||
       'http://localhost:3001/?demo=with-premium-benefits-cost-calculator',
-    extraHTTPHeaders: {
-      //'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_TOKEN || '',
-      //'x-vercel-set-bypass-cookie': 'true',
-    },
   },
 
   /* Configure projects for major browsers */

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -694,14 +694,8 @@ function CostCalculatorFormDemo() {
 }
 
 export function CostCalculatorWithPremiumBenefits() {
-  const proxyURL = window.location.origin;
-
   return (
-    <RemoteFlows
-      components={components}
-      proxy={{ url: proxyURL }}
-      isClientToken
-    >
+    <RemoteFlows components={components} isClientToken>
       <CostCalculatorFormDemo />
     </RemoteFlows>
   );


### PR DESCRIPTION
We don't need to proxy calls on cost calculator as client token is enough

PS: client token not working well in all envs

In production company-currencies stopped working, while in the partners the currency conversion is not working