### PR TITLE
1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,24 @@
 
 ### Minor Changes
 
-- paralelize jobs (#923) [#923](https://github.com/remoteoss/remote-flows/pull/923)
+#### Features
 - add dynamic steps (#922) [#922](https://github.com/remoteoss/remote-flows/pull/922)
-- paralelize deploy (#926) [#926](https://github.com/remoteoss/remote-flows/pull/926)
-- update dependency vite to ^8.0.8 (#929) [#929](https://github.com/remoteoss/remote-flows/pull/929)
 - update dependency dompurify to v3.4.0 [security] (#928) [#928](https://github.com/remoteoss/remote-flows/pull/928)
-- nested fields are parsed now (#930) [#930](https://github.com/remoteoss/remote-flows/pull/930)
-- add help center article (#921) [#921](https://github.com/remoteoss/remote-flows/pull/921)
+- add help center article in textarea (#921) [#921](https://github.com/remoteoss/remote-flows/pull/921)
+- fix submission contract-details in contractor-onboarding as switcher component wasn't working correctly (#932) [#932](https://github.com/remoteoss/remote-flows/pull/932)
+
+
+#### Fixes
+- nested fields are parsed in the error messages (#930) [#930](https://github.com/remoteoss/remote-flows/pull/930)
+
+
+#### Chores
+- paralelize jobs and improve CI (#923) [#923](https://github.com/remoteoss/remote-flows/pull/923)
+- update dependency vite to ^8.0.8 (#929) [#929](https://github.com/remoteoss/remote-flows/pull/929)
 - update vitest monorepo to ^4.1.4 (#931) [#931](https://github.com/remoteoss/remote-flows/pull/931)
 - update actions/cache action to v5 (#933) [#933](https://github.com/remoteoss/remote-flows/pull/933)
 - update actions/upload-artifact action to v7 (#934) [#934](https://github.com/remoteoss/remote-flows/pull/934)
 - update actions/github-script action to v9 (#935) [#935](https://github.com/remoteoss/remote-flows/pull/935)
-- fix submission contract-details (#932) [#932](https://github.com/remoteoss/remote-flows/pull/932)
 
 ## 1.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @remoteoss/remote-flows
 
+## 1.26.0
+
+### Minor Changes
+
+- paralelize jobs (#923) [#923](https://github.com/remoteoss/remote-flows/pull/923)
+- add dynamic steps (#922) [#922](https://github.com/remoteoss/remote-flows/pull/922)
+- paralelize deploy (#926) [#926](https://github.com/remoteoss/remote-flows/pull/926)
+- update dependency vite to ^8.0.8 (#929) [#929](https://github.com/remoteoss/remote-flows/pull/929)
+- update dependency dompurify to v3.4.0 [security] (#928) [#928](https://github.com/remoteoss/remote-flows/pull/928)
+- nested fields are parsed now (#930) [#930](https://github.com/remoteoss/remote-flows/pull/930)
+- add help center article (#921) [#921](https://github.com/remoteoss/remote-flows/pull/921)
+- update vitest monorepo to ^4.1.4 (#931) [#931](https://github.com/remoteoss/remote-flows/pull/931)
+- update actions/cache action to v5 (#933) [#933](https://github.com/remoteoss/remote-flows/pull/933)
+- update actions/upload-artifact action to v7 (#934) [#934](https://github.com/remoteoss/remote-flows/pull/934)
+- update actions/github-script action to v9 (#935) [#935](https://github.com/remoteoss/remote-flows/pull/935)
+- fix submission contract-details (#932) [#932](https://github.com/remoteoss/remote-flows/pull/932)
+
 ## 1.25.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@
 ### Minor Changes
 
 #### Features
+
 - add dynamic steps (#922) [#922](https://github.com/remoteoss/remote-flows/pull/922)
 - update dependency dompurify to v3.4.0 [security] (#928) [#928](https://github.com/remoteoss/remote-flows/pull/928)
 - add help center article in textarea (#921) [#921](https://github.com/remoteoss/remote-flows/pull/921)
 - fix submission contract-details in contractor-onboarding as switcher component wasn't working correctly (#932) [#932](https://github.com/remoteoss/remote-flows/pull/932)
 
-
 #### Fixes
+
 - nested fields are parsed in the error messages (#930) [#930](https://github.com/remoteoss/remote-flows/pull/930)
 
-
 #### Chores
+
 - paralelize jobs and improve CI (#923) [#923](https://github.com/remoteoss/remote-flows/pull/923)
 - update dependency vite to ^8.0.8 (#929) [#929](https://github.com/remoteoss/remote-flows/pull/929)
 - update vitest monorepo to ^4.1.4 (#931) [#931](https://github.com/remoteoss/remote-flows/pull/931)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -3583,9 +3583,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3603,9 +3600,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3623,9 +3617,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3643,9 +3634,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3663,9 +3651,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3683,9 +3668,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.26.0

### Minor Changes

#### Features
- add dynamic steps (#922) [#922](https://github.com/remoteoss/remote-flows/pull/922)
- update dependency dompurify to v3.4.0 [security] (#928) [#928](https://github.com/remoteoss/remote-flows/pull/928)
- add help center article in textarea (#921) [#921](https://github.com/remoteoss/remote-flows/pull/921)
- fix submission contract-details in contractor-onboarding as switcher component wasn't working correctly (#932) [#932](https://github.com/remoteoss/remote-flows/pull/932)


#### Fixes
- nested fields are parsed in the error messages (#930) [#930](https://github.com/remoteoss/remote-flows/pull/930)


#### Chores
- paralelize jobs and improve CI (#923) [#923](https://github.com/remoteoss/remote-flows/pull/923)
- update dependency vite to ^8.0.8 (#929) [#929](https://github.com/remoteoss/remote-flows/pull/929)
- update vitest monorepo to ^4.1.4 (#931) [#931](https://github.com/remoteoss/remote-flows/pull/931)
- update actions/cache action to v5 (#933) [#933](https://github.com/remoteoss/remote-flows/pull/933)
- update actions/upload-artifact action to v7 (#934) [#934](https://github.com/remoteoss/remote-flows/pull/934)
- update actions/github-script action to v9 (#935) [#935](https://github.com/remoteoss/remote-flows/pull/935)

---

This release was automatically generated from conventional commits.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version bump and changelog update, plus lockfile churn from dependency metadata updates; low risk to runtime behavior beyond resolved dependency changes.
> 
> **Overview**
> **Cuts release `1.26.0`.** Updates `package.json`/`package-lock.json` version from `1.25.0` to `1.26.0` and adds the corresponding `1.26.0` entry to `CHANGELOG.md`.
> 
> `package-lock.json` also reflects regenerated dependency metadata (notably around optional `@rolldown/*` native bindings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3b8921026339f50de55973d6e0b0439bae873b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->