### PR TITLE
fix(ci) - fix ci & renovate

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Run CI checks and tests
         run: npm run ci
@@ -90,11 +90,11 @@ jobs:
           node-version: '24'
 
       - name: Install main package dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Install example/ dependencies
         working-directory: ./example
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Install Playwright
         working-directory: ./example

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install example/ dependencies
         working-directory: ./example
-        run: npm ci --include=optional
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Install Playwright
         working-directory: ./example

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Run tests with coverage
         run: npm run test:coverage
@@ -42,7 +42,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install main package dependencies
         run: npm ci --include=optional --ignore-scripts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Run checks
         run: npm run build && npm run check-format && npm run check-exports && npm run lint && npm run type-check
@@ -56,7 +56,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Download current coverage
         uses: actions/download-artifact@v4
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install dependencies (base)
         if: steps.check-scripts.outputs.exists == 'true' && steps.check-base-scripts.outputs.exists == 'true'
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Run tests with coverage (base)
         if: steps.check-scripts.outputs.exists == 'true' && steps.check-base-scripts.outputs.exists == 'true'
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install dependencies (PR branch)
         if: steps.check-scripts.outputs.exists == 'true'
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Download current coverage
         uses: actions/download-artifact@v4
@@ -265,11 +265,11 @@ jobs:
           node-version: '20'
 
       - name: Install main package dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Install example/ dependencies
         working-directory: ./example
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Install Playwright
         working-directory: ./example

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Install example/ dependencies
         working-directory: ./example
-        run: npm ci --include=optional
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Install Playwright
         working-directory: ./example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Check if version changed
         id: version-check

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --include=optional
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Build current branch
         run: npm run build
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies (base)
         if: steps.check_script.outputs.exists == 'true'
         working-directory: base
-        run: npm ci --include=optional
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Build base branch
         if: steps.check_script.outputs.exists == 'true'

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Build current branch
         run: npm run build
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies (base)
         if: steps.check_script.outputs.exists == 'true'
         working-directory: base
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Build base branch
         if: steps.check_script.outputs.exists == 'true'

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --include=optional
+        run: npm ci --include=optional --ignore-scripts
 
       - name: Build project
         run: npm run build

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Build project
         run: npm run build

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@playwright/test": "1.59.1",
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.12.2",
         "@types/react-dom": "^19.2.3",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^6.0.1",
@@ -87,10 +87,10 @@
         "@types/lodash.mergewith": "^4.6.9",
         "@types/lodash.omit": "^4.5.9",
         "@types/lodash.omitby": "^4.6.9",
-        "@types/node": "^22.19.1",
+        "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@vitest/coverage-istanbul": "^4.1.3",
-        "chalk": "^5.3.0",
+        "chalk": "^5.6.2",
         "filesize": "^10.1.0",
         "glob": "^13.0.6",
         "gzip-size": "^7.0.0",
@@ -810,13 +810,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/prismjs": {
@@ -3138,9 +3138,9 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.12.2",
     "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@types/lodash.mergewith": "^4.6.9",
         "@types/lodash.omit": "^4.5.9",
         "@types/lodash.omitby": "^4.6.9",
-        "@types/node": "^22.19.1",
+        "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@vitest/coverage-istanbul": "^4.1.3",
         "chalk": "^5.6.2",
@@ -4538,13 +4538,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
-      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -8970,9 +8970,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@types/lodash.mergewith": "^4.6.9",
     "@types/lodash.omit": "^4.5.9",
     "@types/lodash.omitby": "^4.6.9",
-    "@types/node": "^22.19.1",
+    "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@vitest/coverage-istanbul": "^4.1.3",
     "chalk": "^5.6.2",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
 
+  "npmrc": "optional=true\ninclude=optional",
+
   "postUpdateOptions": ["npmDedupe"],
   "lockFileMaintenance": {
     "enabled": true,
@@ -56,6 +58,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Preserve optional dependencies in lockfile",
+      "matchPackageNames": ["esbuild", "@esbuild/**"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI install semantics to always include optional dependencies and updates type/lockfile dependencies, which could affect build/test determinism across workflows.
> 
> **Overview**
> **CI workflows now install optional dependencies consistently.** All GitHub Actions jobs switch to `npm ci --include=optional --ignore-scripts` (including `example/` installs), and PR E2E tests are aligned to Node `24`.
> 
> **Tooling and dependency metadata are updated to match Node 24 behavior.** Root and `example/` bump `@types/node` to `^24.12.2` (with corresponding lockfile changes, including `undici-types`), and Renovate is updated to set `npmrc` to `optional=true`/`include=optional` plus a rule to preserve optional `esbuild` deps in the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8cfbd35132b8c94d2147c88330e52aba0f0718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->