### PR TITLE
fix(oxlint) - fix any

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Run CI checks and tests
         run: npm run ci
 
+      - name: Install example dependencies
+        working-directory: ./example
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Lint and type-check example app
+        working-directory: ./example
+        run: npm run lint && npm run type-check
+
   deploy-remote-flows:
     name: Deploy Remote Flows Preview
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -23,6 +23,23 @@ jobs:
       - name: Run CI checks and tests
         run: npm run ci
 
+  example-checks:
+    name: Example App Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.1'
+
+      - name: Install main package dependencies
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Build main package
+        run: npm run build
+
       - name: Install example dependencies
         working-directory: ./example
         run: npm ci --include=optional --ignore-scripts
@@ -92,7 +109,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [unit-tests, deploy-remote-flows, deploy-example-app]
+    needs: [unit-tests, example-checks, deploy-remote-flows, deploy-example-app]
     steps:
       - uses: actions/checkout@v6
 
@@ -145,7 +162,7 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [unit-tests, e2e-tests]
+    needs: [unit-tests, example-checks, e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -27,9 +27,13 @@ jobs:
         working-directory: ./example
         run: npm ci --include=optional --ignore-scripts
 
-      - name: Lint and type-check example app
+      - name: Lint example app
         working-directory: ./example
-        run: npm run lint && npm run type-check
+        run: npm run lint
+
+      - name: Type-check example app
+        working-directory: ./example
+        run: npm run type-check
 
   deploy-remote-flows:
     name: Deploy Remote Flows Preview

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Run checks
         run: npm run build && npm run check-format && npm run check-exports && npm run lint && npm run type-check
 
+      - name: Install example dependencies
+        working-directory: ./example
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Lint and type-check example app
+        working-directory: ./example
+        run: npm run lint && npm run type-check
+
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -284,7 +284,13 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [checks-and-tests, example-checks, deploy-remote-flows, deploy-example-app]
+    needs:
+      [
+        checks-and-tests,
+        example-checks,
+        deploy-remote-flows,
+        deploy-example-app,
+      ]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,18 +24,6 @@ jobs:
       - name: Run checks
         run: npm run build && npm run check-format && npm run check-exports && npm run lint && npm run type-check
 
-      - name: Install example dependencies
-        working-directory: ./example
-        run: npm ci --include=optional --ignore-scripts
-
-      - name: Lint example app
-        working-directory: ./example
-        run: npm run lint
-
-      - name: Type-check example app
-        working-directory: ./example
-        run: npm run type-check
-
       - name: Run tests with coverage
         run: npm run test:coverage
 
@@ -51,6 +39,35 @@ jobs:
           name: current-coverage
           path: out/current-coverage.json
           retention-days: 1
+
+  example-checks:
+    name: Example App Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.1'
+
+      - name: Install main package dependencies
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Build main package
+        run: npm run build
+
+      - name: Install example dependencies
+        working-directory: ./example
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Lint example app
+        working-directory: ./example
+        run: npm run lint
+
+      - name: Type-check example app
+        working-directory: ./example
+        run: npm run type-check
 
   coverage-compare:
     name: Compare Coverage
@@ -267,7 +284,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [checks-and-tests, deploy-remote-flows, deploy-example-app]
+    needs: [checks-and-tests, example-checks, deploy-remote-flows, deploy-example-app]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,9 +28,13 @@ jobs:
         working-directory: ./example
         run: npm ci --include=optional --ignore-scripts
 
-      - name: Lint and type-check example app
+      - name: Lint example app
         working-directory: ./example
-        run: npm run lint && npm run type-check
+        run: npm run lint
+
+      - name: Type-check example app
+        working-directory: ./example
+        run: npm run type-check
 
       - name: Run tests with coverage
         run: npm run test:coverage

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,6 +8,7 @@
   "rules": {
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "typescript/no-explicit-any": "error"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "postinstall": "react-flagpack",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "type-check": "tsc -b --noEmit"
   },
   "dependencies": {
     "@remoteoss/remote-flows": "file://..",

--- a/example/src/MagicLinkTest.tsx
+++ b/example/src/MagicLinkTest.tsx
@@ -21,7 +21,7 @@ const MagicLinkTestContent = () => {
   const [userId, setUserId] = useState(import.meta.env.VITE_USER_ID || '');
   const [status, setStatus] = useState<StatusType>('idle');
   const [errorMessage, setErrorMessage] = useState('');
-  const timeoutRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -99,7 +99,8 @@ async function getCommitsFromGitHubAPI(): Promise<Commit[]> {
     // Get all commits, not just merge commits
     const commits = data.commits
       .filter(
-        (commit: $TSFixMe) => !commit.commit.message.includes('Merge pull request'),
+        (commit: $TSFixMe) =>
+          !commit.commit.message.includes('Merge pull request'),
       )
       .map((commit: $TSFixMe) => ({
         hash: commit.sha.substring(0, 7),

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,8 +2,8 @@
 
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
-import { $TSFixMe } from '@/src/types/remoteFlows';
 import { createInterface } from 'readline';
+import { $TSFixMe } from './types';
 
 interface Commit {
   hash: string;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env tsx
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 import { createInterface } from 'readline';
 
 interface Commit {
@@ -99,9 +99,9 @@ async function getCommitsFromGitHubAPI(): Promise<Commit[]> {
     // Get all commits, not just merge commits
     const commits = data.commits
       .filter(
-        (commit: any) => !commit.commit.message.includes('Merge pull request'),
+        (commit: $TSFixMe) => !commit.commit.message.includes('Merge pull request'),
       )
-      .map((commit: any) => ({
+      .map((commit: $TSFixMe) => ({
         hash: commit.sha.substring(0, 7),
         subject: commit.commit.message.split('\n')[0],
         body: commit.commit.message.split('\n').slice(1).join('\n').trim(),

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -91,5 +91,5 @@ export interface CoverageChange {
   delta: number;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export type $TSFixMe = any;

--- a/src/components/form/JSONSchemaForm.tsx
+++ b/src/components/form/JSONSchemaForm.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { Fragment } from 'react';
 import { useFormContext } from 'react-hook-form';
 import omit from 'lodash.omit';
 import { fieldsMap } from '@/src/components/form/fields/fieldsMapping';
 import { Statement } from '@/src/components/form/Statement';
 import { ForcedValueField } from '@/src/components/form/fields/ForcedValueField';
-import { Components, JSFFieldset, JSFFields } from '@/src/types/remoteFlows';
+import { Components, JSFFieldset, JSFFields, $TSFixMe } from '@/src/types/remoteFlows';
 import { StatementComponentProps } from '@/src/types/fields';
 import { checkFieldHasForcedValue, getFieldsWithFlatFieldsets } from './utils';
 
@@ -37,7 +36,7 @@ export const JSONSchemaFormFields = ({
 
   const wrapWithCustomWrapper = (
     content: React.ReactNode,
-    field: any,
+    field: $TSFixMe,
     key: string,
   ) => {
     if (field.WrapperComponent) {
@@ -71,7 +70,7 @@ export const JSONSchemaFormFields = ({
               name={fieldProps.name as string}
               description={fieldProps.description as string}
               value={fieldProps.const as string}
-              statement={fieldProps.statement as any}
+              statement={fieldProps.statement as $TSFixMe}
               label={fieldProps.label as string}
               helpCenter={fieldProps.meta?.helpCenter}
             />,
@@ -81,7 +80,7 @@ export const JSONSchemaFormFields = ({
         }
 
         if (field.Component) {
-          const { Component } = field as any;
+          const { Component } = field as $TSFixMe;
           const fieldProps = omit(field, ['Component', 'WrapperComponent']);
           return wrapWithCustomWrapper(
             <>

--- a/src/components/form/JSONSchemaForm.tsx
+++ b/src/components/form/JSONSchemaForm.tsx
@@ -4,7 +4,12 @@ import omit from 'lodash.omit';
 import { fieldsMap } from '@/src/components/form/fields/fieldsMapping';
 import { Statement } from '@/src/components/form/Statement';
 import { ForcedValueField } from '@/src/components/form/fields/ForcedValueField';
-import { Components, JSFFieldset, JSFFields, $TSFixMe } from '@/src/types/remoteFlows';
+import {
+  Components,
+  JSFFieldset,
+  JSFFields,
+  $TSFixMe,
+} from '@/src/types/remoteFlows';
 import { StatementComponentProps } from '@/src/types/fields';
 import { checkFieldHasForcedValue, getFieldsWithFlatFieldsets } from './utils';
 

--- a/src/components/form/fields/CountryField.tsx
+++ b/src/components/form/fields/CountryField.tsx
@@ -1,13 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { useFormFields } from '@/src/context';
-import { Components, JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import { FormField } from '../../ui/form';
 
 type CountryFieldProps = JSFField & {
   options: Array<{ value: string; label: string }>;
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
   $meta: {
     regions: Record<string, string[]>;
     subregions: Record<string, string[]>;
@@ -54,7 +52,7 @@ export function CountryField({
           <Component
             field={{
               ...field,
-              onChange: (value: any) => {
+              onChange: (value: $TSFixMe) => {
                 field.onChange(value);
                 onChange?.(value);
               },

--- a/src/components/form/fields/DatePickerField.tsx
+++ b/src/components/form/fields/DatePickerField.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormContext } from 'react-hook-form';
 import { FormField } from '@/src/components/ui/form';
 
 import { useFormFields } from '@/src/context';
-import { Components, JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { getMinStartDate } from '@/src/components/form/utils';
 
 export type DatePickerFieldProps = JSFField & {
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
   component?: Components['date'];
 };
 
@@ -60,7 +59,7 @@ export function DatePickerField({
           <Component
             field={{
               ...field,
-              onChange: (value: any) => {
+              onChange: (value: $TSFixMe) => {
                 field.onChange(value);
                 onChange?.(value);
               },

--- a/src/components/form/fields/MultiSelectField.tsx
+++ b/src/components/form/fields/MultiSelectField.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
-import { Components, JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import { FormField } from '../../ui/form';
 
@@ -8,7 +7,7 @@ type MultiSelectFieldProps = JSFField & {
   placeholder?: string;
   options: Array<{ value: string; label: string }>;
   className?: string;
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
   component?: Components['select'];
 };
 
@@ -49,7 +48,7 @@ export function MultiSelectField({
           <Component
             field={{
               ...field,
-              onChange: (value: any) => {
+              onChange: (value: $TSFixMe) => {
                 field.onChange(value);
                 onChange?.(value);
               },

--- a/src/components/form/fields/TextField.tsx
+++ b/src/components/form/fields/TextField.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
 
 import { useFormFields } from '@/src/context';
-import { Components, JSFField } from '@/src/types/remoteFlows';
+import { Components, JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { useFormContext } from 'react-hook-form';
 import { FormField } from '../../ui/form';
 import { TextFieldDataProps } from '@/src/types/fields';
@@ -11,7 +10,7 @@ export type TextFieldProps = React.ComponentProps<'input'> & {
   name: string;
 } & Partial<
     JSFField & {
-      onChange?: (value: any) => void;
+      onChange?: (value: $TSFixMe) => void;
       component?: Components['text'];
       includeErrorMessage?: boolean;
       additionalProps?: Record<string, unknown>;
@@ -22,7 +21,7 @@ type CustomTextFieldProps = TextFieldDataProps & {
   /**
    * @deprecated avoid using this prop in custom components
    */
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
 };
 
 export function TextField({
@@ -66,7 +65,7 @@ export function TextField({
           <Component
             field={{
               ...field,
-              onChange: (value: any) => {
+              onChange: (value: $TSFixMe) => {
                 field.onChange(value);
                 onChange?.(value);
               },

--- a/src/components/form/fields/WorkScheduleField.tsx
+++ b/src/components/form/fields/WorkScheduleField.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { JSFField } from '@/src/types/remoteFlows';
+import { JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { useFormFields } from '@/src/context';
 import { FormField } from '@/src/components/ui/form';
 import { Components } from '@/src/types/remoteFlows';
@@ -16,7 +15,7 @@ import {
 type WorkScheduleFieldProps = JSFField & {
   name: string;
   default: DailySchedule[];
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
   component?: Components['work-schedule'];
 };
 
@@ -70,7 +69,7 @@ export function WorkScheduleField(props: WorkScheduleFieldProps) {
           <Component
             field={{
               ...field,
-              onChange: (value: any) => {
+              onChange: (value: $TSFixMe) => {
                 field.onChange(value);
                 props.onChange?.(value);
               },

--- a/src/components/form/fields/tests/CheckBoxField.test.tsx
+++ b/src/components/form/fields/tests/CheckBoxField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { boolean } from 'yup';
 import { CheckBoxField, CheckBoxFieldProps } from '../CheckBoxField';
 import { CheckboxFieldDefault } from '@/src/components/form/fields/default/CheckboxFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -47,7 +47,7 @@ describe('CheckBoxField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         checkbox: CheckboxFieldDefault,
       },
@@ -78,7 +78,7 @@ describe('CheckBoxField Component', () => {
         <div data-testid='custom-checkbox-field'>Custom Checkbox Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { checkbox: CustomCheckboxField },
     });
 
@@ -95,7 +95,7 @@ describe('CheckBoxField Component', () => {
         <div data-testid='custom-checkbox-field'>Custom Checkbox Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { checkbox: CustomCheckboxField },
     });
 
@@ -122,7 +122,7 @@ describe('CheckBoxField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { checkbox: CustomCheckboxField },
     });
 
@@ -207,7 +207,7 @@ describe('CheckBoxField Component', () => {
         <div data-testid='prop-checkbox-field'>Prop Checkbox Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { checkbox: CustomCheckboxFieldFromContext },
     });
 

--- a/src/components/form/fields/tests/CountryField.test.tsx
+++ b/src/components/form/fields/tests/CountryField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import {
   act,
@@ -10,7 +9,7 @@ import {
 import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
 import { CountryField } from '../CountryField';
-import { JSFField } from '@/src/types/remoteFlows';
+import { JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { CountryFieldDefault } from '@/src/components/form/fields/default/CountryFieldDefault';
 
 // Mock dependencies
@@ -20,7 +19,7 @@ type CountryFieldProps = JSFField & {
   placeholder?: string;
   options: Array<{ value: string; label: string }>;
   className?: string;
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
   $meta: {
     regions: Record<string, string[]>;
     subregions: Record<string, string[]>;
@@ -74,7 +73,7 @@ describe('CountryField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockImplementation(() => ({
+    (useFormFields as $TSFixMe).mockImplementation(() => ({
       components: {
         countries: CountryFieldDefault,
       },
@@ -109,7 +108,7 @@ describe('CountryField Component', () => {
         <div data-testid='custom-select-field'>Custom Select Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { countries: CustomSelectField },
     });
 
@@ -126,7 +125,7 @@ describe('CountryField Component', () => {
         <div data-testid='custom-select-field'>Custom Select Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { countries: CustomSelectField },
     });
 
@@ -155,7 +154,7 @@ describe('CountryField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { countries: CustomSelectField },
     });
 
@@ -232,12 +231,12 @@ describe('CountryField Component', () => {
         <div data-testid='prop-country-field'>Prop Country Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { countries: CustomCountryFieldFromContext },
     });
 
     renderWithFormContext({
-      ...(defaultProps as any),
+      ...(defaultProps as $TSFixMe),
       onChange: mockOnChange,
       component: CustomCountryFieldProp,
     });

--- a/src/components/form/fields/tests/DatePickerField.test.tsx
+++ b/src/components/form/fields/tests/DatePickerField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -6,6 +5,7 @@ import { string } from 'yup';
 import { addBusinessDays } from 'date-fns';
 import { DatePickerField, DatePickerFieldProps } from '../DatePickerField';
 import { DatePickerFieldDefault } from '@/src/components/form/fields/default/DatePickerFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -55,12 +55,12 @@ describe('DatePickerField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         date: DatePickerFieldDefault,
       },
     });
-    (addBusinessDays as any).mockClear();
+    (addBusinessDays as $TSFixMe).mockClear();
   });
 
   it('renders the default implementation correctly', () => {
@@ -93,7 +93,7 @@ describe('DatePickerField Component', () => {
         </div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { date: CustomDatePickerField },
     });
 
@@ -112,7 +112,7 @@ describe('DatePickerField Component', () => {
         </div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { date: CustomDatePickerField },
     });
 
@@ -139,7 +139,7 @@ describe('DatePickerField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { date: CustomDatePickerField },
     });
 
@@ -165,7 +165,7 @@ describe('DatePickerField Component', () => {
         <div data-testid='prop-date-picker-field'>Prop Date Picker Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { date: CustomDatePickerFieldFromContext },
     });
 
@@ -238,7 +238,7 @@ describe('DatePickerField Component', () => {
           <div data-testid='custom-date-picker-field'>Custom Date Picker</div>
         ));
 
-      (useFormFields as any).mockReturnValue({
+      (useFormFields as $TSFixMe).mockReturnValue({
         components: { date: CustomDatePickerField },
       });
 
@@ -265,7 +265,7 @@ describe('DatePickerField Component', () => {
           <div data-testid='custom-date-picker-field'>Custom Date Picker</div>
         ));
 
-      (useFormFields as any).mockReturnValue({
+      (useFormFields as $TSFixMe).mockReturnValue({
         components: { date: CustomDatePickerField },
       });
 

--- a/src/components/form/fields/tests/FileUploadField.test.tsx
+++ b/src/components/form/fields/tests/FileUploadField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
 import { FileUploadField, FileUploadFieldProps } from '../FileUploadField';
 import { FileUploadFieldDefault } from '@/src/components/form/fields/default/FileUploadFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -47,7 +47,7 @@ describe('FileUploadField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         file: FileUploadFieldDefault,
       },
@@ -82,7 +82,7 @@ describe('FileUploadField Component', () => {
         </div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { file: CustomFileUploadField },
     });
 
@@ -101,7 +101,7 @@ describe('FileUploadField Component', () => {
         </div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { file: CustomFileUploadField },
     });
 
@@ -129,7 +129,7 @@ describe('FileUploadField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { file: CustomFileUploadField },
     });
 
@@ -158,7 +158,7 @@ describe('FileUploadField Component', () => {
         <div data-testid='prop-file-upload-field'>Prop File Upload Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { file: CustomFileUploadFieldFromContext },
     });
 

--- a/src/components/form/fields/tests/MultiSelectField.test.tsx
+++ b/src/components/form/fields/tests/MultiSelectField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { array } from 'yup';
 import { MultiSelectField } from '../MultiSelectField';
 import { MultiSelectFieldDefault } from '@/src/components/form/fields/default/MultiSelectFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 type MultiSelectFieldProps = React.ComponentProps<typeof MultiSelectField>;
 
@@ -41,7 +41,7 @@ describe('MultiSelectField Component', () => {
   // Helper function to render the component with a form context
   const renderWithFormContext = (
     props: MultiSelectFieldProps,
-    defaultValues?: any,
+    defaultValues?: $TSFixMe,
   ) => {
     const TestComponent = () => {
       const methods = useForm({
@@ -59,7 +59,7 @@ describe('MultiSelectField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         'multi-select': MultiSelectFieldDefault,
       },
@@ -173,7 +173,7 @@ describe('MultiSelectField Component', () => {
         </div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { 'multi-select': CustomMultiSelectField },
     });
 
@@ -192,7 +192,7 @@ describe('MultiSelectField Component', () => {
         </div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { 'multi-select': CustomMultiSelectField },
     });
 
@@ -222,7 +222,7 @@ describe('MultiSelectField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { 'multi-select': CustomMultiSelectField },
     });
 
@@ -248,7 +248,7 @@ describe('MultiSelectField Component', () => {
         <div data-testid='prop-multi-select-field'>Prop Multi-Select Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { 'multi-select': CustomMultiSelectFieldFromContext },
     });
 

--- a/src/components/form/fields/tests/NumberField.test.tsx
+++ b/src/components/form/fields/tests/NumberField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { number } from 'yup';
 import { NumberField } from '../NumberField';
 import { TextFieldProps } from '../TextField';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 import { NumberFieldDefault } from '@/src/components/form/fields/default/NumberFieldDefault';
 import { TextFieldDefault } from '@/src/components/form/fields/default/TextFieldDefault';
 
@@ -49,7 +49,7 @@ describe('NumberField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         number: NumberFieldDefault,
         text: TextFieldDefault,
@@ -81,7 +81,7 @@ describe('NumberField Component', () => {
         <div data-testid='custom-number-field'>Custom Number Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { number: CustomNumberField },
     });
 
@@ -98,7 +98,7 @@ describe('NumberField Component', () => {
         <div data-testid='custom-number-field'>Custom Number Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { number: CustomNumberField },
     });
 
@@ -119,7 +119,7 @@ describe('NumberField Component', () => {
       return <input data-testid='custom-input' onChange={handleChange} />;
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { number: CustomNumberField },
     });
 
@@ -143,7 +143,7 @@ describe('NumberField Component', () => {
         <div data-testid='prop-number-field'>Prop Number Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { number: CustomNumberFieldFromContext },
     });
 

--- a/src/components/form/fields/tests/RadioGroupField.test.tsx
+++ b/src/components/form/fields/tests/RadioGroupField.test.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
 import { RadioGroupField } from '../RadioGroupField';
-import { JSFField } from '@/src/types/remoteFlows';
+import { JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { RadioGroupFieldDefault } from '@/src/components/form/fields/default/RadioGroupFieldDefault';
 
 type RadioGroupFieldProps = JSFField & {
@@ -16,7 +15,7 @@ type RadioGroupFieldProps = JSFField & {
     disabled?: boolean;
     description?: string;
   }[];
-  component?: any;
+  component?: $TSFixMe;
 };
 
 // Mock dependencies
@@ -63,7 +62,7 @@ describe('RadioGroupField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         radio: RadioGroupFieldDefault,
       },
@@ -95,7 +94,7 @@ describe('RadioGroupField Component', () => {
         <div data-testid='custom-radio-field'>Custom Radio Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { radio: CustomRadioGroupField },
     });
 
@@ -112,7 +111,7 @@ describe('RadioGroupField Component', () => {
         <div data-testid='custom-radio-field'>Custom Radio Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { radio: CustomRadioGroupField },
     });
 
@@ -146,7 +145,7 @@ describe('RadioGroupField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { radio: CustomRadioGroupField },
     });
 
@@ -170,12 +169,12 @@ describe('RadioGroupField Component', () => {
         <div data-testid='prop-radio-field'>Prop Radio Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { radio: CustomRadioGroupFieldFromContext },
     });
 
     renderWithFormContext({
-      ...(defaultProps as any),
+      ...(defaultProps as $TSFixMe),
       onChange: mockOnChange,
       component: CustomRadioGroupFieldProp,
     });

--- a/src/components/form/fields/tests/SelectField.test.tsx
+++ b/src/components/form/fields/tests/SelectField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
 import { SelectField } from '../SelectField';
 import { SelectFieldDefault } from '@/src/components/form/fields/default/SelectFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 type SelectFieldProps = React.ComponentProps<typeof SelectField>;
 
@@ -53,7 +53,7 @@ describe('SelectField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         select: SelectFieldDefault,
       },
@@ -93,7 +93,7 @@ describe('SelectField Component', () => {
         <div data-testid='custom-select-field'>Custom Select Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { select: CustomSelectField },
     });
 
@@ -110,7 +110,7 @@ describe('SelectField Component', () => {
         <div data-testid='custom-select-field'>Custom Select Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { select: CustomSelectField },
     });
 
@@ -139,7 +139,7 @@ describe('SelectField Component', () => {
       );
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { select: CustomSelectField },
     });
 
@@ -163,7 +163,7 @@ describe('SelectField Component', () => {
         <div data-testid='prop-select-field'>Prop Select Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { select: CustomSelectFieldFromContext },
     });
 
@@ -234,7 +234,7 @@ describe('SelectField Component', () => {
         );
       });
 
-      (useFormFields as any).mockReturnValue({
+      (useFormFields as $TSFixMe).mockReturnValue({
         components: { select: CustomSelectField },
       });
 
@@ -273,7 +273,7 @@ describe('SelectField Component', () => {
         );
       });
 
-      (useFormFields as any).mockReturnValue({
+      (useFormFields as $TSFixMe).mockReturnValue({
         components: { select: CustomSelectField },
       });
 

--- a/src/components/form/fields/tests/TelField.test.tsx
+++ b/src/components/form/fields/tests/TelField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { object, string } from 'yup';
 import { TelField, TelFieldDataProps } from '../TelField';
 import { TelFieldDefault } from '../default/TelFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 vi.mock('@/src/context', () => ({
@@ -114,7 +114,7 @@ describe('TelField Component - Split UI', () => {
 
   const renderWithFormContext = (
     props: TelFieldDataProps,
-    defaultValues?: any,
+    defaultValues?: $TSFixMe,
   ) => {
     const TestComponent = () => {
       const methods = useForm({
@@ -137,7 +137,7 @@ describe('TelField Component - Split UI', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { tel: TelFieldDefault },
     });
   });

--- a/src/components/form/fields/tests/TextAreaField.test.tsx
+++ b/src/components/form/fields/tests/TextAreaField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
 import { TextAreaField, TextAreaFieldProps } from '../TextAreaField';
 import { TextAreaFieldDefault } from '@/src/components/form/fields/default/TextAreaFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -47,7 +47,7 @@ describe('TextAreaField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         textarea: TextAreaFieldDefault,
       },
@@ -78,7 +78,7 @@ describe('TextAreaField Component', () => {
         <div data-testid='custom-textarea-field'>Custom TextArea Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { textarea: CustomTextAreaField },
     });
 
@@ -95,7 +95,7 @@ describe('TextAreaField Component', () => {
         <div data-testid='custom-textarea-field'>Custom TextArea Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { textarea: CustomTextAreaField },
     });
 
@@ -116,7 +116,7 @@ describe('TextAreaField Component', () => {
       return <textarea data-testid='custom-textarea' onChange={handleChange} />;
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { textarea: CustomTextAreaField },
     });
 
@@ -140,7 +140,7 @@ describe('TextAreaField Component', () => {
         <div data-testid='prop-textarea-field'>Prop TextArea Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { textarea: CustomTextAreaFieldFromContext },
     });
 

--- a/src/components/form/fields/tests/TextField.test.tsx
+++ b/src/components/form/fields/tests/TextField.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -6,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { string } from 'yup';
 import { TextField, TextFieldProps } from '../TextField';
 import { TextFieldDefault } from '@/src/components/form/fields/default/TextFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -47,7 +47,7 @@ describe('TextField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         text: TextFieldDefault,
       },
@@ -78,7 +78,7 @@ describe('TextField Component', () => {
         <div data-testid='custom-text-field'>Custom Text Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { text: CustomTextField },
     });
 
@@ -95,7 +95,7 @@ describe('TextField Component', () => {
         <div data-testid='custom-text-field'>Custom Text Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { text: CustomTextField },
     });
 
@@ -114,7 +114,7 @@ describe('TextField Component', () => {
         <div data-testid='custom-text-field'>Custom Text Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { text: CustomTextField },
     });
 
@@ -144,7 +144,7 @@ describe('TextField Component', () => {
       return <input data-testid='custom-input' onChange={handleChange} />;
     });
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { text: CustomTextField },
     });
 
@@ -168,7 +168,7 @@ describe('TextField Component', () => {
         <div data-testid='prop-text-field'>Prop Text Field</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { text: CustomTextFieldFromContext },
     });
 

--- a/src/components/form/fields/tests/WorkScheduleField.test.tsx
+++ b/src/components/form/fields/tests/WorkScheduleField.test.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { WorkScheduleField } from '../WorkScheduleField';
 import { DailySchedule } from '../workScheduleUtils';
-import { JSFField } from '@/src/types/remoteFlows';
+import { JSFField, $TSFixMe } from '@/src/types/remoteFlows';
 import { Components } from '@/src/types/remoteFlows';
 import * as yup from 'yup';
 import { WorkScheduleFieldDefault } from '@/src/components/form/fields/default/WorkScheduleFieldDefault';
@@ -20,7 +19,7 @@ vi.mock('@/src/context', () => ({
 type WorkScheduleFieldProps = JSFField & {
   name: string;
   default: DailySchedule[];
-  onChange?: (value: any) => void;
+  onChange?: (value: $TSFixMe) => void;
   component?: Components['work-schedule'];
 };
 
@@ -103,7 +102,7 @@ describe('WorkScheduleField Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         'work-schedule': WorkScheduleFieldDefault,
         checkbox: CheckboxFieldDefault,
@@ -224,7 +223,7 @@ describe('WorkScheduleField Component', () => {
         <div data-testid='custom-work-schedule'>Custom Work Schedule</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { 'work-schedule': CustomWorkSchedule },
     });
 
@@ -247,7 +246,7 @@ describe('WorkScheduleField Component', () => {
         <div data-testid='prop-work-schedule'>Prop Work Schedule</div>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { 'work-schedule': CustomWorkScheduleFromContext },
     });
 

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Field } from '@/src/flows/types';
 import { $TSFixMe } from '@/src/types/remoteFlows';
 import { JSFFields } from '@/src/types/remoteFlows';
@@ -93,9 +92,8 @@ export function convertFromCents(amount?: number | string | null) {
   return round(normalizedValue / 100);
 }
 
-const trimStringValues = (values: Record<string, any>) =>
-  Object.entries(values || {}).reduce<Record<string, any>>(
-    (result, [key, value]) => {
+const trimStringValues = (values: Record<string, $TSFixMe>) =>
+  Object.entries(values || {}).reduce<Record<string, $TSFixMe>>((result, [key, value]) => {
       if (Array.isArray(value)) {
         // If the value is an array, recursively process each element
         result[key] = value.map((item) =>
@@ -125,8 +123,8 @@ const trimStringValues = (values: Record<string, any>) =>
  * @param {Object} values - List with form values { name: value }.
  * @param {Array} fields - Respective form fields configuration.
  */
-function prefillReadOnlyFields(values: Record<string, any>, fields: any[]) {
-  const newValues: Record<string, any> = {};
+function prefillReadOnlyFields(values: Record<string, $TSFixMe>, fields: $TSFixMe[]) {
+  const newValues: Record<string, $TSFixMe> = {};
 
   fields.forEach((field) => {
     const fieldName = field.name;
@@ -161,10 +159,10 @@ function prefillReadOnlyFields(values: Record<string, any>, fields: any[]) {
  * @return {Object} – Raw form values mapped to the field name
  */
 function extractFieldsetFieldsValues(
-  fields: any[],
+  fields: $TSFixMe[],
   formValues: Record<string, unknown>,
 ) {
-  return fields.reduce<Record<string, any>>((nestedAcc, subField) => {
+  return fields.reduce<Record<string, $TSFixMe>>((nestedAcc, subField) => {
     const isFieldsetValueGroupingDisabled =
       subField.type === supportedTypes.FIELDSET &&
       subField.valueGroupingDisabled;
@@ -184,7 +182,7 @@ function extractFieldsetFieldsValues(
   }, {});
 }
 
-export const fieldTypesTransformations: Record<string, any> = {
+export const fieldTypesTransformations: Record<string, $TSFixMe> = {
   [supportedTypes.COUNTRIES]: {
     /**
      * @param {String[] | { name: String }[]} value
@@ -195,7 +193,7 @@ export const fieldTypesTransformations: Record<string, any> = {
      * @example edge cases: [{name: 'Peru'}, {name: 'Germany'}] -> ['Peru', 'Germany']
      */
     transformValueToAPI:
-      (field: any) => (selectedCountries: string[] | { name: string }[]) => {
+      (field: $TSFixMe) => (selectedCountries: string[] | { name: string }[]) => {
         if (!field.multiple || typeof selectedCountries === 'string') {
           return selectedCountries;
         }
@@ -217,10 +215,10 @@ export const fieldTypesTransformations: Record<string, any> = {
      * @example
      * [{ value: 'Hungria' }] -> ['Hungria']
      */
-    transformValue: (selectedCountry: any | any[]) => {
+    transformValue: (selectedCountry: $TSFixMe | $TSFixMe[]) => {
       // name or label are used in dragon. value is used in json-schema-form
       // TODO: it should be the same everywhere — read more at !5667
-      const getCountryValue = (opt: any) =>
+      const getCountryValue = (opt: $TSFixMe) =>
         opt?.name || opt?.value || opt?.label;
       return Array.isArray(selectedCountry)
         ? selectedCountry.map(getCountryValue) // support multi countries
@@ -246,7 +244,7 @@ export const fieldTypesTransformations: Record<string, any> = {
     transformValueToAPI: () => convertToCents,
   },
   [supportedTypes.RADIO]: {
-    transformValueToAPI: (field: any) => (value: string) => {
+    transformValueToAPI: (field: $TSFixMe) => (value: string) => {
       if (field.transformToBool) {
         return value === 'yes';
       }
@@ -254,7 +252,7 @@ export const fieldTypesTransformations: Record<string, any> = {
     },
   },
   [supportedTypes.CHECKBOX]: {
-    transformValueToAPI: (field: any) => (value: string | boolean) => {
+    transformValueToAPI: (field: $TSFixMe) => (value: string | boolean) => {
       if (value === undefined) {
         return false;
       }
@@ -277,7 +275,7 @@ export const fieldTypesTransformations: Record<string, any> = {
      * { value: '1', label: 'One' } -> "One"
      * {} -> ""
      */
-    transformValue: (option: any | any[]) =>
+    transformValue: (option: $TSFixMe | $TSFixMe[]) =>
       Array.isArray(option)
         ? option.map((opt) => opt.value) // multi-options
         : (option?.value ?? ''), // Fallback to '' in case user removes all options,
@@ -293,8 +291,8 @@ export const fieldTypesTransformations: Record<string, any> = {
   },
 };
 export async function parseFormValuesToAPI(
-  formValues: Record<string, any> = {},
-  fields: any[],
+  formValues: Record<string, $TSFixMe> = {},
+  fields: $TSFixMe[],
 ) {
   const filteredFields = fields.filter(
     (field) =>
@@ -304,7 +302,7 @@ export async function parseFormValuesToAPI(
 
   const parsedFieldsWithValues = await Promise.all(
     filteredFields.map(async (field) => {
-      const acc: Record<string, any> = {};
+      const acc: Record<string, $TSFixMe> = {};
 
       switch (field.type) {
         case supportedTypes.FIELDSET: {
@@ -359,13 +357,13 @@ export async function parseFormValuesToAPI(
         case supportedTypes.GROUP_ARRAY: {
           // NOTE: The field `name` in group arrays represents a path, but we only
           // need the last part of it which is represented by `nameKey`.
-          const transformedFields = field?.fields?.().map((subField: any) => ({
+          const transformedFields = field?.fields?.().map((subField: $TSFixMe) => ({
             ...subField,
             name: subField.nameKey || '',
           }));
 
           const parsedFieldValues = await Promise.all(
-            formValues[field.name]?.map((fieldValues: Record<string, any>) =>
+            formValues[field.name]?.map((fieldValues: Record<string, $TSFixMe>) =>
               parseFormValuesToAPI(fieldValues, transformedFields),
             ) || [],
           );
@@ -429,7 +427,7 @@ export async function parseFormValuesToAPI(
   );
 }
 
-function isFieldVisible(field: any, formValues: Record<string, unknown>) {
+function isFieldVisible(field: $TSFixMe, formValues: Record<string, unknown>) {
   if (field.visibilityCondition) {
     return field.visibilityCondition(formValues);
   }
@@ -442,7 +440,7 @@ function isFieldVisible(field: any, formValues: Record<string, unknown>) {
 }
 
 function applyFieldDynamicProperties(
-  field: any,
+  field: $TSFixMe,
   values: Record<string, unknown> | Record<string, unknown>[],
 ) {
   if (field.calculateDynamicProperties) {
@@ -456,12 +454,12 @@ function applyFieldDynamicProperties(
 }
 
 function excludeValuesInvisible(
-  values: any,
-  fields: any[],
+  values: $TSFixMe,
+  fields: $TSFixMe[],
   keepTruthyInvisibleValues?: boolean,
   parentFieldKeyPath?: string,
 ) {
-  const valuesAsked: Record<string, any> = {};
+  const valuesAsked: Record<string, $TSFixMe> = {};
 
   fields
     .map((field) => applyFieldDynamicProperties(field, values))
@@ -516,9 +514,9 @@ function excludeValuesInvisible(
   return valuesAsked;
 }
 
-function removeEmptyValues<T extends Record<string, any>>(
+function removeEmptyValues<T extends Record<string, $TSFixMe>>(
   obj: T,
-): Record<string, any> {
+): Record<string, $TSFixMe> {
   return Object.fromEntries(
     Object.entries(obj).filter(
       ([, value]) => value !== undefined && value !== null && value !== '',
@@ -526,7 +524,7 @@ function removeEmptyValues<T extends Record<string, any>>(
   );
 }
 
-function cleanUnderscoreFields(obj: Record<string, any>): Record<string, any> {
+function cleanUnderscoreFields(obj: Record<string, $TSFixMe>): Record<string, $TSFixMe> {
   if (Array.isArray(obj)) {
     return obj.map(cleanUnderscoreFields);
   }
@@ -538,15 +536,15 @@ function cleanUnderscoreFields(obj: Record<string, any>): Record<string, any> {
         }
         return acc;
       },
-      {} as Record<string, any>,
+      {} as Record<string, $TSFixMe>,
     );
   }
   return obj;
 }
 
 export async function parseSubmitValues(
-  formValues: Record<string, any>,
-  fields: any[],
+  formValues: Record<string, $TSFixMe>,
+  fields: $TSFixMe[],
   config?: { keepInvisibleValues?: boolean },
 ) {
   const visibleFormValues = config?.keepInvisibleValues
@@ -570,7 +568,7 @@ export async function parseSubmitValues(
 }
 
 export async function parseJSFToValidate(
-  formValues: Record<string, any>,
+  formValues: Record<string, $TSFixMe>,
   fields: JSFFields,
   config: { isPartialValidation: boolean } = {
     isPartialValidation: false,
@@ -598,7 +596,7 @@ function getDefaultValueForType(type: string) {
 }
 
 function getInitialDefaultValue(
-  defaultValues: Record<string, any>,
+  defaultValues: Record<string, $TSFixMe>,
   field: Field,
 ) {
   // getNestedValue is needed because some values could be nested object, like billing address
@@ -627,7 +625,7 @@ function getInitialDefaultValue(
       : null;
 
   // nullish coalescing but excluding empty strings. (to support 0 (zero) as valid numbers)
-  const excludeString = (val: any) => (val === '' ? undefined : val);
+  const excludeString = (val: $TSFixMe) => (val === '' ? undefined : val);
 
   return (
     excludeString(generatedValue) ??
@@ -746,7 +744,7 @@ export function getFieldsWithFlatFieldsets({
   fieldsets = {},
   values,
 }: {
-  fields: any[];
+  fields: $TSFixMe[];
   fieldsets: Record<string, { propertiesByName: string[]; title: string }>;
   values: Record<string, unknown>;
 }) {
@@ -768,7 +766,7 @@ export function getFieldsWithFlatFieldsets({
 
     const childFields = flatFieldsetFields
       .map((name) => fields.find((f) => f.name === name))
-      .filter((field): field is any => !!field);
+      .filter((field): field is $TSFixMe => !!field);
 
     return {
       ...rest,
@@ -800,7 +798,7 @@ export function getFieldsWithFlatFieldsets({
     accumulatedFieldsSorted.splice(
       fieldsetPosition,
       0,
-      field as unknown as any,
+      field as unknown as $TSFixMe,
     );
 
     return accumulatedFieldsSorted;
@@ -860,7 +858,7 @@ export function getMinStartDate(minOnBoardingTime: number) {
  * @param field - The field to check.
  * @returns True if the field has a forced value, false otherwise.
  */
-export function checkFieldHasForcedValue(field: any) {
+export function checkFieldHasForcedValue(field: $TSFixMe) {
   // A field to be considered "forced value" must:
   return (
     field.const !== undefined && // Only accepts a specific value

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -93,7 +93,8 @@ export function convertFromCents(amount?: number | string | null) {
 }
 
 const trimStringValues = (values: Record<string, $TSFixMe>) =>
-  Object.entries(values || {}).reduce<Record<string, $TSFixMe>>((result, [key, value]) => {
+  Object.entries(values || {}).reduce<Record<string, $TSFixMe>>(
+    (result, [key, value]) => {
       if (Array.isArray(value)) {
         // If the value is an array, recursively process each element
         result[key] = value.map((item) =>
@@ -123,7 +124,10 @@ const trimStringValues = (values: Record<string, $TSFixMe>) =>
  * @param {Object} values - List with form values { name: value }.
  * @param {Array} fields - Respective form fields configuration.
  */
-function prefillReadOnlyFields(values: Record<string, $TSFixMe>, fields: $TSFixMe[]) {
+function prefillReadOnlyFields(
+  values: Record<string, $TSFixMe>,
+  fields: $TSFixMe[],
+) {
   const newValues: Record<string, $TSFixMe> = {};
 
   fields.forEach((field) => {
@@ -193,7 +197,8 @@ export const fieldTypesTransformations: Record<string, $TSFixMe> = {
      * @example edge cases: [{name: 'Peru'}, {name: 'Germany'}] -> ['Peru', 'Germany']
      */
     transformValueToAPI:
-      (field: $TSFixMe) => (selectedCountries: string[] | { name: string }[]) => {
+      (field: $TSFixMe) =>
+      (selectedCountries: string[] | { name: string }[]) => {
         if (!field.multiple || typeof selectedCountries === 'string') {
           return selectedCountries;
         }
@@ -357,14 +362,17 @@ export async function parseFormValuesToAPI(
         case supportedTypes.GROUP_ARRAY: {
           // NOTE: The field `name` in group arrays represents a path, but we only
           // need the last part of it which is represented by `nameKey`.
-          const transformedFields = field?.fields?.().map((subField: $TSFixMe) => ({
-            ...subField,
-            name: subField.nameKey || '',
-          }));
+          const transformedFields = field
+            ?.fields?.()
+            .map((subField: $TSFixMe) => ({
+              ...subField,
+              name: subField.nameKey || '',
+            }));
 
           const parsedFieldValues = await Promise.all(
-            formValues[field.name]?.map((fieldValues: Record<string, $TSFixMe>) =>
-              parseFormValuesToAPI(fieldValues, transformedFields),
+            formValues[field.name]?.map(
+              (fieldValues: Record<string, $TSFixMe>) =>
+                parseFormValuesToAPI(fieldValues, transformedFields),
             ) || [],
           );
 
@@ -524,7 +532,9 @@ function removeEmptyValues<T extends Record<string, $TSFixMe>>(
   );
 }
 
-function cleanUnderscoreFields(obj: Record<string, $TSFixMe>): Record<string, $TSFixMe> {
+function cleanUnderscoreFields(
+  obj: Record<string, $TSFixMe>,
+): Record<string, $TSFixMe> {
   if (Array.isArray(obj)) {
     return obj.map(cleanUnderscoreFields);
   }

--- a/src/components/ui/tests/form.test.tsx
+++ b/src/components/ui/tests/form.test.tsx
@@ -3,6 +3,7 @@ import { screen, render } from '@testing-library/react';
 import { TestProviders } from '@/src/tests/testHelpers';
 import { PropsWithChildren } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 const wrapper = ({ children }: PropsWithChildren) => {
   const TestComponent = () => {
@@ -45,8 +46,7 @@ describe('Form', () => {
         return <span data-testid='test'>hello this is my message</span>;
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const renderComponent: any = () => {
+      const renderComponent: $TSFixMe = () => {
         return <TestComponent />;
       };
       render(<FormDescription>{renderComponent}</FormDescription>, {

--- a/src/flows/Onboarding/tests/OnboardingBack.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingBack.test.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { useOnboardingContext } from '@/src/flows/Onboarding/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { OnboardingBack } from '../components/OnboardingBack';
 import { ButtonDefault } from '@/src/components/form/fields/default/ButtonDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -20,13 +20,13 @@ describe('OnboardingBack Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useOnboardingContext as any).mockReturnValue({
+    (useOnboardingContext as $TSFixMe).mockReturnValue({
       onboardingBag: {
         back: mockBack,
         isEmploymentReadOnly: false,
       },
     });
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         button: ButtonDefault,
       },
@@ -74,7 +74,7 @@ describe('OnboardingBack Component', () => {
         <button data-testid='custom-button'>{children}</button>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 
@@ -94,7 +94,7 @@ describe('OnboardingBack Component', () => {
         </button>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 
@@ -138,7 +138,7 @@ describe('OnboardingBack Component', () => {
         ),
       );
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 
@@ -195,13 +195,13 @@ describe('OnboardingBack Component', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           back: mockBack,
           isEmploymentReadOnly: true,
         },
       });
-      (useFormFields as any).mockReturnValue({
+      (useFormFields as $TSFixMe).mockReturnValue({
         components: { button: ButtonDefault },
       });
     });
@@ -225,7 +225,7 @@ describe('OnboardingBack Component', () => {
           </button>
         ));
 
-      (useFormFields as any).mockReturnValue({
+      (useFormFields as $TSFixMe).mockReturnValue({
         components: { button: CustomButton },
       });
 

--- a/src/flows/Onboarding/tests/OnboardingSubmit.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingSubmit.test.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useFormFields } from '@/src/context';
 import { useOnboardingContext } from '@/src/flows/Onboarding/context';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { OnboardingSubmit } from '../components/OnboardingSubmit';
 import { ButtonDefault } from '@/src/components/form/fields/default/ButtonDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock dependencies
 vi.mock('@/src/context', () => ({
@@ -20,11 +20,11 @@ describe('OnboardingSubmit Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useOnboardingContext as any).mockReturnValue({
+    (useOnboardingContext as $TSFixMe).mockReturnValue({
       formId: mockFormId,
       onboardingBag: { isSubmitting: false },
     });
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: {
         button: ButtonDefault,
       },
@@ -82,7 +82,7 @@ describe('OnboardingSubmit Component', () => {
         <button data-testid='custom-button'>{children}</button>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 
@@ -106,7 +106,7 @@ describe('OnboardingSubmit Component', () => {
         </button>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 
@@ -147,7 +147,7 @@ describe('OnboardingSubmit Component', () => {
       ),
     );
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 
@@ -181,7 +181,7 @@ describe('OnboardingSubmit Component', () => {
   });
 
   it('handles missing formId gracefully', () => {
-    (useOnboardingContext as any).mockReturnValue({
+    (useOnboardingContext as $TSFixMe).mockReturnValue({
       formId: undefined,
       onboardingBag: {},
     });
@@ -207,7 +207,7 @@ describe('OnboardingSubmit Component', () => {
         </button>
       ));
 
-    (useFormFields as any).mockReturnValue({
+    (useFormFields as $TSFixMe).mockReturnValue({
       components: { button: CustomButton },
     });
 

--- a/src/flows/Onboarding/tests/ReviewStep.test.tsx
+++ b/src/flows/Onboarding/tests/ReviewStep.test.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useOnboardingContext } from '@/src/flows/Onboarding/context';
 import { ReviewStep } from '@/src/flows/Onboarding/components/ReviewStep';
 import { CreditRiskStatus, Employment } from '@/src/flows/Onboarding/types';
 import { render, screen } from '@testing-library/react';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 // Mock the context
 vi.mock('@/src/flows/Onboarding/context', () => ({
@@ -30,7 +30,7 @@ describe('ReviewStep Component', () => {
       <div data-testid='rendered-content'>Test Content</div>,
     );
 
-    (useOnboardingContext as any).mockReturnValue({
+    (useOnboardingContext as $TSFixMe).mockReturnValue({
       onboardingBag: mockOnboardingBag,
       creditScore: mockCreditScore,
     });
@@ -38,7 +38,7 @@ describe('ReviewStep Component', () => {
 
   describe('deposit_required scenarios', () => {
     it('should render with creditRiskState "deposit_required" when deposit is required and status allows it', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: { status: 'created' },
@@ -58,7 +58,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should render with creditRiskState "deposit_required" when onboardingReservesStatus is deposit_required', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'no_deposit_required',
           onboardingReservesStatus: 'deposit_required',
@@ -79,7 +79,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should render with creditRiskState "deposit_required" when either creditRiskStatus or onboardingReservesStatus is deposit_required', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           onboardingReservesStatus: 'no_deposit_required',
@@ -100,7 +100,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should not show deposit_required when employment status is "invited"', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: { status: 'invited' },
@@ -120,7 +120,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should not show deposit_required when employment status is "created_reserve_paid"', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: { status: 'created_reserve_paid' },
@@ -142,7 +142,7 @@ describe('ReviewStep Component', () => {
 
   describe('invite scenarios', () => {
     it('should render with creditRiskState "invite" when creditRiskStatus is not in CREDIT_RISK_STATUSES', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'ready',
           employment: { status: 'created' },
@@ -164,7 +164,7 @@ describe('ReviewStep Component', () => {
 
   describe('invite_successful scenarios', () => {
     it('should render with creditRiskState "invite_successful" when showInviteSuccessful is true and employment status is in statusesToNotShowDeposit', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: { status: 'invited' },
@@ -186,7 +186,7 @@ describe('ReviewStep Component', () => {
 
   describe('referred scenarios', () => {
     it('should render with creditRiskState "referred" when creditRiskStatus is "referred"', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: { creditRiskStatus: 'referred' },
       });
 
@@ -201,7 +201,7 @@ describe('ReviewStep Component', () => {
 
   describe('edge cases and null scenarios', () => {
     it('should handle missing employment gracefully', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: undefined,
@@ -221,7 +221,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should handle missing employment status gracefully', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: {},
@@ -241,7 +241,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should handle undefined creditRiskStatus', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: undefined,
           employment: { status: 'created' },
@@ -263,7 +263,7 @@ describe('ReviewStep Component', () => {
 
   describe('complex scenarios', () => {
     it('should prioritize deposit_required_successful over deposit_required when showReserveInvoice is true', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'deposit_required',
           employment: { status: 'created' },
@@ -283,7 +283,7 @@ describe('ReviewStep Component', () => {
     });
 
     it('should prioritize invite_successful over invite when showInviteSuccessful is true', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'ready',
           employment: { status: 'created' },
@@ -316,7 +316,7 @@ describe('ReviewStep Component', () => {
       creditRiskStatuses.forEach((status) => {
         mockRender.mockClear();
 
-        (useOnboardingContext as any).mockReturnValue({
+        (useOnboardingContext as $TSFixMe).mockReturnValue({
           onboardingBag: {
             creditRiskStatus: status,
             employment: { status: 'created' },
@@ -348,7 +348,7 @@ describe('ReviewStep Component', () => {
 
   describe('render prop functionality', () => {
     it('should call the render prop with correct arguments', () => {
-      (useOnboardingContext as any).mockReturnValue({
+      (useOnboardingContext as $TSFixMe).mockReturnValue({
         onboardingBag: {
           creditRiskStatus: 'ready',
           employment: { status: 'created' },

--- a/src/flows/Termination/json-schemas/schema.ts
+++ b/src/flows/Termination/json-schemas/schema.ts
@@ -3,9 +3,9 @@ import { employeeComunicationSchema } from '@/src/flows/Termination/json-schemas
 import { paidTimeOffSchema } from '@/src/flows/Termination/json-schemas/paidTimeOff';
 import { terminationDetailsSchema } from '@/src/flows/Termination/json-schemas/terminationDetails';
 import { StepTerminationKeys } from '@/src/flows/Termination/utils';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const schema: Record<StepTerminationKeys, Record<string, any>> = {
+export const schema: Record<StepTerminationKeys, Record<string, $TSFixMe>> = {
   employee_communication: employeeComunicationSchema,
   termination_details: terminationDetailsSchema,
   paid_time_off: paidTimeOffSchema,

--- a/src/flows/utils.ts
+++ b/src/flows/utils.ts
@@ -1,4 +1,5 @@
 import { SupportedTypes } from '../components/form/fields/types';
+import { $TSFixMe } from '@/src/types/remoteFlows';
 
 type ParsedRadioValues = Record<string, unknown>;
 
@@ -33,8 +34,7 @@ export function parseFormRadioValues(
 }
 
 export function findFieldsByType(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fields: Record<string, any>,
+  fields: Record<string, $TSFixMe>,
   type: SupportedTypes,
 ) {
   const fieldsNames = [];

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -2,11 +2,17 @@ import { Meta, $TSFixMe } from '@/src/types/remoteFlows';
 import { UseMutationResult } from '@tanstack/react-query';
 
 type MutationData<T> =
-  T extends UseMutationResult<infer R, $TSFixMe, $TSFixMe, $TSFixMe> ? R : never;
+  T extends UseMutationResult<infer R, $TSFixMe, $TSFixMe, $TSFixMe>
+    ? R
+    : never;
 type MutationVariables<T> =
-  T extends UseMutationResult<$TSFixMe, $TSFixMe, infer V, $TSFixMe> ? V : never;
+  T extends UseMutationResult<$TSFixMe, $TSFixMe, infer V, $TSFixMe>
+    ? V
+    : never;
 type MutationError<T> =
-  T extends UseMutationResult<$TSFixMe, infer E, $TSFixMe, $TSFixMe> ? E : never;
+  T extends UseMutationResult<$TSFixMe, infer E, $TSFixMe, $TSFixMe>
+    ? E
+    : never;
 
 /**
  * Unwraps the .data property from the response type

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -1,13 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { Meta } from '@/src/types/remoteFlows';
+import { Meta, $TSFixMe } from '@/src/types/remoteFlows';
 import { UseMutationResult } from '@tanstack/react-query';
 
 type MutationData<T> =
-  T extends UseMutationResult<infer R, any, any, any> ? R : never;
+  T extends UseMutationResult<infer R, $TSFixMe, $TSFixMe, $TSFixMe> ? R : never;
 type MutationVariables<T> =
-  T extends UseMutationResult<any, any, infer V, any> ? V : never;
+  T extends UseMutationResult<$TSFixMe, $TSFixMe, infer V, $TSFixMe> ? V : never;
 type MutationError<T> =
-  T extends UseMutationResult<any, infer E, any, any> ? E : never;
+  T extends UseMutationResult<$TSFixMe, infer E, $TSFixMe, $TSFixMe> ? E : never;
 
 /**
  * Unwraps the .data property from the response type
@@ -39,7 +38,7 @@ type PromiseResult<D, E> = SuccessResponse<D> | ErrorResponse<E>;
  * @param error - The error response object
  * @returns Array of field errors with field name and messages
  */
-export function extractFieldErrors(error: any): FieldError[] {
+export function extractFieldErrors(error: $TSFixMe): FieldError[] {
   const errors = error.error || error;
   if (!errors || !errors.errors || typeof errors.errors !== 'object') return [];
 
@@ -49,7 +48,7 @@ export function extractFieldErrors(error: any): FieldError[] {
     if (Array.isArray(value)) {
       fieldErrors.push({
         field: key,
-        messages: value.map((msg: any) => String(msg)),
+        messages: value.map((msg: $TSFixMe) => String(msg)),
       });
       return;
     }
@@ -58,7 +57,7 @@ export function extractFieldErrors(error: any): FieldError[] {
         if (Array.isArray(nestedValue)) {
           fieldErrors.push({
             field: nestedKey,
-            messages: nestedValue.map((msg: any) => String(msg)),
+            messages: nestedValue.map((msg: $TSFixMe) => String(msg)),
           });
         }
       });
@@ -76,7 +75,7 @@ export function extractFieldErrors(error: any): FieldError[] {
  * @returns
  */
 export function mutationToPromise<
-  T extends UseMutationResult<any, any, any, any>,
+  T extends UseMutationResult<$TSFixMe, $TSFixMe, $TSFixMe, $TSFixMe>,
 >(mutation: T) {
   type Data = MutationData<T>;
   type Variables = MutationVariables<T>;

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -217,7 +217,7 @@ export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {
   credentials?: RequestCredentials;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export type $TSFixMe = any;
 
 // Extend the global Window interface to include RemoteFlowsSDK

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -217,7 +217,7 @@ export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {
   credentials?: RequestCredentials;
 };
 
-// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export type $TSFixMe = any;
 
 // Extend the global Window interface to include RemoteFlowsSDK

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -16,8 +16,7 @@ class MockPointerEvent extends Event {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-window.PointerEvent = MockPointerEvent as any;
+window.PointerEvent = MockPointerEvent as $TSFixMe;
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 window.HTMLElement.prototype.releasePointerCapture = vi.fn();
 window.HTMLElement.prototype.hasPointerCapture = vi.fn();


### PR DESCRIPTION
I notice doing another PR, the linter wasn't working correctly, besides we weren't linting | type-checking the example app

now that works


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to new CI gating (example lint/type-check) and stricter linting that could affect contributor workflows, though runtime behavior changes are minimal and largely type-only refactors.
> 
> **Overview**
> **CI now validates the `example` app.** Both `ci-main.yml` and `pr.yml` add an `example-checks` job that builds the main package, then installs/lints/type-checks the `example` app, and `e2e-tests`/production deploys now `needs` these checks.
> 
> **Oxlint now errors on `any`.** `.oxlintrc.json` enables `typescript/no-explicit-any`, and codebase updates replace explicit `any` (and ESLint disables) with a shared `$TSFixMe` alias across form components/utilities, mutation helpers, scripts, and tests; the example app also gains a `type-check` script and a small `setTimeout` typing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b007c52eacf62202ee22c019d12161d7bc1b8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->