### PR TITLE
fix(ci) - disable automatic nodejs updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,13 @@
       "semanticCommitScope": "deps"
     },
     {
+      "description": "Disable automatic Node.js engine updates (handle manually for major releases)",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "enabled": false
+    },
+    {
       "description": "Preserve optional dependencies in lockfile",
       "matchPackageNames": ["esbuild", "@esbuild/**"],
       "enabled": true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: configuration-only change that just stops Renovate from proposing `node` engine updates, with no runtime or application logic impact.
> 
> **Overview**
> Disables Renovate updates for the npm `engines.node` constraint by adding a package rule that matches `node` under `engines` and sets `enabled: false`, so Node.js engine/version bumps are handled manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c7d28b6bc03fcc62cfad60431f01ed71b044a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->