### PR TITLE
1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,50 +4,25 @@
 
 ### Minor Changes
 
+#### Features
+
+- add support for new tel field (#858) [#858](https://github.com/remoteoss/remote-flows/pull/858)
+- update react-hook-form to v7.72.1 and @hookform/resolvers to v5.2.2 (#902) [#902](https://github.com/remoteoss/remote-flows/pull/902)
+
+
+#### Chores
 - add renovate (#840) [#840](https://github.com/remoteoss/remote-flows/pull/840)
-- move to v6 (#845) [#845](https://github.com/remoteoss/remote-flows/pull/845)
-- wait 7d to make updates (#849) [#849](https://github.com/remoteoss/remote-flows/pull/849)
-- update to latest (#837) [#837](https://github.com/remoteoss/remote-flows/pull/837)
+- move to typescript v6 (#845) [#845](https://github.com/remoteoss/remote-flows/pull/845)
 - move to oxlint (#838) [#838](https://github.com/remoteoss/remote-flows/pull/838)
-- add support for new field (#858) [#858](https://github.com/remoteoss/remote-flows/pull/858)
-- Update deps (#863) [#863](https://github.com/remoteoss/remote-flows/pull/863)
 - update dependency axios to v1.15.0 [SECURITY] (#866) [#866](https://github.com/remoteoss/remote-flows/pull/866)
-- improve rules (#867) [#867](https://github.com/remoteoss/remote-flows/pull/867)
-- update chalk (#870) [#870](https://github.com/remoteoss/remote-flows/pull/870)
-- fix ci & renovate (#874) [#874](https://github.com/remoteoss/remote-flows/pull/874)
 - update dependency dompurify to ^3.3.3 (#872) [#872](https://github.com/remoteoss/remote-flows/pull/872)
-- update dependency filesize to ^10.1.6 (#871) [#871](https://github.com/remoteoss/remote-flows/pull/871)
-- update dependency postcss to ^8.5.9 (#875) [#875](https://github.com/remoteoss/remote-flows/pull/875)
-- update dependency lucide-react to v0.577.0 (#865) [#865](https://github.com/remoteoss/remote-flows/pull/865)
-- update dependency tsx to ^4.21.0 (#877) [#877](https://github.com/remoteoss/remote-flows/pull/877)
-- update dependency express to ^4.22.1 (#878) [#878](https://github.com/remoteoss/remote-flows/pull/878)
 - update dependency tailwind-merge to ^3.5.0 (#880) [#880](https://github.com/remoteoss/remote-flows/pull/880)
-- update schneegans/dynamic-badges-action action to v1.8.0 (#882) [#882](https://github.com/remoteoss/remote-flows/pull/882)
-- update dependency @types/jsdom to v28 (#884) [#884](https://github.com/remoteoss/remote-flows/pull/884)
 - update tailwindcss monorepo to ^4.2.2 (#883) [#883](https://github.com/remoteoss/remote-flows/pull/883)
-- update dependency filesize to v11 (#885) [#885](https://github.com/remoteoss/remote-flows/pull/885)
-- update dependency jsdom to v29 (#886) [#886](https://github.com/remoteoss/remote-flows/pull/886)
-- update actions/checkout action to v6 (#887) [#887](https://github.com/remoteoss/remote-flows/pull/887)
-- update actions/github-script action to v8 (#888) [#888](https://github.com/remoteoss/remote-flows/pull/888)
-- update actions/setup-node action to v6 (#889) [#889](https://github.com/remoteoss/remote-flows/pull/889)
-- update amondnet/vercel-action action to v25 (#890) [#890](https://github.com/remoteoss/remote-flows/pull/890)
-- update github artifact actions (#891) [#891](https://github.com/remoteoss/remote-flows/pull/891)
-- update dependency express to v5 (#895) [#895](https://github.com/remoteoss/remote-flows/pull/895)
 - update dependency lucide-react to v1 (#896) [#896](https://github.com/remoteoss/remote-flows/pull/896)
 - upgrade react-day-picker from v8 to v9 with improved styling (#903) [#903](https://github.com/remoteoss/remote-flows/pull/903)
-- update react-hook-form to v7.72.1 and @hookform/resolvers to v5.2.2 (#902) [#902](https://github.com/remoteoss/remote-flows/pull/902)
-- update dependency lucide-react to ^1.8.0 (#901) [#901](https://github.com/remoteoss/remote-flows/pull/901)
-- update dependency msw to ^2.13.0 (#908) [#908](https://github.com/remoteoss/remote-flows/pull/908)
-- fix renovate rules (#909) [#909](https://github.com/remoteoss/remote-flows/pull/909)
-- update dependency jsdom to ^29.0.2 (#913) [#913](https://github.com/remoteoss/remote-flows/pull/913)
 - update dependency oxfmt to ^0.44.0 (#912) [#912](https://github.com/remoteoss/remote-flows/pull/912)
-- update dependency oxlint to ^1.59.0 (#911) [#911](https://github.com/remoteoss/remote-flows/pull/911)
-- update dependency node to v24.14.1 (#916) [#916](https://github.com/remoteoss/remote-flows/pull/916)
-- fix layout issues (#907) [#907](https://github.com/remoteoss/remote-flows/pull/907)
-- remove deprecated packages (#917) [#917](https://github.com/remoteoss/remote-flows/pull/917)
-- fix any (#920) [#920](https://github.com/remoteoss/remote-flows/pull/920)
-- update dependency msw to ^2.13.1 (#919) [#919](https://github.com/remoteoss/remote-flows/pull/919)
-- update dependency msw to ^2.13.2 (#924) [#924](https://github.com/remoteoss/remote-flows/pull/924)
+- remove lodash deprecated packages (#917) [#917](https://github.com/remoteoss/remote-flows/pull/917)
+- fix any linter (#920) [#920](https://github.com/remoteoss/remote-flows/pull/920)
 
 ## 1.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # @remoteoss/remote-flows
 
+## 1.25.0
+
+### Minor Changes
+
+- add renovate (#840) [#840](https://github.com/remoteoss/remote-flows/pull/840)
+- move to v6 (#845) [#845](https://github.com/remoteoss/remote-flows/pull/845)
+- wait 7d to make updates (#849) [#849](https://github.com/remoteoss/remote-flows/pull/849)
+- update to latest (#837) [#837](https://github.com/remoteoss/remote-flows/pull/837)
+- move to oxlint (#838) [#838](https://github.com/remoteoss/remote-flows/pull/838)
+- add support for new field (#858) [#858](https://github.com/remoteoss/remote-flows/pull/858)
+- Update deps (#863) [#863](https://github.com/remoteoss/remote-flows/pull/863)
+- update dependency axios to v1.15.0 [SECURITY] (#866) [#866](https://github.com/remoteoss/remote-flows/pull/866)
+- improve rules (#867) [#867](https://github.com/remoteoss/remote-flows/pull/867)
+- update chalk (#870) [#870](https://github.com/remoteoss/remote-flows/pull/870)
+- fix ci & renovate (#874) [#874](https://github.com/remoteoss/remote-flows/pull/874)
+- update dependency dompurify to ^3.3.3 (#872) [#872](https://github.com/remoteoss/remote-flows/pull/872)
+- update dependency filesize to ^10.1.6 (#871) [#871](https://github.com/remoteoss/remote-flows/pull/871)
+- update dependency postcss to ^8.5.9 (#875) [#875](https://github.com/remoteoss/remote-flows/pull/875)
+- update dependency lucide-react to v0.577.0 (#865) [#865](https://github.com/remoteoss/remote-flows/pull/865)
+- update dependency tsx to ^4.21.0 (#877) [#877](https://github.com/remoteoss/remote-flows/pull/877)
+- update dependency express to ^4.22.1 (#878) [#878](https://github.com/remoteoss/remote-flows/pull/878)
+- update dependency tailwind-merge to ^3.5.0 (#880) [#880](https://github.com/remoteoss/remote-flows/pull/880)
+- update schneegans/dynamic-badges-action action to v1.8.0 (#882) [#882](https://github.com/remoteoss/remote-flows/pull/882)
+- update dependency @types/jsdom to v28 (#884) [#884](https://github.com/remoteoss/remote-flows/pull/884)
+- update tailwindcss monorepo to ^4.2.2 (#883) [#883](https://github.com/remoteoss/remote-flows/pull/883)
+- update dependency filesize to v11 (#885) [#885](https://github.com/remoteoss/remote-flows/pull/885)
+- update dependency jsdom to v29 (#886) [#886](https://github.com/remoteoss/remote-flows/pull/886)
+- update actions/checkout action to v6 (#887) [#887](https://github.com/remoteoss/remote-flows/pull/887)
+- update actions/github-script action to v8 (#888) [#888](https://github.com/remoteoss/remote-flows/pull/888)
+- update actions/setup-node action to v6 (#889) [#889](https://github.com/remoteoss/remote-flows/pull/889)
+- update amondnet/vercel-action action to v25 (#890) [#890](https://github.com/remoteoss/remote-flows/pull/890)
+- update github artifact actions (#891) [#891](https://github.com/remoteoss/remote-flows/pull/891)
+- update dependency express to v5 (#895) [#895](https://github.com/remoteoss/remote-flows/pull/895)
+- update dependency lucide-react to v1 (#896) [#896](https://github.com/remoteoss/remote-flows/pull/896)
+- upgrade react-day-picker from v8 to v9 with improved styling (#903) [#903](https://github.com/remoteoss/remote-flows/pull/903)
+- update react-hook-form to v7.72.1 and @hookform/resolvers to v5.2.2 (#902) [#902](https://github.com/remoteoss/remote-flows/pull/902)
+- update dependency lucide-react to ^1.8.0 (#901) [#901](https://github.com/remoteoss/remote-flows/pull/901)
+- update dependency msw to ^2.13.0 (#908) [#908](https://github.com/remoteoss/remote-flows/pull/908)
+- fix renovate rules (#909) [#909](https://github.com/remoteoss/remote-flows/pull/909)
+- update dependency jsdom to ^29.0.2 (#913) [#913](https://github.com/remoteoss/remote-flows/pull/913)
+- update dependency oxfmt to ^0.44.0 (#912) [#912](https://github.com/remoteoss/remote-flows/pull/912)
+- update dependency oxlint to ^1.59.0 (#911) [#911](https://github.com/remoteoss/remote-flows/pull/911)
+- update dependency node to v24.14.1 (#916) [#916](https://github.com/remoteoss/remote-flows/pull/916)
+- fix layout issues (#907) [#907](https://github.com/remoteoss/remote-flows/pull/907)
+- remove deprecated packages (#917) [#917](https://github.com/remoteoss/remote-flows/pull/917)
+- fix any (#920) [#920](https://github.com/remoteoss/remote-flows/pull/920)
+- update dependency msw to ^2.13.1 (#919) [#919](https://github.com/remoteoss/remote-flows/pull/919)
+- update dependency msw to ^2.13.2 (#924) [#924](https://github.com/remoteoss/remote-flows/pull/924)
+
 ## 1.24.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - add support for new tel field (#858) [#858](https://github.com/remoteoss/remote-flows/pull/858)
 - update react-hook-form to v7.72.1 and @hookform/resolvers to v5.2.2 (#902) [#902](https://github.com/remoteoss/remote-flows/pull/902)
 
-
 #### Chores
+
 - add renovate (#840) [#840](https://github.com/remoteoss/remote-flows/pull/840)
 - move to typescript v6 (#845) [#845](https://github.com/remoteoss/remote-flows/pull/845)
 - move to oxlint (#838) [#838](https://github.com/remoteoss/remote-flows/pull/838)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - add support for new tel field (#858) [#858](https://github.com/remoteoss/remote-flows/pull/858)
 - update react-hook-form to v7.72.1 and @hookform/resolvers to v5.2.2 (#902) [#902](https://github.com/remoteoss/remote-flows/pull/902)
+- update dependency lucide-react to v1 (#896) [#896](https://github.com/remoteoss/remote-flows/pull/896)
 
 #### Chores
 
@@ -18,7 +19,6 @@
 - update dependency dompurify to ^3.3.3 (#872) [#872](https://github.com/remoteoss/remote-flows/pull/872)
 - update dependency tailwind-merge to ^3.5.0 (#880) [#880](https://github.com/remoteoss/remote-flows/pull/880)
 - update tailwindcss monorepo to ^4.2.2 (#883) [#883](https://github.com/remoteoss/remote-flows/pull/883)
-- update dependency lucide-react to v1 (#896) [#896](https://github.com/remoteoss/remote-flows/pull/896)
 - upgrade react-day-picker from v8 to v9 with improved styling (#903) [#903](https://github.com/remoteoss/remote-flows/pull/903)
 - update dependency oxfmt to ^0.44.0 (#912) [#912](https://github.com/remoteoss/remote-flows/pull/912)
 - remove lodash deprecated packages (#917) [#917](https://github.com/remoteoss/remote-flows/pull/917)

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -33,7 +33,7 @@
     },
     "..": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -53,10 +53,9 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "dompurify": "^3.3.3",
+        "fast-deep-equal": "^3.1.3",
         "lodash.capitalize": "^4.2.1",
-        "lodash.get": "^4.4.2",
         "lodash.groupby": "^4.6.0",
-        "lodash.isequal": "^4.5.0",
         "lodash.isnull": "^3.0.0",
         "lodash.mergewith": "^4.6.2",
         "lodash.omit": "^4.5.0",
@@ -80,9 +79,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jsdom": "^28.0.1",
         "@types/lodash.capitalize": "^4.2.9",
-        "@types/lodash.get": "^4.4.9",
         "@types/lodash.groupby": "^4.6.9",
-        "@types/lodash.isequal": "^4.5.8",
         "@types/lodash.isnull": "^3.0.9",
         "@types/lodash.mergewith": "^4.6.9",
         "@types/lodash.omit": "^4.5.9",
@@ -95,7 +92,7 @@
         "glob": "^13.0.6",
         "gzip-size": "^7.0.0",
         "jsdom": "^29.0.2",
-        "msw": "^2.13.0",
+        "msw": "^2.13.2",
         "oxfmt": "^0.44.0",
         "oxlint": "^1.59.0",
         "tsup": "^8.5.1",
@@ -309,9 +306,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -329,9 +323,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -349,9 +340,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -369,9 +357,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -389,9 +374,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -409,9 +391,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -429,9 +408,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -449,9 +425,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.25.0

### Minor Changes

#### Features

- add support for new tel field (#858) [#858](https://github.com/remoteoss/remote-flows/pull/858)
- update react-hook-form to v7.72.1 and @hookform/resolvers to v5.2.2 (#902) [#902](https://github.com/remoteoss/remote-flows/pull/902)
- update dependency lucide-react to v1 (#896) [#896](https://github.com/remoteoss/remote-flows/pull/896)



#### Chores
- add renovate (#840) [#840](https://github.com/remoteoss/remote-flows/pull/840)
- move to typescript v6 (#845) [#845](https://github.com/remoteoss/remote-flows/pull/845)
- move to oxlint (#838) [#838](https://github.com/remoteoss/remote-flows/pull/838)
- update dependency axios to v1.15.0 [SECURITY] (#866) [#866](https://github.com/remoteoss/remote-flows/pull/866)
- update dependency dompurify to ^3.3.3 (#872) [#872](https://github.com/remoteoss/remote-flows/pull/872)
- update dependency tailwind-merge to ^3.5.0 (#880) [#880](https://github.com/remoteoss/remote-flows/pull/880)
- update tailwindcss monorepo to ^4.2.2 (#883) [#883](https://github.com/remoteoss/remote-flows/pull/883)
- upgrade react-day-picker from v8 to v9 with improved styling (#903) [#903](https://github.com/remoteoss/remote-flows/pull/903)
- update dependency oxfmt to ^0.44.0 (#912) [#912](https://github.com/remoteoss/remote-flows/pull/912)
- remove lodash deprecated packages (#917) [#917](https://github.com/remoteoss/remote-flows/pull/917)
- fix any linter (#920) [#920](https://github.com/remoteoss/remote-flows/pull/920)

---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to version/changelog updates and lockfile dependency bumps/removals. Main risk is unexpected downstream behavior from updated/transitively updated packages.
> 
> **Overview**
> **Release `1.25.0`** by updating `package.json`/lockfiles and adding a new `CHANGELOG.md` entry.
> 
> Lockfile updates include dependency housekeeping (e.g., adding `fast-deep-equal`, removing deprecated `lodash.*` packages/types, and bumping `msw`), plus refreshed transitive metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943b5db12d7c18d047ec2f914d0a9a28a09ff766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->