### PR TITLE
feat(deps) - upgrade react-day-picker from v8 to v9 with improved styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "lodash.omitby": "^4.6.0",
         "lucide-react": "^1.7.0",
         "postcss": "^8.5.9",
-        "react-day-picker": "^8.10.1",
+        "react-day-picker": "^9.14.0",
         "react-flagpack": "^2.0.6",
         "react-hook-form": "^7.54.2",
         "tailwind-merge": "^3.5.0",
@@ -547,6 +547,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -3961,6 +3967,15 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tailwindcss/cli": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.2.2.tgz",
@@ -5387,6 +5402,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7606,16 +7627,35 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
-      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0 || ^3.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-day-picker/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.1.0",
         "dompurify": "^3.3.3",
         "lodash.capitalize": "^4.2.1",
         "lodash.get": "^4.4.2",
@@ -3361,16 +3361,6 @@
         "node": ">=18.14.0"
       }
     },
-    "node_modules/@remoteoss/remote-json-schema-form-kit/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.13",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
@@ -5395,9 +5385,10 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -7646,16 +7637,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-day-picker/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "lodash.omitby": "^4.6.0",
     "lucide-react": "^1.7.0",
     "postcss": "^8.5.9",
-    "react-day-picker": "^8.10.1",
+    "react-day-picker": "^9.14.0",
     "react-flagpack": "^2.0.6",
     "react-hook-form": "^7.54.2",
     "tailwind-merge": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.1.0",
     "dompurify": "^3.3.3",
     "lodash.capitalize": "^4.2.1",
     "lodash.get": "^4.4.2",

--- a/src/components/form/fields/default/DatePickerFieldDefault.tsx
+++ b/src/components/form/fields/default/DatePickerFieldDefault.tsx
@@ -64,8 +64,9 @@ export function DatePickerFieldDefault({
             mode='single'
             className='RemoteFlows__DatepickerField__Calendar'
             selected={field.value ? new Date(field.value) : undefined}
-            onSelect={(date) => {
-              field.onChange(date ? format(date, 'yyyy-MM-dd') : null);
+            onDayClick={(day) => {
+              const formattedDate = format(day, 'yyyy-MM-dd');
+              field.onChange(formattedDate);
               setOpen(false);
             }}
             defaultMonth={minDateValue}

--- a/src/components/form/fields/default/DatePickerFieldDefault.tsx
+++ b/src/components/form/fields/default/DatePickerFieldDefault.tsx
@@ -11,13 +11,13 @@ import { CalendarIcon } from 'lucide-react';
 import { format } from 'date-fns';
 import {
   Popover,
-  PopoverClose,
   PopoverContent,
   PopoverTrigger,
 } from '@/src/components/ui/popover';
 import { cn } from '@/src/lib/utils';
 import { Calendar } from '@/src/components/ui/calendar';
 import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
+import { useState } from 'react';
 
 export function DatePickerFieldDefault({
   field,
@@ -27,6 +27,8 @@ export function DatePickerFieldDefault({
   const { name, label, description, minDate, maxDate } = fieldData;
   const minDateValue = minDate ? new Date(minDate) : undefined;
   const maxDateValue = maxDate ? new Date(maxDate) : undefined;
+  const [open, setOpen] = useState(false);
+
   return (
     <FormItem
       data-field={name}
@@ -35,7 +37,7 @@ export function DatePickerFieldDefault({
       <FormLabel className='RemoteFlows__DatePickerField__Label'>
         {label}
       </FormLabel>
-      <Popover>
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <FormControl>
             <div>
@@ -64,13 +66,9 @@ export function DatePickerFieldDefault({
             selected={field.value ? new Date(field.value) : undefined}
             onSelect={(date) => {
               field.onChange(date ? format(date, 'yyyy-MM-dd') : null);
+              setOpen(false);
             }}
             defaultMonth={minDateValue}
-            components={{
-              DayContent: (props) => {
-                return <PopoverClose>{props.date.getDate()}</PopoverClose>;
-              },
-            }}
             disabled={(date: Date) => {
               if (minDateValue && date < minDateValue) return true;
               if (maxDateValue && date > maxDateValue) return true;

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -18,52 +18,52 @@ function Calendar({
       classNames={{
         months: 'flex flex-col sm:flex-row gap-2',
         month: 'flex flex-col gap-4',
-        caption: 'flex justify-center pt-1 relative items-center w-full',
+        month_caption: 'flex justify-center pt-1 relative items-center w-full',
         caption_label: 'text-sm font-medium',
         nav: 'flex items-center gap-1',
-        nav_button: cn(
+        button_previous: cn(
           buttonVariants({ variant: 'outline' }),
-          'size-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+          'size-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1',
         ),
-        nav_button_previous: 'absolute left-1',
-        nav_button_next: 'absolute right-1',
-        table: 'w-full border-collapse space-x-1',
-        head_row: 'flex',
-        head_cell:
+        button_next: cn(
+          buttonVariants({ variant: 'outline' }),
+          'size-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1',
+        ),
+        month_grid: 'w-full border-collapse space-x-1',
+        weekdays: 'flex',
+        weekday:
           'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
-        row: 'flex w-full mt-2',
-        cell: cn(
+        week: 'flex w-full mt-2',
+        day: cn(
           'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
           props.mode === 'range'
             ? '[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md'
             : '[&:has([aria-selected])]:rounded-md',
         ),
-        day: cn(
+        day_button: cn(
           buttonVariants({ variant: 'ghost' }),
           'size-8 p-0 font-normal aria-selected:opacity-100',
         ),
-        day_range_start:
+        range_start:
           'day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground',
-        day_range_end:
+        range_end:
           'day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground',
-        day_selected:
+        selected:
           'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
-        day_today: 'bg-accent text-accent-foreground',
-        day_outside:
+        today: 'bg-accent text-accent-foreground',
+        outside:
           'day-outside text-muted-foreground aria-selected:text-muted-foreground',
-        day_disabled: 'text-muted-foreground opacity-50',
-        day_range_middle:
+        disabled: 'text-muted-foreground opacity-50',
+        range_middle:
           'aria-selected:bg-accent aria-selected:text-accent-foreground',
-        day_hidden: 'invisible',
+        hidden: 'invisible',
         ...classNames,
       }}
       components={{
-        IconLeft: ({ className, ...props }) => (
-          <ChevronLeft className={cn('size-4', className)} {...props} />
-        ),
-        IconRight: ({ className, ...props }) => (
-          <ChevronRight className={cn('size-4', className)} {...props} />
-        ),
+        Chevron: ({ orientation, className, ...props }) => {
+          const Icon = orientation === 'left' ? ChevronLeft : ChevronRight;
+          return <Icon className={cn('size-4', className)} {...props} />;
+        },
       }}
       {...props}
     />

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -3,71 +3,45 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { DayPicker } from 'react-day-picker';
 
 import { cn } from '@/src/lib/utils';
-import { buttonVariants } from '@/src/components/ui/button';
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
 function Calendar({
   className,
   classNames,
   showOutsideDays = true,
   ...props
-}: React.ComponentProps<typeof DayPicker>) {
+}: CalendarProps) {
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn('p-3', className)}
       classNames={{
-        months: 'flex flex-col sm:flex-row gap-2',
-        month: 'flex flex-col gap-4',
-        month_caption: 'flex justify-center pt-1 relative items-center w-full',
-        caption_label: 'text-sm font-medium',
-        nav: 'flex items-center gap-1',
-        button_previous: cn(
-          buttonVariants({ variant: 'outline' }),
-          'size-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1',
-        ),
-        button_next: cn(
-          buttonVariants({ variant: 'outline' }),
-          'size-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1',
-        ),
-        month_grid: 'w-full border-collapse space-x-1',
+        months: 'flex flex-col sm:flex-row gap-4',
+        month: 'flex flex-col gap-y-4',
+        month_caption: 'flex h-8 w-full items-center justify-center relative',
+        caption_label: 'font-medium text-sm',
+        nav: 'flex items-center justify-between w-full',
+        month_grid: 'w-full border-collapse mt-4',
         weekdays: 'flex',
         weekday:
-          'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
+          'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
         week: 'flex w-full mt-2',
-        day: cn(
-          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
-          props.mode === 'range'
-            ? '[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md'
-            : '[&:has([aria-selected])]:rounded-md',
-        ),
-        day_button: cn(
-          buttonVariants({ variant: 'ghost' }),
-          'size-8 p-0 font-normal aria-selected:opacity-100',
-        ),
-        range_start:
-          'day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground',
-        range_end:
-          'day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground',
-        selected:
-          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
-        today: 'bg-accent text-accent-foreground',
-        outside:
-          'day-outside text-muted-foreground aria-selected:text-muted-foreground',
-        disabled: 'text-muted-foreground opacity-50',
-        range_middle:
-          'aria-selected:bg-accent aria-selected:text-accent-foreground',
-        hidden: 'invisible',
+        day: 'h-9 w-9 text-center text-sm p-0 relative',
         ...classNames,
       }}
       components={{
-        Chevron: ({ orientation, className, ...props }) => {
-          const Icon = orientation === 'left' ? ChevronLeft : ChevronRight;
-          return <Icon className={cn('size-4', className)} {...props} />;
+        Chevron: ({ orientation, ...props }) => {
+          if (orientation === 'left') {
+            return <ChevronLeft {...props} />;
+          }
+          return <ChevronRight {...props} />;
         },
       }}
       {...props}
     />
   );
 }
+Calendar.displayName = 'Calendar';
 
 export { Calendar };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,4 +104,123 @@
   .RemoteFlows__EstimationResults__Headers__Label {
     @apply text-sm text-[#27272A] text-right;
   }
+
+  /* React Day Picker v9 Styling */
+
+  /* Base day button styling */
+  .rdp-button {
+    height: 2.25rem;
+    width: 2.25rem;
+    padding: 0;
+    font-weight: 400;
+    border-radius: 0.375rem;
+    cursor: pointer;
+  }
+
+  /* Hover state for non-disabled, non-selected days */
+  .rdp-button:hover:not([disabled]):not([aria-selected='true']) {
+    background-color: var(--color-accent);
+    color: var(--color-accent-foreground);
+  }
+
+  /* Selected and today states (use same accent styling with bold weight for selected) */
+  .rdp-button[aria-selected='true'],
+  .rdp-day_selected .rdp-button,
+  .rdp-day_today:not(.rdp-day_selected) .rdp-button {
+    background-color: var(--color-accent);
+    color: var(--color-accent-foreground);
+  }
+
+  .rdp-button[aria-selected='true'],
+  .rdp-day_selected .rdp-button {
+    font-weight: 600;
+  }
+
+  /* Disabled days */
+  .rdp-button[disabled],
+  .rdp-day_disabled .rdp-button {
+    color: var(--color-muted-foreground);
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: auto;
+  }
+
+  /* Outside days (days from previous/next month) */
+  .rdp-day_outside .rdp-button {
+    color: var(--color-muted-foreground);
+    opacity: 0.5;
+  }
+
+  .rdp-day_outside.rdp-day_selected .rdp-button {
+    opacity: 0.3;
+  }
+
+  /* Weekday headers */
+  .rdp-head_cell {
+    width: 2.25rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-muted-foreground);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding-bottom: 0.5rem;
+  }
+
+  /* Caption container - holds title and navigation buttons */
+  .rdp-caption {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem 0;
+    margin-bottom: 0.5rem;
+  }
+
+  /* Caption title - absolutely centered */
+  .rdp-caption > div[aria-live='polite'] {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  /* Navigation container - use display: contents to not affect layout */
+  .rdp-nav {
+    display: contents;
+  }
+
+  /* Navigation buttons - positioned at far left and right */
+  .rdp-nav_button {
+    position: absolute;
+    height: 1.75rem;
+    width: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    padding: 0;
+    opacity: 0.75;
+    cursor: pointer;
+    color: var(--color-foreground);
+  }
+
+  .rdp-nav_button_previous {
+    left: 0;
+  }
+
+  .rdp-nav_button_next {
+    right: 0;
+  }
+
+  .rdp-nav_button:hover {
+    opacity: 1;
+    background-color: var(--color-accent);
+  }
+
+  /* Navigation icons - smaller chevrons */
+  .rdp-nav_icon {
+    height: 0.75rem;
+    width: 0.75rem;
+  }
 }


### PR DESCRIPTION
## Summary

- Upgrade react-day-picker from v8 to v9
- Update date-fns from 3.6.0 to 4.1.0
- Improve calendar UI with better styling and UX

## Changes

### react-day-picker v9 Upgrade
- Updated to latest react-day-picker v9 API
- Removed deprecated v8 classNames and components
- Simplified component structure with new v9 patterns

### Calendar UI Improvements
- **Navigation buttons**: Added bordered buttons with hover effects, positioned at far left and right
- **Centered title**: Absolutely positioned month/year title for perfect centering
- **Smaller chevrons**: Reduced icon size from 1rem to 0.75rem for cleaner look
- **Styled weekday headers**: Added uppercase text, letter-spacing, and better typography
- **Improved spacing**: Added proper padding and margins throughout

### Dependencies
- Updated date-fns from 3.6.0 to 4.1.0 (latest)

## Visual Changes

The calendar now has:
- Bordered navigation arrows on far left and right
- Perfectly centered month/year title
- Prettier weekday headers (Su, Mo, Tu, etc.) with uppercase styling
- Better overall spacing and visual hierarchy

## Test plan

- [x] Calendar renders correctly with new styling
- [x] Navigation buttons work (previous/next month)
- [x] Date selection works as expected
- [x] Hover states display correctly
- [x] Disabled dates are properly styled
- [x] Selected dates are highlighted correctly
- [x] Outside days (previous/next month) are dimmed


<img width="1146" height="402" alt="image" src="https://github.com/user-attachments/assets/a8e99ca8-d7d1-4dc4-b782-0650b26b17da" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to major `react-day-picker` upgrade (v8→v9) and `date-fns` v4 bump, which can subtly change calendar behavior, styling, and date handling.
> 
> **Overview**
> Upgrades the calendar stack by bumping `react-day-picker` from v8 to v9 and `date-fns` to v4, updating the lockfile with new transitive deps.
> 
> Refactors the shared `Calendar` wrapper to the v9 API (new `classNames` keys and `Chevron` component) and moves most visual treatment to new global `.rdp-*` CSS rules for navigation, weekdays, hover/selected/disabled states, and layout.
> 
> Updates `DatePickerFieldDefault` to explicitly control popover open state and to close the popover immediately on day click (replacing the prior `PopoverClose`-wrapped day content).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd49af90b89bb2d154843f70ef7284af26071769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->