### PR TITLE
chore(ci) - paralelize deploy

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -206,7 +206,8 @@ jobs:
 
   deploy-remote-flows-production:
     name: Deploy Remote Flows to Production
-    needs: [lint-and-format, build-and-exports, tests, example-checks, e2e-tests]
+    needs:
+      [lint-and-format, build-and-exports, tests, example-checks, e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -224,7 +225,14 @@ jobs:
 
   deploy-example-app-production:
     name: Deploy Example App to Production
-    needs: [lint-and-format, build-and-exports, tests, example-checks, deploy-example-app]
+    needs:
+      [
+        lint-and-format,
+        build-and-exports,
+        tests,
+        example-checks,
+        deploy-example-app,
+      ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -232,6 +232,7 @@ jobs:
         tests,
         example-checks,
         deploy-example-app,
+        e2e-tests,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -109,7 +109,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [unit-tests, example-checks, deploy-remote-flows, deploy-example-app]
+    needs: [unit-tests, example-checks, deploy-remote-flows]
     steps:
       - uses: actions/checkout@v6
 
@@ -134,16 +134,10 @@ jobs:
         with:
           name: remote-flows-url
 
-      - name: Download example-app URL
-        uses: actions/download-artifact@v8
-        with:
-          name: example-app-url
-
-      - name: Set deployment URLs
-        id: set-urls
+      - name: Set deployment URL
+        id: set-url
         run: |
           echo "REMOTE_FLOWS_URL=$(cat remote-flows-url.txt)" >> $GITHUB_ENV
-          echo "EXAMPLE_APP_URL=$(cat example-app-url.txt)" >> $GITHUB_ENV
 
       - name: Run Playwright tests
         env:
@@ -160,9 +154,9 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-  deploy-production:
-    name: Deploy to Production
-    needs: [unit-tests, example-checks, e2e-tests]
+  deploy-remote-flows-production:
+    name: Deploy Remote Flows to Production
+    needs: [e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -177,6 +171,13 @@ jobs:
           vercel-args: '--prod'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-comment: true
+
+  deploy-example-app-production:
+    name: Deploy Example App to Production
+    needs: [unit-tests, example-checks, deploy-example-app]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Promote example app to production
         uses: amondnet/vercel-action@v25


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions job dependencies for preview and production deploys; misconfigured `needs` or artifacts could skip required gates or deploy the wrong app at the wrong time.
> 
> **Overview**
> **CI pipeline now parallelizes production promotions.** The previous single production deploy job is split into `deploy-remote-flows-production` and `deploy-example-app-production`, with distinct `needs` so remote-flows can promote after `e2e-tests` while the example app promotion additionally waits for `deploy-example-app`.
> 
> **E2E tests no longer depend on the example-app preview deploy.** The workflow stops downloading/setting `EXAMPLE_APP_URL` and only sets `REMOTE_FLOWS_URL` for Playwright (`BASE_URL`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e946d2430ee1837ff7cef0c06321e3766d9478d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->