### PR TITLE
fix(errors) - nested fields are parsed now

### DIFF
--- a/example/src/ReviewOnboardingStep.tsx
+++ b/example/src/ReviewOnboardingStep.tsx
@@ -5,7 +5,8 @@ import {
   Employment,
   CreditRiskState,
   NormalizedFieldError,
-  Meta,
+  MetaValues,
+  NestedMeta,
 } from '@remoteoss/remote-flows';
 import { AlertError } from './AlertError';
 import { OnboardingAlertStatuses } from './OnboardingAlertStatuses';
@@ -110,47 +111,48 @@ export function ReviewMeta({
   meta,
   isNested = false,
 }: {
-  meta: Meta;
+  meta: NestedMeta;
   isNested?: boolean;
 }) {
+  if (!meta) return null;
+
   return (
     <div className={isNested ? 'onboarding-values' : 'onboarding-values pl-3'}>
       {Object.entries(meta).map(([key, value]) => {
-        const label = value?.label;
-        const prettyValue = value?.prettyValue;
+        if (!value) return null;
 
-        // If this has a label and prettyValue, it's a field - render it
-        if (label && prettyValue !== undefined && prettyValue !== '') {
-          let displayValue;
+        const isLeafNode =
+          typeof value === 'object' &&
+          ('label' in value || 'prettyValue' in value || 'inputType' in value);
 
-          // Handle file uploads (array of File objects)
-          if (value?.inputType === 'file' && Array.isArray(prettyValue)) {
-            displayValue = prettyValue
-              .map((file: File) => file.name)
-              .join(', ');
+        if (isLeafNode) {
+          const metaValue = value as MetaValues;
+          const label = metaValue.label;
+          const prettyValue = metaValue.prettyValue;
+
+          if (label && prettyValue !== undefined && prettyValue !== '') {
+            let displayValue;
+
+            if (metaValue.inputType === 'file' && Array.isArray(prettyValue)) {
+              displayValue = prettyValue
+                .map((file: File) => file.name)
+                .join(', ');
+            } else if (typeof prettyValue === 'boolean') {
+              displayValue = prettyValue ? 'Yes' : 'No';
+            } else {
+              displayValue = prettyValue;
+            }
+
+            return (
+              <pre key={key}>
+                {label}: {displayValue}
+              </pre>
+            );
           }
-          // Handle boolean prettyValue
-          else if (typeof prettyValue === 'boolean') {
-            displayValue = prettyValue ? 'Yes' : 'No';
-          }
-          // Handle other types
-          else {
-            displayValue = prettyValue;
-          }
-
-          return (
-            <pre key={key}>
-              {label}: {displayValue}
-            </pre>
-          );
-        }
-
-        // If this is an object without label/prettyValue, it's a fieldset
-        // Recursively render its nested fields with indentation
-        if (value && typeof value === 'object' && !label && !prettyValue) {
+        } else if (typeof value === 'object') {
           return (
             <div key={key}>
-              <ReviewMeta meta={value as Meta} isNested />
+              <ReviewMeta meta={value as NestedMeta} isNested />
             </div>
           );
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,6 +123,8 @@ export type {
   DrawerComponentProps,
   PDFPreviewComponentProps,
   Meta,
+  NestedMeta,
+  MetaValues,
 } from '@/src/types/remoteFlows';
 
 export type {

--- a/src/lib/__tests__/mutations.test.ts
+++ b/src/lib/__tests__/mutations.test.ts
@@ -1,5 +1,99 @@
-import { ErrorResponse, mutationToPromise } from '@/src/lib/mutations';
-import { $TSFixMe } from '@/src/types/remoteFlows';
+import {
+  ErrorResponse,
+  mutationToPromise,
+  normalizeFieldErrors,
+  FieldError,
+} from '@/src/lib/mutations';
+import { $TSFixMe, Meta } from '@/src/types/remoteFlows';
+
+describe('normalizeFieldErrors', () => {
+  it('should return empty array when no errors', () => {
+    expect(normalizeFieldErrors([])).toEqual([]);
+  });
+
+  it('should use field name when no meta provided', () => {
+    const fieldErrors: FieldError[] = [
+      { field: 'email', messages: ['Email is required'] },
+    ];
+
+    const result = normalizeFieldErrors(fieldErrors);
+
+    expect(result).toEqual([
+      {
+        field: 'email',
+        messages: ['Email is required'],
+        userFriendlyLabel: 'email',
+      },
+    ]);
+  });
+
+  it('should use label from meta when available', () => {
+    const fieldErrors: FieldError[] = [
+      { field: 'email', messages: ['Email is required'] },
+    ];
+    const meta: Meta = { email: { label: 'Email Address' } };
+
+    const result = normalizeFieldErrors(fieldErrors, meta);
+
+    expect(result).toEqual([
+      {
+        field: 'email',
+        messages: ['Email is required'],
+        userFriendlyLabel: 'Email Address',
+      },
+    ]);
+  });
+
+  it('should handle one level nested field with slash notation', () => {
+    const fieldErrors: FieldError[] = [
+      {
+        field: 'service_duration/expiration_date',
+        messages: ['date must be after start date'],
+      },
+    ];
+    const meta: Meta = {
+      service_duration: {
+        expiration_date: { label: 'Service end date' },
+      },
+    };
+
+    const result = normalizeFieldErrors(fieldErrors, meta);
+
+    expect(result).toEqual([
+      {
+        field: 'service_duration/expiration_date',
+        messages: ['date must be after start date'],
+        userFriendlyLabel: 'Service end date',
+      },
+    ]);
+  });
+
+  it('should handle multiple level nested fields', () => {
+    const fieldErrors: FieldError[] = [
+      {
+        field: 'contact/address/street',
+        messages: ['Street is required'],
+      },
+    ];
+    const meta: Meta = {
+      contact: {
+        address: {
+          street: { label: 'Street Address' },
+        },
+      },
+    };
+
+    const result = normalizeFieldErrors(fieldErrors, meta);
+
+    expect(result).toEqual([
+      {
+        field: 'contact/address/street',
+        messages: ['Street is required'],
+        userFriendlyLabel: 'Street Address',
+      },
+    ]);
+  });
+});
 
 describe('mutationToPromise', () => {
   describe('mutateAsync', () => {

--- a/src/lib/__tests__/mutations.test.ts
+++ b/src/lib/__tests__/mutations.test.ts
@@ -4,7 +4,7 @@ import {
   normalizeFieldErrors,
   FieldError,
 } from '@/src/lib/mutations';
-import { $TSFixMe, Meta } from '@/src/types/remoteFlows';
+import { $TSFixMe, Meta, NestedMeta } from '@/src/types/remoteFlows';
 
 describe('normalizeFieldErrors', () => {
   it('should return empty array when no errors', () => {
@@ -51,7 +51,7 @@ describe('normalizeFieldErrors', () => {
         messages: ['date must be after start date'],
       },
     ];
-    const meta: Meta = {
+    const meta: NestedMeta = {
       service_duration: {
         expiration_date: { label: 'Service end date' },
       },
@@ -75,7 +75,7 @@ describe('normalizeFieldErrors', () => {
         messages: ['Street is required'],
       },
     ];
-    const meta: Meta = {
+    const meta: NestedMeta = {
       contact: {
         address: {
           street: { label: 'Street Address' },

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -1,4 +1,4 @@
-import { Meta, $TSFixMe } from '@/src/types/remoteFlows';
+import { $TSFixMe, NestedMeta } from '@/src/types/remoteFlows';
 import { UseMutationResult } from '@tanstack/react-query';
 
 type MutationData<T> =
@@ -184,7 +184,7 @@ export interface NormalizedFieldError extends FieldError {
  */
 export function normalizeFieldErrors(
   fieldErrors: FieldError[],
-  meta?: Meta,
+  meta?: NestedMeta,
 ): NormalizedFieldError[] {
   if (!fieldErrors || fieldErrors.length === 0) {
     return [];

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -191,8 +191,29 @@ export function normalizeFieldErrors(
   }
 
   return fieldErrors.map((fieldError) => {
-    const fieldMeta = meta?.[fieldError.field];
-    const userFriendlyLabel = fieldMeta?.label || fieldError.field;
+    let fieldMeta = meta?.[fieldError.field];
+    let userFriendlyLabel: string = fieldError.field;
+
+    // If not found directly, try nested path (e.g., "service_duration/expiration_date")
+    if (!fieldMeta && meta && fieldError.field.includes('/')) {
+      const pathParts = fieldError.field.split('/');
+      let current: $TSFixMe = meta;
+
+      for (const part of pathParts) {
+        if (current && typeof current === 'object') {
+          current = current[part];
+        } else {
+          current = undefined;
+          break;
+        }
+      }
+
+      fieldMeta = current;
+    }
+
+    if (typeof fieldMeta?.label === 'string') {
+      userFriendlyLabel = fieldMeta.label;
+    }
 
     return {
       ...fieldError,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { ValidationError } from 'yup';
 import DOMPurify from 'dompurify';
-import { JSFFields, Meta } from '@/src/types/remoteFlows';
+import { JSFFields, NestedMeta } from '@/src/types/remoteFlows';
 import {
   NormalizedFieldError,
   normalizeFieldErrors,
@@ -292,7 +292,7 @@ export function isStructuredError(err: unknown): err is {
  */
 export function handleStepError(
   err: unknown,
-  fieldsMeta?: Meta,
+  fieldsMeta?: NestedMeta,
 ): {
   error: Error;
   rawError: Record<string, unknown>;

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -229,13 +229,23 @@ declare global {
   }
 }
 
-type MetaValues = {
+export type MetaValues = {
   label?: string;
   prettyValue?: string | boolean;
   inputType?: string;
   desiredCurrency?: string;
 };
 
-export interface Meta {
-  [key: string]: MetaValues | Meta;
+/**
+ * Meta is a record of field names and their values.
+ * @deprecated Use NestedMeta instead.
+ */
+export type Meta = Record<string, MetaValues>;
+
+/**
+ * NestedMeta is a record of field names and their values.
+ * This is used to retrieve the label for a field from the meta data.
+ */
+export interface NestedMeta {
+  [key: string]: MetaValues | NestedMeta;
 }

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -236,4 +236,6 @@ type MetaValues = {
   desiredCurrency?: string;
 };
 
-export type Meta = Record<string, MetaValues>;
+export interface Meta {
+  [key: string]: MetaValues | Meta;
+}


### PR DESCRIPTION
## Before

<img width="2370" height="426" alt="image" src="https://github.com/user-attachments/assets/228c1468-7760-49ff-a877-017faaeaddc3" />


## Now

<img width="602" height="115" alt="image" src="https://github.com/user-attachments/assets/2db1bbf3-0041-4b5f-b015-c14b4a02a685" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared error-normalization logic used across multiple flows; a mistake could regress how field-level validation errors are labeled or displayed, though the change is localized and covered by new tests.
> 
> **Overview**
> Improves field-error normalization to resolve labels from **nested** meta structures, including slash-delimited field paths (e.g. `service_duration/expiration_date`), instead of only supporting flat `Meta` lookups.
> 
> Introduces and exports `NestedMeta`/`MetaValues` (marking `Meta` as deprecated), updates consumers (`handleStepError` and the example `ReviewMeta` renderer) to use the nested type, and adds unit tests covering nested-path label resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a49186e8e2100130fff274f189e3c4734bd1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->