### PR TITLE
chore(renovate) - improve rules

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "^25.6.0",
-        "@types/react-dom": "^19.0.4",
+        "@types/react-dom": "^19.2.3",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^6.0.1",
         "nodemon": "^3.1.14",
@@ -88,7 +88,7 @@
         "@types/lodash.omit": "^4.5.9",
         "@types/lodash.omitby": "^4.6.9",
         "@types/node": "^22.19.1",
-        "@types/react": "^19.2.6",
+        "@types/react": "^19.2.14",
         "@vitest/coverage-istanbul": "^4.1.3",
         "chalk": "^5.3.0",
         "filesize": "^10.1.0",
@@ -826,21 +826,23 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
-      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -1176,10 +1178,11 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/example/package.json
+++ b/example/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@playwright/test": "1.59.1",
     "@types/node": "^25.6.0",
-    "@types/react-dom": "^19.0.4",
+    "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",
     "nodemon": "^3.1.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@types/lodash.omit": "^4.5.9",
         "@types/lodash.omitby": "^4.6.9",
         "@types/node": "^22.19.1",
-        "@types/react": "^19.2.6",
+        "@types/react": "^19.2.14",
         "@vitest/coverage-istanbul": "^4.1.3",
         "chalk": "^5.3.0",
         "filesize": "^10.1.0",
@@ -4548,9 +4548,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@types/lodash.omit": "^4.5.9",
     "@types/lodash.omitby": "^4.6.9",
     "@types/node": "^22.19.1",
-    "@types/react": "^19.2.6",
+    "@types/react": "^19.2.14",
     "@vitest/coverage-istanbul": "^4.1.3",
     "chalk": "^5.3.0",
     "filesize": "^10.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -2,14 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "rangeStrategy": "bump",
+
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
+
   "vulnerabilityAlerts": {
     "enabled": true,
     "groupName": null,
     "minimumReleaseAge": "0 days"
   },
+
   "semanticCommits": "enabled",
+
   "packageRules": [
     {
       "description": "Enforce 7-day wait for all non-security updates",
@@ -18,7 +22,6 @@
     },
     {
       "description": "Security updates bypass wait time",
-      "matchDepTypes": ["dependencies", "devDependencies"],
       "matchDatasources": ["npm"],
       "vulnerabilityAlerts": {
         "enabled": true
@@ -28,23 +31,25 @@
       "semanticCommitScope": "security"
     },
     {
-      "description": "Semantic commit types based on update type",
+      "description": "DevDependencies always use chore (all update types)",
+      "matchDepTypes": ["devDependencies"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps-dev",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Production major updates trigger minor version bump",
+      "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["major"],
       "semanticCommitType": "feat",
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Minor and patch updates as chores",
+      "description": "Production minor/patch updates are chores",
+      "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
-    },
-    {
-      "description": "DevDependencies updates",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps-dev"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,48 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "minimumReleaseAge": "7 days",
   "rangeStrategy": "bump",
-  "semanticCommits": "enabled",
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "vulnerabilityAlerts": {
     "enabled": true,
     "groupName": null,
-    "minimumReleaseAge": "0 days",
-    "semanticCommitType": "fix",
-    "semanticCommitScope": "security"
+    "minimumReleaseAge": "0 days"
   },
+  "semanticCommits": "enabled",
   "packageRules": [
     {
+      "description": "Enforce 7-day wait for all non-security updates",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Security updates bypass wait time",
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "matchDatasources": ["npm"],
+      "vulnerabilityAlerts": {
+        "enabled": true
+      },
+      "minimumReleaseAge": "0 days",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "security"
+    },
+    {
+      "description": "Semantic commit types based on update type",
       "matchUpdateTypes": ["major"],
       "semanticCommitType": "feat",
       "semanticCommitScope": "deps"
     },
     {
+      "description": "Minor and patch updates as chores",
       "matchUpdateTypes": ["minor", "patch"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
     },
     {
+      "description": "DevDependencies updates",
       "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps-dev"
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dependency type-version bumps and Renovate configuration; no runtime or production logic is modified.
> 
> **Overview**
> Updates TypeScript typings by bumping `@types/react` and `@types/react-dom` (plus lockfile updates like `csstype`) in both the root package and the `example` app.
> 
> Refactors `renovate.json` to enforce a default 7-day wait for non-security updates, allow immediate security/vulnerability updates with `fix(security)` commits, and standardize semantic commit types/scopes for `dependencies` vs `devDependencies` (including adding `internalChecksFilter: strict`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85db318a24659d5ce401ed413d83413bd07ce208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->