### PR TITLE
feat(contractor-onboarding) - initial code

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -43,6 +43,8 @@ import CostCalculatorWithPremiumBenefitsCode from './CostCalculatorWithPremiumBe
 import CostCalculatorWithReplaceableComponentsCode from './CostCalculatorWithReplaceableComponents?raw';
 import TerminationCode from './Termination?raw';
 import ContractAmendmentCode from './ContractAmendment?raw';
+import { ContractorOnboardingForm } from './ContractorOnboarding';
+import ContractorOnboardingCode from './ContractorOnboarding?raw';
 
 const costCalculatorDemos = [
   {
@@ -138,6 +140,13 @@ const additionalDemos = [
         sourceCode: '',
       },
     ],
+  },
+  {
+    id: 'contract-onboarding',
+    title: 'Contract Onboarding',
+    description: 'Onboarding flow of a new contractor',
+    component: ContractorOnboardingForm,
+    sourceCode: ContractorOnboardingCode,
   },
 ];
 

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -12,7 +12,12 @@ import { RemoteFlows } from './RemoteFlows';
 import { AlertError } from './AlertError';
 import './css/main.css';
 
-const STEPS = ['Select Country', 'Basic Information', 'Contract Details'];
+const STEPS = [
+  'Select Country',
+  'Basic Information',
+  'Pricing Plan',
+  'Contract Options',
+];
 
 type MultiStepFormProps = {
   contractorOnboardingBag: ContractorOnboardingRenderProps['contractorOnboardingBag'];
@@ -23,8 +28,14 @@ const MultiStepForm = ({
   components,
   contractorOnboardingBag,
 }: MultiStepFormProps) => {
-  const { BasicInformationStep, SubmitButton, BackButton, SelectCountryStep } =
-    components;
+  const {
+    BasicInformationStep,
+    SubmitButton,
+    BackButton,
+    SelectCountryStep,
+    PricingPlanStep,
+    ContractOptionsStep,
+  } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
     fieldErrors: NormalizedFieldError[];
@@ -95,6 +106,20 @@ const MultiStepForm = ({
           </div>
         </>
       );
+
+    case 'pricing_plan':
+      return (
+        <>
+          <PricingPlanStep />
+        </>
+      );
+
+    case 'contract_options':
+      return (
+        <>
+          <ContractOptionsStep />
+        </>
+      );
   }
 };
 
@@ -139,21 +164,18 @@ const OnBoardingRender = ({
 type OnboardingFormData = {
   countryCode?: string;
   companyId: string;
-  type: 'employee' | 'contractor';
   employmentId: string;
   externalId?: string;
 };
 
 const OnboardingWithProps = ({
   companyId,
-  type,
   employmentId,
   externalId,
 }: OnboardingFormData) => (
   <RemoteFlows>
     <ContractorOnboardingFlow
       companyId={companyId}
-      type={type}
       render={OnBoardingRender}
       employmentId={employmentId}
       externalId={externalId}
@@ -197,26 +219,6 @@ export const ContractorOnboardingForm = () => {
           placeholder='e.g. Your Company ID'
           className='onboarding-form-input'
         />
-      </div>
-      <div className='onboarding-form-group'>
-        <label htmlFor='type' className='onboarding-form-label'>
-          Type:
-        </label>
-        <select
-          id='type'
-          value={formData.type}
-          onChange={(e) =>
-            setFormData((prev) => ({
-              ...prev,
-              type: e.target.value as 'employee' | 'contractor',
-            }))
-          }
-          required
-          className='onboarding-form-select'
-        >
-          <option value='employee'>Employee</option>
-          <option value='contractor'>Contractor</option>
-        </select>
       </div>
       <div className='onboarding-form-group'>
         <label htmlFor='employmentId' className='onboarding-form-label'>

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -1,0 +1,256 @@
+import {
+  ContractorOnboardingRenderProps,
+  BasicInformationFormPayload,
+  EmploymentCreationResponse,
+  SelectCountrySuccess,
+  SelectCountryFormPayload,
+  NormalizedFieldError,
+  ContractorOnboardingFlow,
+} from '@remoteoss/remote-flows';
+import React, { useState } from 'react';
+import { RemoteFlows } from './RemoteFlows';
+import { AlertError } from './AlertError';
+import './css/main.css';
+
+const STEPS = ['Select Country', 'Basic Information', 'Contract Details'];
+
+type MultiStepFormProps = {
+  contractorOnboardingBag: ContractorOnboardingRenderProps['contractorOnboardingBag'];
+  components: ContractorOnboardingRenderProps['components'];
+};
+
+const MultiStepForm = ({
+  components,
+  contractorOnboardingBag,
+}: MultiStepFormProps) => {
+  const { BasicInformationStep, SubmitButton, BackButton, SelectCountryStep } =
+    components;
+  const [errors, setErrors] = useState<{
+    apiError: string;
+    fieldErrors: NormalizedFieldError[];
+  }>({
+    apiError: '',
+    fieldErrors: [],
+  });
+
+  switch (contractorOnboardingBag.stepState.currentStep.name) {
+    case 'select_country':
+      return (
+        <>
+          <SelectCountryStep
+            onSubmit={(payload: SelectCountryFormPayload) =>
+              console.log('payload', payload)
+            }
+            onSuccess={(response: SelectCountrySuccess) =>
+              console.log('response', response)
+            }
+            onError={({
+              error,
+              fieldErrors,
+            }: {
+              error: Error;
+              fieldErrors: NormalizedFieldError[];
+            }) => setErrors({ apiError: error.message, fieldErrors })}
+          />
+          <div className='buttons-container'>
+            <SubmitButton
+              className='submit-button'
+              disabled={contractorOnboardingBag.isSubmitting}
+              variant='outline'
+            >
+              Continue
+            </SubmitButton>
+          </div>
+        </>
+      );
+    case 'basic_information':
+      return (
+        <>
+          <BasicInformationStep
+            onSubmit={(payload: BasicInformationFormPayload) =>
+              console.log('payload', payload)
+            }
+            onSuccess={(data: EmploymentCreationResponse) =>
+              console.log('data', data)
+            }
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <AlertError errors={errors} />
+          <div className='buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Previous Step
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              disabled={contractorOnboardingBag.isSubmitting}
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Create Employment & Continue
+            </SubmitButton>
+          </div>
+        </>
+      );
+  }
+};
+
+const OnBoardingRender = ({
+  contractorOnboardingBag,
+  components,
+}: MultiStepFormProps) => {
+  const currentStepIndex = contractorOnboardingBag.stepState.currentStep.index;
+
+  const stepTitle = STEPS[currentStepIndex];
+
+  if (contractorOnboardingBag.isLoading) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <>
+      <div className='steps-navigation'>
+        <ul>
+          {STEPS.map((step, index) => (
+            <li
+              key={index}
+              className={`step-item ${index === currentStepIndex ? 'active' : ''}`}
+            >
+              {step}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className='card' style={{ marginBottom: '20px' }}>
+        <h1 className='heading'>{stepTitle}</h1>
+        <MultiStepForm
+          contractorOnboardingBag={contractorOnboardingBag}
+          components={components}
+        />
+      </div>
+    </>
+  );
+};
+
+type OnboardingFormData = {
+  countryCode?: string;
+  companyId: string;
+  type: 'employee' | 'contractor';
+  employmentId: string;
+  externalId?: string;
+};
+
+const OnboardingWithProps = ({
+  companyId,
+  type,
+  employmentId,
+  externalId,
+}: OnboardingFormData) => (
+  <RemoteFlows>
+    <ContractorOnboardingFlow
+      companyId={companyId}
+      type={type}
+      render={OnBoardingRender}
+      employmentId={employmentId}
+      externalId={externalId}
+    />
+  </RemoteFlows>
+);
+
+export const ContractorOnboardingForm = () => {
+  const [formData, setFormData] = useState<OnboardingFormData>({
+    type: 'contractor',
+    employmentId: import.meta.env.VITE_EMPLOYMENT_ID || '', // use your own employment ID
+    companyId:
+      import.meta.env.VITE_COMPANY_ID || 'c3c22940-e118-425c-9e31-f2fd4d43c6d8', // use your own company ID
+    externalId: '',
+  });
+  const [showOnboarding, setShowOnboarding] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setShowOnboarding(true);
+  };
+
+  if (showOnboarding) {
+    return <OnboardingWithProps {...formData} />;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className='onboarding-form-container'>
+      <div className='onboarding-form-group'>
+        <label htmlFor='companyId' className='onboarding-form-label'>
+          Company ID:
+        </label>
+        <input
+          id='companyId'
+          type='text'
+          value={formData.companyId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, companyId: e.target.value }))
+          }
+          required
+          placeholder='e.g. Your Company ID'
+          className='onboarding-form-input'
+        />
+      </div>
+      <div className='onboarding-form-group'>
+        <label htmlFor='type' className='onboarding-form-label'>
+          Type:
+        </label>
+        <select
+          id='type'
+          value={formData.type}
+          onChange={(e) =>
+            setFormData((prev) => ({
+              ...prev,
+              type: e.target.value as 'employee' | 'contractor',
+            }))
+          }
+          required
+          className='onboarding-form-select'
+        >
+          <option value='employee'>Employee</option>
+          <option value='contractor'>Contractor</option>
+        </select>
+      </div>
+      <div className='onboarding-form-group'>
+        <label htmlFor='employmentId' className='onboarding-form-label'>
+          Employment ID:
+        </label>
+        <input
+          id='employmentId'
+          type='text'
+          value={formData.employmentId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, employmentId: e.target.value }))
+          }
+          placeholder='Enter employment ID'
+          className='onboarding-form-input'
+        />
+      </div>
+      <div className='onboarding-form-group'>
+        <label htmlFor='externalId' className='onboarding-form-label'>
+          External ID:
+        </label>
+        <input
+          id='externalId'
+          type='text'
+          value={formData.externalId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, externalId: e.target.value }))
+          }
+          placeholder='Enter External ID'
+          className='onboarding-form-input'
+        />
+      </div>
+      <button type='submit' className='onboarding-form-button'>
+        Start Onboarding
+      </button>
+    </form>
+  );
+};

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -63,7 +63,7 @@ const MultiStepForm = ({
           </div>
         </>
       );
-    case 'basic_information':
+    /*  case 'basic_information':
       return (
         <>
           <BasicInformationStep
@@ -94,7 +94,7 @@ const MultiStepForm = ({
             </SubmitButton>
           </div>
         </>
-      );
+      ); */
   }
 };
 

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -6,6 +6,10 @@ import {
   SelectCountryFormPayload,
   NormalizedFieldError,
   ContractorOnboardingFlow,
+  PricingPlanFormPayload,
+  PricingPlanResponse,
+  ContractOptionsFormPayload,
+  ContractOptionsResponse,
 } from '@remoteoss/remote-flows';
 import React, { useState } from 'react';
 import { RemoteFlows } from './RemoteFlows';
@@ -110,14 +114,64 @@ const MultiStepForm = ({
     case 'pricing_plan':
       return (
         <>
-          <PricingPlanStep />
+          <PricingPlanStep
+            onSubmit={(payload: PricingPlanFormPayload) =>
+              console.log('payload', payload)
+            }
+            onSuccess={(response: PricingPlanResponse) =>
+              console.log('response', response)
+            }
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <div className='buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Previous Step
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              disabled={contractorOnboardingBag.isSubmitting}
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Next
+            </SubmitButton>
+          </div>
         </>
       );
 
     case 'contract_options':
       return (
         <>
-          <ContractOptionsStep />
+          <ContractOptionsStep
+            onSubmit={(payload: ContractOptionsFormPayload) =>
+              console.log('payload', payload)
+            }
+            onSuccess={(response: ContractOptionsResponse) =>
+              console.log('response', response)
+            }
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <div className='buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Previous Step
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              disabled={contractorOnboardingBag.isSubmitting}
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Next
+            </SubmitButton>
+          </div>
         </>
       );
   }
@@ -163,19 +217,16 @@ const OnBoardingRender = ({
 
 type OnboardingFormData = {
   countryCode?: string;
-  companyId: string;
   employmentId: string;
   externalId?: string;
 };
 
 const OnboardingWithProps = ({
-  companyId,
   employmentId,
   externalId,
 }: OnboardingFormData) => (
   <RemoteFlows>
     <ContractorOnboardingFlow
-      companyId={companyId}
       render={OnBoardingRender}
       employmentId={employmentId}
       externalId={externalId}
@@ -185,10 +236,7 @@ const OnboardingWithProps = ({
 
 export const ContractorOnboardingForm = () => {
   const [formData, setFormData] = useState<OnboardingFormData>({
-    type: 'contractor',
     employmentId: import.meta.env.VITE_EMPLOYMENT_ID || '', // use your own employment ID
-    companyId:
-      import.meta.env.VITE_COMPANY_ID || 'c3c22940-e118-425c-9e31-f2fd4d43c6d8', // use your own company ID
     externalId: '',
   });
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -204,22 +252,6 @@ export const ContractorOnboardingForm = () => {
 
   return (
     <form onSubmit={handleSubmit} className='onboarding-form-container'>
-      <div className='onboarding-form-group'>
-        <label htmlFor='companyId' className='onboarding-form-label'>
-          Company ID:
-        </label>
-        <input
-          id='companyId'
-          type='text'
-          value={formData.companyId}
-          onChange={(e) =>
-            setFormData((prev) => ({ ...prev, companyId: e.target.value }))
-          }
-          required
-          placeholder='e.g. Your Company ID'
-          className='onboarding-form-input'
-        />
-      </div>
       <div className='onboarding-form-group'>
         <label htmlFor='employmentId' className='onboarding-form-label'>
           Employment ID:

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -63,7 +63,7 @@ const MultiStepForm = ({
           </div>
         </>
       );
-    /*  case 'basic_information':
+    case 'basic_information':
       return (
         <>
           <BasicInformationStep
@@ -94,7 +94,7 @@ const MultiStepForm = ({
             </SubmitButton>
           </div>
         </>
-      ); */
+      );
   }
 };
 

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -224,15 +224,17 @@ type OnboardingFormData = {
 const OnboardingWithProps = ({
   employmentId,
   externalId,
-}: OnboardingFormData) => (
-  <RemoteFlows>
-    <ContractorOnboardingFlow
-      render={OnBoardingRender}
-      employmentId={employmentId}
-      externalId={externalId}
-    />
-  </RemoteFlows>
-);
+}: OnboardingFormData) => {
+  return (
+    <RemoteFlows>
+      <ContractorOnboardingFlow
+        render={OnBoardingRender}
+        employmentId={employmentId}
+        externalId={externalId}
+      />
+    </RemoteFlows>
+  );
+};
 
 export const ContractorOnboardingForm = () => {
   const [formData, setFormData] = useState<OnboardingFormData>({

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -6,6 +6,8 @@ import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/
 import { BasicInformationStep } from '@/src/flows/ContractorOnboarding/components/BasicInformationStep';
 import { OnboardingSubmit } from '@/src/flows/ContractorOnboarding/components/OnboardingSubmit';
 import { useId } from 'react';
+import { PricingPlanStep } from '@/src/flows/ContractorOnboarding/components/PricingPlan';
+import { ContractOptionsStep } from '@/src/flows/ContractorOnboarding/components/ContractOptionsStep';
 
 export const ContractorOnboardingFlow = ({
   render,
@@ -24,6 +26,8 @@ export const ContractorOnboardingFlow = ({
           SelectCountryStep: SelectCountryStep,
           BackButton: OnboardingBack,
           SubmitButton: OnboardingSubmit,
+          PricingPlanStep: PricingPlanStep,
+          ContractOptionsStep: ContractOptionsStep,
         },
       })}
     </ContractorOnboardingContext.Provider>

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -11,9 +11,21 @@ import { ContractOptionsStep } from '@/src/flows/ContractorOnboarding/components
 
 export const ContractorOnboardingFlow = ({
   render,
+  employmentId,
+  externalId,
+  countryCode,
+  skipSteps,
+  initialValues,
   options,
 }: ContractorOnboardingFlowProps) => {
-  const contractorOnboardingBag = useContractorOnboarding({ options });
+  const contractorOnboardingBag = useContractorOnboarding({
+    options,
+    employmentId,
+    externalId,
+    countryCode,
+    skipSteps,
+    initialValues,
+  });
   const formId = useId();
   return (
     <ContractorOnboardingContext.Provider

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -1,8 +1,10 @@
+import { OnboardingBack } from '@/src/flows/ContractorOnboarding/components/OnboardingBack';
 import { SelectCountryStep } from '@/src/flows/ContractorOnboarding/components/SelectCountryStep';
 import { ContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
 import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/types';
-import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
+import { BasicInformationStep } from '@/src/flows/ContractorOnboarding/components/BasicInformationStep';
+import { OnboardingSubmit } from '@/src/flows/ContractorOnboarding/components/OnboardingSubmit';
 import { useId } from 'react';
 
 export const ContractorOnboardingFlow = ({
@@ -20,6 +22,8 @@ export const ContractorOnboardingFlow = ({
         components: {
           BasicInformationStep: BasicInformationStep,
           SelectCountryStep: SelectCountryStep,
+          Back: OnboardingBack,
+          Submit: OnboardingSubmit,
         },
       })}
     </ContractorOnboardingContext.Provider>

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -1,0 +1,18 @@
+import { ContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
+import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/types';
+import { useId } from 'react';
+
+export const ContractorOnboardingFlow = (
+  props: ContractorOnboardingFlowProps,
+) => {
+  const contractorOnboardingBag = useContractorOnboarding();
+  const formId = useId();
+  return (
+    <ContractorOnboardingContext.Provider
+      value={{ contractorOnboardingBag, formId }}
+    >
+      <div>ContractorOnboarding</div>
+    </ContractorOnboardingContext.Provider>
+  );
+};

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -1,18 +1,24 @@
 import { ContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
 import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/types';
+import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
 import { useId } from 'react';
 
-export const ContractorOnboardingFlow = (
-  props: ContractorOnboardingFlowProps,
-) => {
+export const ContractorOnboardingFlow = ({
+  render,
+}: ContractorOnboardingFlowProps) => {
   const contractorOnboardingBag = useContractorOnboarding();
   const formId = useId();
   return (
     <ContractorOnboardingContext.Provider
       value={{ contractorOnboardingBag, formId }}
     >
-      <div>ContractorOnboarding</div>
+      {render({
+        contractorOnboardingBag,
+        components: {
+          BasicInformationStep: BasicInformationStep,
+        },
+      })}
     </ContractorOnboardingContext.Provider>
   );
 };

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -22,8 +22,8 @@ export const ContractorOnboardingFlow = ({
         components: {
           BasicInformationStep: BasicInformationStep,
           SelectCountryStep: SelectCountryStep,
-          Back: OnboardingBack,
-          Submit: OnboardingSubmit,
+          BackButton: OnboardingBack,
+          SubmitButton: OnboardingSubmit,
         },
       })}
     </ContractorOnboardingContext.Provider>

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -1,3 +1,4 @@
+import { SelectCountryStep } from '@/src/flows/ContractorOnboarding/components/SelectCountryStep';
 import { ContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
 import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/types';
@@ -6,8 +7,9 @@ import { useId } from 'react';
 
 export const ContractorOnboardingFlow = ({
   render,
+  options,
 }: ContractorOnboardingFlowProps) => {
-  const contractorOnboardingBag = useContractorOnboarding();
+  const contractorOnboardingBag = useContractorOnboarding({ options });
   const formId = useId();
   return (
     <ContractorOnboardingContext.Provider
@@ -17,6 +19,7 @@ export const ContractorOnboardingFlow = ({
         contractorOnboardingBag,
         components: {
           BasicInformationStep: BasicInformationStep,
+          SelectCountryStep: SelectCountryStep,
         },
       })}
     </ContractorOnboardingContext.Provider>

--- a/src/flows/ContractorOnboarding/components/BasicInformationStep.tsx
+++ b/src/flows/ContractorOnboarding/components/BasicInformationStep.tsx
@@ -1,0 +1,85 @@
+import { BasicInformationFormPayload } from '@/src/flows/Onboarding/types';
+import { EmploymentCreationResponse } from '@/src/client';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+import {
+  normalizeFieldErrors,
+  NormalizedFieldError,
+} from '@/src/lib/mutations';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+
+type BasicInformationStepProps = {
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: BasicInformationFormPayload) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: EmploymentCreationResponse) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function BasicInformationStep({
+  onSubmit,
+  onSuccess,
+  onError,
+}: BasicInformationStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const handleSubmit = async (payload: $TSFixMe) => {
+    try {
+      await onSubmit?.(
+        contractorOnboardingBag.parseFormValues(
+          payload,
+        ) as BasicInformationFormPayload,
+      );
+      const response = await contractorOnboardingBag.onSubmit(payload);
+      if (response?.data) {
+        await onSuccess?.(response?.data as EmploymentCreationResponse);
+        contractorOnboardingBag?.next();
+        return;
+      }
+      if (response?.error) {
+        const normalizedFieldErrors = normalizeFieldErrors(
+          response?.fieldErrors || [],
+          contractorOnboardingBag.meta?.fields?.basic_information,
+        );
+
+        onError?.({
+          error: response?.error,
+          rawError: response?.rawError,
+          fieldErrors: normalizedFieldErrors,
+        });
+      }
+    } catch (error: unknown) {
+      onError?.({
+        error: error as Error,
+        rawError: error as Record<string, unknown>,
+        fieldErrors: [],
+      });
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.basic_information ||
+    contractorOnboardingBag.initialValues.basic_information;
+
+  return (
+    <ContractorOnboardingForm
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/components/ContractOptionsStep.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractOptionsStep.tsx
@@ -6,19 +6,19 @@ import {
 import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
 import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
 
-type PricingPlanFormPayload = $TSFixMe;
+type ContractOptionsFormPayload = $TSFixMe;
 
-type PricingPlanResponse = $TSFixMe;
+type ContractOptionsResponse = $TSFixMe;
 
-type PricingPlanStepProps = {
+type ContractOptionsStepProps = {
   /*
    * The function is called when the form is submitted. It receives the form values as an argument.
    */
-  onSubmit?: (payload: PricingPlanFormPayload) => void | Promise<void>;
+  onSubmit?: (payload: ContractOptionsFormPayload) => void | Promise<void>;
   /*
    * The function is called when the form submission is successful.
    */
-  onSuccess?: (data: PricingPlanResponse) => void | Promise<void>;
+  onSuccess?: (data: ContractOptionsResponse) => void | Promise<void>;
   /*
    * The function is called when an error occurs during form submission.
    */
@@ -33,11 +33,11 @@ type PricingPlanStepProps = {
   }) => void;
 };
 
-export function PricingPlanStep({
+export function ContractOptionsStep({
   onSubmit,
   onSuccess,
   onError,
-}: PricingPlanStepProps) {
+}: ContractOptionsStepProps) {
   const { contractorOnboardingBag } = useContractorOnboardingContext();
 
   const handleSubmit = async (payload: $TSFixMe) => {
@@ -54,7 +54,7 @@ export function PricingPlanStep({
       if (response?.error) {
         const normalizedFieldErrors = normalizeFieldErrors(
           response?.fieldErrors || [],
-          contractorOnboardingBag.meta?.fields?.pricing_plan,
+          contractorOnboardingBag.meta?.fields?.contract_options,
         );
 
         onError?.({
@@ -73,8 +73,8 @@ export function PricingPlanStep({
   };
 
   const initialValues =
-    contractorOnboardingBag.stepState.values?.pricing_plan ||
-    contractorOnboardingBag.initialValues.pricing_plan;
+    contractorOnboardingBag.stepState.values?.contract_options ||
+    contractorOnboardingBag.initialValues.contract_options;
 
   return (
     <ContractorOnboardingForm

--- a/src/flows/ContractorOnboarding/components/ContractOptionsStep.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractOptionsStep.tsx
@@ -5,10 +5,10 @@ import {
 } from '@/src/lib/mutations';
 import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
 import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
-
-type ContractOptionsFormPayload = $TSFixMe;
-
-type ContractOptionsResponse = $TSFixMe;
+import {
+  ContractOptionsFormPayload,
+  ContractOptionsResponse,
+} from '@/src/flows/ContractorOnboarding/types';
 
 type ContractOptionsStepProps = {
   /*

--- a/src/flows/ContractorOnboarding/components/ContractorOnboardingForm.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractorOnboardingForm.tsx
@@ -1,0 +1,91 @@
+import { JSONSchemaFormFields } from '@/src/components/form/JSONSchemaForm';
+import { Form } from '@/src/components/ui/form';
+import { useForm } from 'react-hook-form';
+import { useJsonSchemasValidationFormResolver } from '@/src/components/form/yupValidationResolver';
+import { Fields } from '@remoteoss/json-schema-form';
+import {
+  BasicInformationFormPayload,
+  BenefitsFormPayload,
+  ContractDetailsFormPayload,
+} from '@/src/flows/Onboarding/types';
+import { Components } from '@/src/types/remoteFlows';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+
+type ContractorOnboardingFormProps = {
+  onSubmit: (
+    payload:
+      | BasicInformationFormPayload
+      | BenefitsFormPayload
+      | ContractDetailsFormPayload,
+  ) => void;
+  components?: Components;
+  fields?: Fields;
+  defaultValues: Record<string, unknown>;
+};
+
+export function ContractorOnboardingForm({
+  defaultValues,
+  onSubmit,
+  components,
+}: ContractorOnboardingFormProps) {
+  const { formId, contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const resolver = useJsonSchemasValidationFormResolver(
+    // @ts-expect-error no matching type
+    contractorOnboardingBag.handleValidation,
+  );
+
+  const form = useForm({
+    resolver,
+    defaultValues,
+    shouldUnregister: false,
+    mode: 'onBlur',
+  });
+
+  /* useEffect(() => {
+    // When the employmentId is set,
+    // we need to run the checkFieldUpdates to update fieldValues in useStepState
+    if (contractorOnboardingBag.employmentId) {
+      contractorOnboardingBag?.checkFieldUpdates(form.getValues());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); */
+
+  /* useEffect(() => {
+    const subscription = form?.watch((values) => {
+      const isAnyFieldDirty = Object.keys(values).some(
+        (key) =>
+          values[key as keyof unknown] !== defaultValues[key as keyof unknown],
+      );
+      if (isAnyFieldDirty) {
+        contractorOnboardingBag?.checkFieldUpdates(values);
+      }
+    });
+    return () => subscription?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); */
+
+  const handleSubmit = async (values: Record<string, unknown>) => {
+    onSubmit(values);
+  };
+
+  return (
+    <Form
+      {...form}
+      key={`form-${contractorOnboardingBag.stepState.currentStep.name}`}
+    >
+      <form
+        id={formId}
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className='space-y-4 RemoteFlows__OnboardingForm'
+      >
+        <JSONSchemaFormFields
+          components={components}
+          fields={contractorOnboardingBag.fields}
+          fieldsets={contractorOnboardingBag.meta.fieldsets}
+          fieldValues={contractorOnboardingBag.fieldValues}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/flows/ContractorOnboarding/components/ContractorOnboardingForm.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractorOnboardingForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/src/flows/Onboarding/types';
 import { Components } from '@/src/types/remoteFlows';
 import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { useEffect } from 'react';
 
 type ContractorOnboardingFormProps = {
   onSubmit: (
@@ -42,16 +43,16 @@ export function ContractorOnboardingForm({
     mode: 'onBlur',
   });
 
-  /* useEffect(() => {
+  useEffect(() => {
     // When the employmentId is set,
     // we need to run the checkFieldUpdates to update fieldValues in useStepState
     if (contractorOnboardingBag.employmentId) {
       contractorOnboardingBag?.checkFieldUpdates(form.getValues());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); */
+  }, []);
 
-  /* useEffect(() => {
+  useEffect(() => {
     const subscription = form?.watch((values) => {
       const isAnyFieldDirty = Object.keys(values).some(
         (key) =>
@@ -63,7 +64,7 @@ export function ContractorOnboardingForm({
     });
     return () => subscription?.unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); */
+  }, []);
 
   const handleSubmit = async (values: Record<string, unknown>) => {
     onSubmit(values);

--- a/src/flows/ContractorOnboarding/components/OnboardingBack.tsx
+++ b/src/flows/ContractorOnboarding/components/OnboardingBack.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/src/components/ui/button';
+import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { useFormFields } from '@/src/context';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+
+type OnboardingBackProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  Record<string, unknown>;
+
+export function OnboardingBack({
+  children,
+  onClick,
+  ...props
+}: PropsWithChildren<OnboardingBackProps>) {
+  const {
+    contractorOnboardingBag: { back, isEmploymentReadOnly },
+  } = useContractorOnboardingContext();
+
+  const { components } = useFormFields();
+
+  const onBackHandler = (evt: React.MouseEvent<HTMLButtonElement>) => {
+    if (!isEmploymentReadOnly) {
+      back();
+    }
+    onClick?.(evt);
+  };
+
+  const CustomButton = components?.button;
+  if (CustomButton) {
+    return (
+      <CustomButton {...props} onClick={onBackHandler}>
+        {children}
+      </CustomButton>
+    );
+  }
+
+  return (
+    <Button {...props} onClick={onBackHandler}>
+      {children}
+    </Button>
+  );
+}

--- a/src/flows/ContractorOnboarding/components/OnboardingSubmit.tsx
+++ b/src/flows/ContractorOnboarding/components/OnboardingSubmit.tsx
@@ -1,0 +1,29 @@
+import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { Button } from '@/src/components/ui/button';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { useFormFields } from '@/src/context';
+
+export function OnboardingSubmit({
+  children,
+  ...props
+}: PropsWithChildren<
+  ButtonHTMLAttributes<HTMLButtonElement> & Record<string, unknown>
+>) {
+  const { formId } = useContractorOnboardingContext();
+  const { components } = useFormFields();
+
+  const CustomButton = components?.button;
+  if (CustomButton) {
+    return (
+      <CustomButton {...props} form={formId}>
+        {children}
+      </CustomButton>
+    );
+  }
+
+  return (
+    <Button {...props} form={formId}>
+      {children}
+    </Button>
+  );
+}

--- a/src/flows/ContractorOnboarding/components/PricingPlan.tsx
+++ b/src/flows/ContractorOnboarding/components/PricingPlan.tsx
@@ -5,10 +5,10 @@ import {
 } from '@/src/lib/mutations';
 import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
 import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
-
-type PricingPlanFormPayload = $TSFixMe;
-
-type PricingPlanResponse = $TSFixMe;
+import {
+  PricingPlanFormPayload,
+  PricingPlanResponse,
+} from '@/src/flows/ContractorOnboarding/types';
 
 type PricingPlanStepProps = {
   /*

--- a/src/flows/ContractorOnboarding/components/PricingPlan.tsx
+++ b/src/flows/ContractorOnboarding/components/PricingPlan.tsx
@@ -1,0 +1,83 @@
+import { BasicInformationFormPayload } from '@/src/flows/Onboarding/types';
+import { EmploymentCreationResponse } from '@/src/client';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+import {
+  normalizeFieldErrors,
+  NormalizedFieldError,
+} from '@/src/lib/mutations';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+
+type BasicInformationStepProps = {
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: BasicInformationFormPayload) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: EmploymentCreationResponse) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function PricingPlanStep({
+  onSubmit,
+  onSuccess,
+  onError,
+}: BasicInformationStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const handleSubmit = async (payload: $TSFixMe) => {
+    try {
+      await onSubmit?.(
+        contractorOnboardingBag.parseFormValues(payload) as $TSFixMe, // TODO: add type
+      );
+      const response = await contractorOnboardingBag.onSubmit(payload);
+      if (response?.data) {
+        await onSuccess?.(response?.data as $TSFixMe); // TODO: add type
+        contractorOnboardingBag?.next();
+        return;
+      }
+      if (response?.error) {
+        const normalizedFieldErrors = normalizeFieldErrors(
+          response?.fieldErrors || [],
+          contractorOnboardingBag.meta?.fields?.basic_information,
+        );
+
+        onError?.({
+          error: response?.error,
+          rawError: response?.rawError,
+          fieldErrors: normalizedFieldErrors,
+        });
+      }
+    } catch (error: unknown) {
+      onError?.({
+        error: error as Error,
+        rawError: error as Record<string, unknown>,
+        fieldErrors: [],
+      });
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.pricing_plan ||
+    contractorOnboardingBag.initialValues.pricing_plan;
+
+  return (
+    <ContractorOnboardingForm
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/components/SelectCountryStep.tsx
+++ b/src/flows/ContractorOnboarding/components/SelectCountryStep.tsx
@@ -62,9 +62,9 @@ export function SelectCountryStep({
     }
   };
 
-  const initialValues =
-    contractorOnboardingBag.stepState.values?.select_country ||
-    contractorOnboardingBag.initialValues.select_country;
+  const initialValues = {};
+  /*  contractorOnboardingBag.stepState.values?.select_country ||
+    contractorOnboardingBag.initialValues.select_country; */
 
   return (
     <ContractorOnboardingForm

--- a/src/flows/ContractorOnboarding/components/SelectCountryStep.tsx
+++ b/src/flows/ContractorOnboarding/components/SelectCountryStep.tsx
@@ -1,0 +1,75 @@
+// TODO: Correct types later
+import {
+  SelectCountryFormPayload,
+  SelectCountrySuccess,
+} from '@/src/flows/Onboarding/types';
+import { NormalizedFieldError } from '@/src/lib/mutations';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+
+type SelectCountryStepProps = {
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: SelectCountryFormPayload) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: SelectCountrySuccess) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function SelectCountryStep({
+  onSubmit,
+  onSuccess,
+  onError,
+}: SelectCountryStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+  const handleSubmit = async (payload: $TSFixMe) => {
+    try {
+      await onSubmit?.({ countryCode: payload.country });
+      const response = await contractorOnboardingBag.onSubmit(payload);
+      if (response?.data) {
+        await onSuccess?.(response?.data as SelectCountrySuccess);
+        contractorOnboardingBag?.next();
+        return;
+      }
+      if (response?.error) {
+        onError?.({
+          error: response.error,
+          rawError: response.rawError,
+          fieldErrors: [],
+        });
+      }
+    } catch (error: unknown) {
+      onError?.({
+        error: error as Error,
+        rawError: error as Record<string, unknown>,
+        fieldErrors: [],
+      });
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.select_country ||
+    contractorOnboardingBag.initialValues.select_country;
+
+  return (
+    <ContractorOnboardingForm
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/components/SelectCountryStep.tsx
+++ b/src/flows/ContractorOnboarding/components/SelectCountryStep.tsx
@@ -62,9 +62,9 @@ export function SelectCountryStep({
     }
   };
 
-  const initialValues = {};
-  /*  contractorOnboardingBag.stepState.values?.select_country ||
-    contractorOnboardingBag.initialValues.select_country; */
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.select_country ||
+    contractorOnboardingBag.initialValues.select_country;
 
   return (
     <ContractorOnboardingForm

--- a/src/flows/ContractorOnboarding/context.ts
+++ b/src/flows/ContractorOnboarding/context.ts
@@ -1,0 +1,24 @@
+import type { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
+import { createContext, useContext } from 'react';
+
+export const ContractorOnboardingContext = createContext<{
+  formId: string | undefined;
+  contractorOnboardingBag: ReturnType<typeof useContractorOnboarding> | null;
+}>({
+  formId: undefined,
+  contractorOnboardingBag: null,
+});
+
+export const useContractorOnboardingContext = () => {
+  const context = useContext(ContractorOnboardingContext);
+  if (!context.formId || !context.contractorOnboardingBag) {
+    throw new Error(
+      'useContractorOnboardingContext must be used within a ContractorOnboardingContextProvider',
+    );
+  }
+
+  return {
+    formId: context.formId,
+    contractorOnboardingBag: context.contractorOnboardingBag,
+  } as const;
+};

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1,3 +1,4 @@
+import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/types';
 import { STEPS } from '@/src/flows/ContractorOnboarding/utils';
 import { JSONSchemaFormType } from '@/src/flows/types';
 import { Step, useStepState } from '@/src/flows/useStepState';
@@ -6,10 +7,18 @@ const stepToFormSchemaMap: Record<
   keyof typeof STEPS,
   JSONSchemaFormType | null
 > = {
+  select_country: null,
   basic_information: 'employment_basic_information',
 };
 
-export const useContractorOnboarding = () => {
+type useContractorOnboardingProps = Omit<
+  ContractorOnboardingFlowProps,
+  'render'
+>;
+
+export const useContractorOnboarding = ({
+  options,
+}: useContractorOnboardingProps) => {
   const {
     fieldValues,
     stepState,

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1,0 +1,6 @@
+export const useContractorOnboarding = () => {
+  return {
+    isLoading: false,
+    isSubmitting: false,
+  };
+};

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -429,5 +429,11 @@ export const useContractorOnboarding = ({
      * Employment id
      */
     employmentId: internalEmploymentId,
+
+    /**
+     * Loading state indicating if the onboarding mutation is in progress
+     */
+    isSubmitting:
+      createEmploymentMutation.isPending || updateEmploymentMutation.isPending,
   };
 };

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1,6 +1,79 @@
+import { STEPS } from '@/src/flows/ContractorOnboarding/utils';
+import { JSONSchemaFormType } from '@/src/flows/types';
+import { Step, useStepState } from '@/src/flows/useStepState';
+
+const stepToFormSchemaMap: Record<
+  keyof typeof STEPS,
+  JSONSchemaFormType | null
+> = {
+  basic_information: 'employment_basic_information',
+};
+
 export const useContractorOnboarding = () => {
+  const {
+    fieldValues,
+    stepState,
+    setFieldValues,
+    previousStep,
+    nextStep,
+    goToStep,
+  } = useStepState(
+    STEPS as Record<keyof typeof STEPS, Step<keyof typeof STEPS>>,
+  );
+
+  const formType =
+    stepToFormSchemaMap[stepState.currentStep.name] ||
+    'employment_basic_information';
+
+  const goTo = (step: keyof typeof STEPS) => {
+    goToStep(step);
+  };
+
+  function onSubmit() {
+    console.log('onSubmit');
+  }
+
   return {
-    isLoading: false,
-    isSubmitting: false,
+    /**
+     * Current state of the form fields for the current step.
+     */
+    fieldValues,
+
+    /**
+     * Current step state containing the current step and total number of steps
+     */
+    stepState,
+
+    /**
+     * Function to update the current form field values
+     * @param values - New form values to set
+     */
+    checkFieldUpdates: setFieldValues,
+
+    /**
+     * Function to handle going back to the previous step
+     * @returns {void}
+     */
+    back: previousStep,
+
+    /**
+     * Function to handle going to the next step
+     * @returns {void}
+     */
+    next: nextStep,
+
+    /**
+     * Function to handle going to a specific step
+     * @param step The step to go to.
+     * @returns {void}
+     */
+    goTo: goTo,
+
+    /**
+     * Function to handle form submission
+     * @param values - Form values to submit
+     * @returns Promise resolving to the mutation result
+     */
+    onSubmit,
   };
 };

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -145,5 +145,11 @@ export const useContractorOnboarding = ({
       fields: fieldsMetaRef.current,
       fieldsets: stepFieldsWithFlatFieldsets[stepState.currentStep.name],
     },
+
+    /**
+     * let's the user know that the employment cannot be edited, happens when employment.status is invited, created_awaiting_reserve or created_reserve_paid
+     * @returns {boolean}
+     */
+    isEmploymentReadOnly: false, // TODO: TBD
   };
 };

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -62,9 +62,13 @@ export const useContractorOnboarding = ({
   const fieldsMetaRef = useRef<{
     select_country: Meta;
     basic_information: Meta;
+    pricing_plan: Meta;
+    contract_options: Meta;
   }>({
     select_country: {},
     basic_information: {},
+    pricing_plan: {},
+    contract_options: {},
   });
 
   const stepsToUse = skipSteps?.includes('select_country')

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -4,7 +4,10 @@ import {
   parseJSFToValidate,
 } from '@/src/components/form/utils';
 import { ContractorOnboardingFlowProps } from '@/src/flows/ContractorOnboarding/types';
-import { STEPS } from '@/src/flows/ContractorOnboarding/utils';
+import {
+  STEPS,
+  STEPS_WITHOUT_SELECT_COUNTRY,
+} from '@/src/flows/ContractorOnboarding/utils';
 import {
   useCountriesSchemaField,
   useCreateEmployment,
@@ -44,6 +47,7 @@ export const useContractorOnboarding = ({
   countryCode,
   externalId,
   employmentId,
+  skipSteps,
   options,
   initialValues: onboardingInitialValues,
 }: useContractorOnboardingProps) => {
@@ -56,23 +60,15 @@ export const useContractorOnboarding = ({
   const fieldsMetaRef = useRef<{
     select_country: Meta;
     basic_information: Meta;
-    contract_details: Meta;
-    benefits: Meta;
   }>({
     select_country: {},
     basic_information: {},
-    contract_details: {},
-    benefits: {},
   });
 
-  const stepFieldsWithFlatFieldsets: Record<
-    keyof typeof STEPS,
-    JSFFieldset | null | undefined
-  > = {
-    select_country: null,
-    // TODO: fix me later
-    basic_information: null,
-  };
+  const stepsToUse = skipSteps?.includes('select_country')
+    ? STEPS_WITHOUT_SELECT_COUNTRY
+    : STEPS;
+
   const {
     fieldValues,
     stepState,
@@ -81,7 +77,7 @@ export const useContractorOnboarding = ({
     nextStep,
     goToStep,
   } = useStepState(
-    STEPS as Record<keyof typeof STEPS, Step<keyof typeof STEPS>>,
+    stepsToUse as Record<keyof typeof STEPS, Step<keyof typeof STEPS>>,
   );
 
   const { data: employment, isLoading: isLoadingEmployment } =
@@ -189,6 +185,14 @@ export const useContractorOnboarding = ({
     }),
     [selectCountryForm?.fields, basicInformationForm?.fields],
   );
+
+  const stepFieldsWithFlatFieldsets: Record<
+    keyof typeof STEPS,
+    JSFFieldset | null | undefined
+  > = {
+    select_country: null,
+    basic_information: basicInformationForm?.meta['x-jsf-fieldsets'],
+  };
 
   const { country, basic_information: employmentBasicInformation = {} } =
     employment || {};

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -35,6 +35,8 @@ const stepToFormSchemaMap: Record<
 > = {
   select_country: null,
   basic_information: 'employment_basic_information',
+  pricing_plan: null,
+  contract_options: null,
 };
 
 const jsonSchemaToEmployment: Partial<
@@ -182,6 +184,8 @@ export const useContractorOnboarding = ({
     () => ({
       select_country: selectCountryForm?.fields || [],
       basic_information: basicInformationForm?.fields || [],
+      pricing_plan: [],
+      contract_options: [],
     }),
     [selectCountryForm?.fields, basicInformationForm?.fields],
   );
@@ -192,6 +196,8 @@ export const useContractorOnboarding = ({
   > = {
     select_country: null,
     basic_information: basicInformationForm?.meta['x-jsf-fieldsets'],
+    pricing_plan: null,
+    contract_options: null,
   };
 
   const { country, basic_information: employmentBasicInformation = {} } =
@@ -224,6 +230,8 @@ export const useContractorOnboarding = ({
     return {
       select_country: selectCountryInitialValues,
       basic_information: basicInformationInitialValues,
+      pricing_plan: {},
+      contract_options: {},
     };
   }, [selectCountryInitialValues, basicInformationInitialValues]);
 
@@ -412,5 +420,10 @@ export const useContractorOnboarding = ({
      * Initial form values
      */
     initialValues,
+
+    /**
+     * Employment id
+     */
+    employmentId: internalEmploymentId,
   };
 };

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -90,13 +90,9 @@ export const useContractorOnboarding = ({
     useEmployment(internalEmploymentId);
 
   const createEmploymentMutation = useCreateEmployment(options);
-  const updateEmploymentMutation = useUpdateEmployment(options);
 
   const { mutateAsync: createEmploymentMutationAsync } = mutationToPromise(
     createEmploymentMutation,
-  );
-  const { mutateAsync: updateEmploymentMutationAsync } = mutationToPromise(
-    updateEmploymentMutation,
   );
 
   // if the employment is loaded, country code has not been set yet
@@ -300,13 +296,9 @@ export const useContractorOnboarding = ({
             throw error;
           }
         } else if (internalEmploymentId) {
-          return updateEmploymentMutationAsync({
-            employmentId: internalEmploymentId,
-            basic_information: parsedValues,
-            pricing_plan_details: {
-              frequency: 'monthly',
-            },
-            external_id: externalId,
+          // TODO: Provisional it seems you cannot update a contractor employment
+          return Promise.resolve({
+            data: { employmentId: internalEmploymentId },
           });
         }
 

--- a/src/flows/ContractorOnboarding/index.ts
+++ b/src/flows/ContractorOnboarding/index.ts
@@ -1,0 +1,2 @@
+export { ContractorOnboardingFlow } from './ContractorOnboarding';
+export type { ContractorOnboardingFlowProps } from './types';

--- a/src/flows/ContractorOnboarding/index.ts
+++ b/src/flows/ContractorOnboarding/index.ts
@@ -2,4 +2,8 @@ export { ContractorOnboardingFlow } from './ContractorOnboarding';
 export type {
   ContractorOnboardingFlowProps,
   ContractorOnboardingRenderProps,
+  PricingPlanFormPayload,
+  PricingPlanResponse,
+  ContractOptionsFormPayload,
+  ContractOptionsResponse,
 } from './types';

--- a/src/flows/ContractorOnboarding/index.ts
+++ b/src/flows/ContractorOnboarding/index.ts
@@ -1,2 +1,5 @@
 export { ContractorOnboardingFlow } from './ContractorOnboarding';
-export type { ContractorOnboardingFlowProps } from './types';
+export type {
+  ContractorOnboardingFlowProps,
+  ContractorOnboardingRenderProps,
+} from './types';

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -1,7 +1,7 @@
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
 import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
 import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
-import { FlowOptions } from '@/src/flows/types';
+import { FlowOptions, JSFModify, JSONSchemaFormType } from '@/src/flows/types';
 
 export type ContractorOnboardingRenderProps = {
   /**
@@ -32,5 +32,10 @@ export type ContractorOnboardingFlowProps = {
   /**
    * The options for the contractor onboarding flow.
    */
-  options?: FlowOptions;
+  options?: Omit<FlowOptions, 'jsfModify'> & {
+    jsfModify?: {
+      select_country?: JSFModify;
+      basic_information?: JSFModify;
+    };
+  };
 };

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -42,6 +42,12 @@ export type ContractorOnboardingFlowProps = {
    * If not provided, it defaults to null. While uniqueness is recommended, it is not strictly enforced within Remote's system.
    */
   externalId?: string;
+
+  /**
+   * The steps to skip for the onboarding. We only support skipping the select_country step for now.
+   */
+  skipSteps?: ['select_country'];
+
   /**
    * The render prop function with the params passed by the useContractorOnboarding hook and the components available to use for this flow
    */

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -21,8 +21,8 @@ export type ContractorOnboardingRenderProps = {
   components: {
     BasicInformationStep: typeof BasicInformationStep;
     SelectCountryStep: typeof SelectCountryStep;
-    Back: typeof OnboardingBack;
-    Submit: typeof OnboardingSubmit;
+    BackButton: typeof OnboardingBack;
+    SubmitButton: typeof OnboardingSubmit;
   };
 };
 

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -1,3 +1,4 @@
+import { ContractOptionsStep } from '@/src/flows/ContractorOnboarding/components/ContractOptionsStep';
 import { OnboardingBack } from '@/src/flows/ContractorOnboarding/components/OnboardingBack';
 import { OnboardingSubmit } from '@/src/flows/ContractorOnboarding/components/OnboardingSubmit';
 import { PricingPlanStep } from '@/src/flows/ContractorOnboarding/components/PricingPlan';

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -28,6 +28,10 @@ export type ContractorOnboardingRenderProps = {
 
 export type ContractorOnboardingFlowProps = {
   /**
+   * The country code to use for the onboarding.
+   */
+  countryCode?: string;
+  /**
    * The render prop function with the params passed by the useContractorOnboarding hook and the components available to use for this flow
    */
   render: ({

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -31,6 +31,17 @@ export type ContractorOnboardingFlowProps = {
    * The country code to use for the onboarding.
    */
   countryCode?: string;
+
+  /**
+   * The employment id to use for the onboarding.
+   */
+  employmentId?: string;
+
+  /**
+   * Unique reference code for the employment record in a non-Remote system. This optional field links to external data sources.
+   * If not provided, it defaults to null. While uniqueness is recommended, it is not strictly enforced within Remote's system.
+   */
+  externalId?: string;
   /**
    * The render prop function with the params passed by the useContractorOnboarding hook and the components available to use for this flow
    */
@@ -47,4 +58,11 @@ export type ContractorOnboardingFlowProps = {
       basic_information?: JSFModify;
     };
   };
+
+  /**
+   * Initial values to pre-populate the form fields.
+   * These are flat field values that will be automatically mapped to the correct step.
+   * Server data will override these values. This happens when you pass employmentId and the server returns an employment object.
+   */
+  initialValues?: Record<string, unknown>;
 };

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -6,6 +6,7 @@ import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks'
 import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
 import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
 import { FlowOptions, JSFModify } from '@/src/flows/types';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 export type ContractorOnboardingRenderProps = {
   /**
@@ -80,3 +81,11 @@ export type ContractorOnboardingFlowProps = {
    */
   initialValues?: Record<string, unknown>;
 };
+
+export type PricingPlanFormPayload = $TSFixMe;
+
+export type PricingPlanResponse = $TSFixMe;
+
+export type ContractOptionsFormPayload = $TSFixMe;
+
+export type ContractOptionsResponse = $TSFixMe;

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -1,7 +1,9 @@
+import { OnboardingBack } from '@/src/flows/ContractorOnboarding/components/OnboardingBack';
+import { OnboardingSubmit } from '@/src/flows/ContractorOnboarding/components/OnboardingSubmit';
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
 import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
 import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
-import { FlowOptions, JSFModify, JSONSchemaFormType } from '@/src/flows/types';
+import { FlowOptions, JSFModify } from '@/src/flows/types';
 
 export type ContractorOnboardingRenderProps = {
   /**
@@ -14,10 +16,13 @@ export type ContractorOnboardingRenderProps = {
    * The components used in the contractor onboarding flow.
    * @see {@link BasicInformationStep}
    * @see {@link SelectCountryStep}
+   * @see {@link OnboardingBack}
    */
   components: {
     BasicInformationStep: typeof BasicInformationStep;
     SelectCountryStep: typeof SelectCountryStep;
+    Back: typeof OnboardingBack;
+    Submit: typeof OnboardingSubmit;
   };
 };
 

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -13,7 +13,11 @@ export type ContractorOnboardingRenderProps = {
    */
   components: Record<string, React.ComponentType<$TSFixMe>>;
 };
+
 export type ContractorOnboardingFlowProps = {
+  /**
+   * The render prop function with the params passed by the useContractorOnboarding hook and the components available to use for this flow
+   */
   render: ({
     contractorOnboardingBag,
     components,

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -1,5 +1,7 @@
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
-import { $TSFixMe } from '@/src/types/remoteFlows';
+import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
+import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
+import { FlowOptions } from '@/src/flows/types';
 
 export type ContractorOnboardingRenderProps = {
   /**
@@ -10,8 +12,13 @@ export type ContractorOnboardingRenderProps = {
   contractorOnboardingBag: ReturnType<typeof useContractorOnboarding>;
   /**
    * The components used in the contractor onboarding flow.
+   * @see {@link BasicInformationStep}
+   * @see {@link SelectCountryStep}
    */
-  components: Record<string, React.ComponentType<$TSFixMe>>;
+  components: {
+    BasicInformationStep: typeof BasicInformationStep;
+    SelectCountryStep: typeof SelectCountryStep;
+  };
 };
 
 export type ContractorOnboardingFlowProps = {
@@ -22,4 +29,8 @@ export type ContractorOnboardingFlowProps = {
     contractorOnboardingBag,
     components,
   }: ContractorOnboardingRenderProps) => React.ReactNode;
+  /**
+   * The options for the contractor onboarding flow.
+   */
+  options?: FlowOptions;
 };

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -1,5 +1,6 @@
 import { OnboardingBack } from '@/src/flows/ContractorOnboarding/components/OnboardingBack';
 import { OnboardingSubmit } from '@/src/flows/ContractorOnboarding/components/OnboardingSubmit';
+import { PricingPlanStep } from '@/src/flows/ContractorOnboarding/components/PricingPlan';
 import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
 import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
 import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
@@ -17,12 +18,18 @@ export type ContractorOnboardingRenderProps = {
    * @see {@link BasicInformationStep}
    * @see {@link SelectCountryStep}
    * @see {@link OnboardingBack}
+   * @see {@link PricingPlanStep}
+   * @see {@link ContractOptionsStep}
+   * @see {@link OnboardingSubmit}
+   * @see {@link OnboardingBack}
    */
   components: {
     BasicInformationStep: typeof BasicInformationStep;
     SelectCountryStep: typeof SelectCountryStep;
     BackButton: typeof OnboardingBack;
     SubmitButton: typeof OnboardingSubmit;
+    PricingPlanStep: typeof PricingPlanStep;
+    ContractOptionsStep: typeof ContractOptionsStep;
   };
 };
 

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -1,0 +1,21 @@
+import { useContractorOnboarding } from '@/src/flows/ContractorOnboarding/hooks';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+
+export type ContractorOnboardingRenderProps = {
+  /**
+   * The contractor onboarding bag returned by the useContractorOnboarding hook.
+   * This bag contains all the methods and properties needed to handle the contractor onboarding flow.
+   * @see {@link useContractorOnboarding}
+   */
+  contractorOnboardingBag: ReturnType<typeof useContractorOnboarding>;
+  /**
+   * The components used in the contractor onboarding flow.
+   */
+  components: Record<string, React.ComponentType<$TSFixMe>>;
+};
+export type ContractorOnboardingFlowProps = {
+  render: ({
+    contractorOnboardingBag,
+    components,
+  }: ContractorOnboardingRenderProps) => React.ReactNode;
+};

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -1,0 +1,7 @@
+import { Step } from '@/src/flows/useStepState';
+
+type StepKeys = 'basic_information';
+
+export const STEPS: Record<StepKeys, Step<StepKeys>> = {
+  basic_information: { index: 0, name: 'basic_information' },
+} as const;

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -1,7 +1,8 @@
 import { Step } from '@/src/flows/useStepState';
 
-type StepKeys = 'basic_information';
+type StepKeys = 'select_country' | 'basic_information';
 
 export const STEPS: Record<StepKeys, Step<StepKeys>> = {
-  basic_information: { index: 0, name: 'basic_information' },
+  select_country: { index: 0, name: 'select_country' },
+  basic_information: { index: 1, name: 'basic_information' },
 } as const;

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -6,3 +6,10 @@ export const STEPS: Record<StepKeys, Step<StepKeys>> = {
   select_country: { index: 0, name: 'select_country' },
   basic_information: { index: 1, name: 'basic_information' },
 } as const;
+
+export const STEPS_WITHOUT_SELECT_COUNTRY: Record<
+  Exclude<StepKeys, 'select_country'>,
+  Step<Exclude<StepKeys, 'select_country'>>
+> = {
+  basic_information: { index: 0, name: 'basic_information' },
+} as const;

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -1,10 +1,16 @@
 import { Step } from '@/src/flows/useStepState';
 
-type StepKeys = 'select_country' | 'basic_information';
+type StepKeys =
+  | 'select_country'
+  | 'basic_information'
+  | 'pricing_plan'
+  | 'contract_options';
 
 export const STEPS: Record<StepKeys, Step<StepKeys>> = {
   select_country: { index: 0, name: 'select_country' },
   basic_information: { index: 1, name: 'basic_information' },
+  pricing_plan: { index: 2, name: 'pricing_plan' },
+  contract_options: { index: 3, name: 'contract_options' },
 } as const;
 
 export const STEPS_WITHOUT_SELECT_COUNTRY: Record<
@@ -12,4 +18,6 @@ export const STEPS_WITHOUT_SELECT_COUNTRY: Record<
   Step<Exclude<StepKeys, 'select_country'>>
 > = {
   basic_information: { index: 0, name: 'basic_information' },
+  pricing_plan: { index: 1, name: 'pricing_plan' },
+  contract_options: { index: 2, name: 'contract_options' },
 } as const;

--- a/src/flows/Onboarding/OnboardingFlow.tsx
+++ b/src/flows/Onboarding/OnboardingFlow.tsx
@@ -1,58 +1,16 @@
-import React, { useId, useState } from 'react';
+import { useId, useState } from 'react';
 import { useOnboarding } from '@/src/flows/Onboarding/hooks';
 import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
 import { OnboardingContext } from '@/src/flows/Onboarding/context';
 import { OnboardingSubmit } from '@/src/flows/Onboarding/components/OnboardingSubmit';
 import { OnboardingBack } from '@/src/flows/Onboarding/components/OnboardingBack';
-import { OnboardingFlowParams } from '@/src/flows/Onboarding/types';
+import { OnboardingFlowProps } from '@/src/flows/Onboarding/types';
 import { OnboardingInvite } from '@/src/flows/Onboarding/components/OnboardingInvite';
 import { ContractDetailsStep } from '@/src/flows/Onboarding/components/ContractDetailsStep';
 import { BenefitsStep } from '@/src/flows/Onboarding/components/BenefitsStep';
 import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
 import { ReviewStep } from '@/src/flows/Onboarding/components/ReviewStep';
 import { SaveDraftButton } from '@/src/flows/Onboarding/components/SaveDraftButton';
-
-export type OnboardingRenderProps = {
-  /**
-   * The onboarding bag returned by the useOnboarding hook.
-   * This bag contains all the methods and properties needed to handle the onboarding flow.
-   * @see {@link useOnboarding}
-   */
-  onboardingBag: ReturnType<typeof useOnboarding>;
-  /**
-   * The components used in the onboarding flow.
-   * This includes different steps, submit button, back button.
-   * @see {@link BasicInformationStep}
-   * @see {@link ContractDetailsStep}
-   * @see {@link OnboardingSubmit}
-   * @see {@link OnboardingBack}
-   * @see {@link OnboardingInvite}
-   * @see {@link BenefitsStep}
-   * @see {@link OnboardingCreateReserve}
-   * @see {@link InvitationSection}
-   * @see {@link SelectCountryStep}
-   * @see {@link ReviewStep}
-   * @see {@link SaveDraftButton}
-   */
-  components: {
-    SubmitButton: typeof OnboardingSubmit;
-    BackButton: typeof OnboardingBack;
-    BasicInformationStep: typeof BasicInformationStep;
-    OnboardingInvite: typeof OnboardingInvite;
-    ContractDetailsStep: typeof ContractDetailsStep;
-    BenefitsStep: typeof BenefitsStep;
-    SelectCountryStep: typeof SelectCountryStep;
-    ReviewStep: typeof ReviewStep;
-    SaveDraftButton: typeof SaveDraftButton;
-  };
-};
-
-type OnboardingFlowProps = OnboardingFlowParams & {
-  render: ({
-    onboardingBag,
-    components,
-  }: OnboardingRenderProps) => React.ReactNode;
-};
 
 export const OnboardingFlow = ({
   employmentId,

--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -25,7 +25,7 @@ import {
 import { convertToCents } from '@/src/components/form/utils';
 import { useClient } from '@/src/context';
 import { selectCountryStepSchema } from '@/src/flows/Onboarding/json-schemas/selectCountryStep';
-import { OnboardingFlowParams } from '@/src/flows/Onboarding/types';
+import { OnboardingFlowProps } from '@/src/flows/Onboarding/types';
 import { FlowOptions, JSONSchemaFormType } from '@/src/flows/types';
 import { findFieldsByType } from '@/src/flows/utils';
 import { JSFFieldset } from '@/src/types/remoteFlows';
@@ -255,7 +255,7 @@ export const useJSONSchemaForm = ({
 export const useBenefitOffersSchema = (
   employmentId: string,
   fieldValues: FieldValues,
-  options: OnboardingFlowParams['options'],
+  options: OnboardingFlowProps['options'],
 ) => {
   const jsonSchemaQueryParam = options?.jsonSchemaVersion
     ?.benefit_offers_form_schema
@@ -308,7 +308,7 @@ export const useBenefitOffersSchema = (
  * @returns
  */
 export const useCreateEmployment = (
-  options?: OnboardingFlowParams['options'],
+  options?: OnboardingFlowProps['options'],
 ) => {
   const { client } = useClient();
   const jsonSchemaQueryParam = options?.jsonSchemaVersion?.form_schema
@@ -335,7 +335,7 @@ export const useCreateEmployment = (
 };
 
 export const useUpdateEmployment = (
-  options?: OnboardingFlowParams['options'],
+  options?: OnboardingFlowProps['options'],
 ) => {
   const { client } = useClient();
   const jsonSchemaQueryParams = {
@@ -375,7 +375,7 @@ export const useUpdateEmployment = (
 };
 
 export const useUpdateBenefitsOffers = (
-  options?: OnboardingFlowParams['options'],
+  options?: OnboardingFlowProps['options'],
 ) => {
   const { client } = useClient();
   return useMutation({

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/src/components/form/utils';
 import { mutationToPromise } from '@/src/lib/mutations';
 import { FieldValues } from 'react-hook-form';
-import { OnboardingFlowParams } from '@/src/flows/Onboarding/types';
+import { OnboardingFlowProps } from '@/src/flows/Onboarding/types';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import mergeWith from 'lodash.mergewith';
 import {
@@ -40,7 +40,7 @@ import { AnnualGrossSalary } from '@/src/flows/Onboarding/components/AnnualGross
 import { $TSFixMe, JSFField, JSFFieldset, Meta } from '@/src/types/remoteFlows';
 import { EquityPriceDetails } from '@/src/flows/Onboarding/components/EquityPriceDetails';
 
-type OnboardingHookProps = OnboardingFlowParams;
+type OnboardingHookProps = Omit<OnboardingFlowProps, 'render'>;
 
 const jsonSchemaToEmployment: Partial<
   Record<JSONSchemaFormType, keyof Employment>

--- a/src/flows/Onboarding/index.ts
+++ b/src/flows/Onboarding/index.ts
@@ -1,5 +1,4 @@
 export { OnboardingFlow } from './OnboardingFlow';
-export type { OnboardingRenderProps } from './OnboardingFlow';
 export type { OnboardingInviteProps } from './components/OnboardingInvite';
 export type {
   BenefitsFormPayload,
@@ -10,4 +9,5 @@ export type {
   CreditRiskStatus,
   Employment,
   CreditRiskState,
+  OnboardingRenderProps,
 } from './types';

--- a/src/flows/Onboarding/tests/SaveDraftButton.test.tsx
+++ b/src/flows/Onboarding/tests/SaveDraftButton.test.tsx
@@ -1,7 +1,4 @@
-import {
-  OnboardingFlow,
-  OnboardingRenderProps,
-} from '@/src/flows/Onboarding/OnboardingFlow';
+import { OnboardingFlow } from '@/src/flows/Onboarding/OnboardingFlow';
 import {
   basicInformationSchema,
   benefitOffersResponse,
@@ -12,7 +9,10 @@ import {
   employmentResponse,
 } from '@/src/flows/Onboarding/tests/fixtures';
 import { fillBasicInformation } from '@/src/flows/Onboarding/tests/helpers';
-import { OnboardingFlowParams } from '@/src/flows/Onboarding/types';
+import {
+  OnboardingFlowProps,
+  OnboardingRenderProps,
+} from '@/src/flows/Onboarding/types';
 import { FormFieldsProvider } from '@/src/RemoteFlowsProvider';
 import { server } from '@/src/tests/server';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -119,7 +119,7 @@ const defaultProps = {
   countryCode: 'PRT',
   options: {},
   render: mockRender,
-  skipSteps: ['select_country'] as OnboardingFlowParams['skipSteps'],
+  skipSteps: ['select_country'] as OnboardingFlowProps['skipSteps'],
 };
 
 describe('SaveDraftButton', () => {

--- a/src/flows/Onboarding/types.ts
+++ b/src/flows/Onboarding/types.ts
@@ -2,9 +2,54 @@ import {
   EmploymentCreateParams,
   Employment as EmploymentResponse,
 } from '@/src/client';
+import { BasicInformationStep } from '@/src/flows/Onboarding/components/BasicInformationStep';
+import { OnboardingBack } from '@/src/flows/Onboarding/components/OnboardingBack';
+import { OnboardingInvite } from '@/src/flows/Onboarding/components/OnboardingInvite';
+import { ContractDetailsStep } from '@/src/flows/Onboarding/components/ContractDetailsStep';
+import { OnboardingSubmit } from '@/src/flows/Onboarding/components/OnboardingSubmit';
+import { BenefitsStep } from '@/src/flows/Onboarding/components/BenefitsStep';
+import { useOnboarding } from '@/src/flows/Onboarding/hooks';
 import { FlowOptions, JSFModify } from '@/src/flows/types';
+import { SelectCountryStep } from '@/src/flows/Onboarding/components/SelectCountryStep';
+import { ReviewStep } from '@/src/flows/Onboarding/components/ReviewStep';
+import { SaveDraftButton } from '@/src/flows/Onboarding/components/SaveDraftButton';
 
-export type OnboardingFlowParams = {
+export type OnboardingRenderProps = {
+  /**
+   * The onboarding bag returned by the useOnboarding hook.
+   * This bag contains all the methods and properties needed to handle the onboarding flow.
+   * @see {@link useOnboarding}
+   */
+  onboardingBag: ReturnType<typeof useOnboarding>;
+  /**
+   * The components used in the onboarding flow.
+   * This includes different steps, submit button, back button.
+   * @see {@link BasicInformationStep}
+   * @see {@link ContractDetailsStep}
+   * @see {@link OnboardingSubmit}
+   * @see {@link OnboardingBack}
+   * @see {@link OnboardingInvite}
+   * @see {@link BenefitsStep}
+   * @see {@link OnboardingCreateReserve}
+   * @see {@link InvitationSection}
+   * @see {@link SelectCountryStep}
+   * @see {@link ReviewStep}
+   * @see {@link SaveDraftButton}
+   */
+  components: {
+    SubmitButton: typeof OnboardingSubmit;
+    BackButton: typeof OnboardingBack;
+    BasicInformationStep: typeof BasicInformationStep;
+    OnboardingInvite: typeof OnboardingInvite;
+    ContractDetailsStep: typeof ContractDetailsStep;
+    BenefitsStep: typeof BenefitsStep;
+    SelectCountryStep: typeof SelectCountryStep;
+    ReviewStep: typeof ReviewStep;
+    SaveDraftButton: typeof SaveDraftButton;
+  };
+};
+
+export type OnboardingFlowProps = {
   /**
    * The country code to use for the onboarding.
    */
@@ -47,6 +92,13 @@ export type OnboardingFlowParams = {
       benefits?: JSFModify;
     };
   };
+  /**
+   * The render prop function with the params passed by the useOnboarding hook and the components available to use for this flow
+   */
+  render: ({
+    onboardingBag,
+    components,
+  }: OnboardingRenderProps) => React.ReactNode;
 };
 
 export type SelectCountryFormPayload = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ export type { CostCalculatorFlowProps } from '@/src/flows/CostCalculator';
 export * from '@/src/flows/ContractAmendment';
 export * from '@/src/flows/Termination';
 export * from '@/src/flows/Onboarding';
+export * from '@/src/flows/ContractorOnboarding';
 
 export type * from '@/src/flows/CostCalculator/types';
 export * from '@/src/common/api';


### PR DESCRIPTION
I created `ContractorOnboardingFlow`, I decided to go this way as it let us experiment with it, see what are the requirements, we don't affect the current `OnboardingFlow` that we have in production.

I believe once it's done or the main requirements have been lay out, we can think if it makes sense to reuse code from one or the other as we have tons of repeated code at this moment.

