### PR TITLE
chore(ci) - update chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@types/node": "^22.19.1",
         "@types/react": "^19.2.14",
         "@vitest/coverage-istanbul": "^4.1.3",
-        "chalk": "^5.3.0",
+        "chalk": "^5.6.2",
         "filesize": "^10.1.0",
         "glob": "^13.0.6",
         "gzip-size": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@types/node": "^22.19.1",
     "@types/react": "^19.2.14",
     "@vitest/coverage-istanbul": "^4.1.3",
-    "chalk": "^5.3.0",
+    "chalk": "^5.6.2",
     "filesize": "^10.1.0",
     "glob": "^13.0.6",
     "gzip-size": "^7.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
 
+  "postUpdateOptions": ["npmDedupe"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": false
+  },
+
   "vulnerabilityAlerts": {
     "enabled": true,
     "groupName": null,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency/tooling-only change: updates `chalk` and adjusts Renovate settings without affecting runtime/library code paths.
> 
> **Overview**
> Bumps the `chalk` dev dependency from `^5.3.0` to `^5.6.2` (updating both `package.json` and `package-lock.json`).
> 
> Updates `renovate.json` to run `npmDedupe` after updates and to enable scheduled lockfile maintenance PRs (not auto-merged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4a94cbfba7a31c6f76ab58158618c195211afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->