### PR TITLE
docs(termination) - use useJSONSchemaForm abstraction

### DIFF
--- a/src/flows/Termination/TerminationForm.tsx
+++ b/src/flows/Termination/TerminationForm.tsx
@@ -10,7 +10,7 @@ import { ValidationResult } from '@remoteoss/remote-json-schema-form-kit';
 type TerminationFormProps = {
   onSubmit: (payload: TerminationFormValues) => void;
   fields?: JSFFields;
-  defaultValues?: FieldValues;
+  defaultValues: Record<string, unknown>;
 };
 
 export function TerminationForm({
@@ -26,7 +26,7 @@ export function TerminationForm({
     handleValidation: terminationBag.handleValidation as (
       values: FieldValues,
     ) => Promise<ValidationResult | null>,
-    defaultValues: defaultValues || {},
+    defaultValues: defaultValues,
     checkFieldUpdates: terminationBag.checkFieldUpdates as (
       values: FieldValues,
     ) => void,

--- a/src/flows/Termination/TerminationForm.tsx
+++ b/src/flows/Termination/TerminationForm.tsx
@@ -5,6 +5,7 @@ import { useTerminationContext } from './context';
 import { TerminationFormValues } from '@/src/flows/Termination/types';
 import { useJSONSchemaForm } from '@/src/components/form/useJSONSchemaForm';
 import { FieldValues } from 'react-hook-form';
+import { ValidationResult } from '@remoteoss/remote-json-schema-form-kit';
 
 type TerminationFormProps = {
   onSubmit: (payload: TerminationFormValues) => void;
@@ -19,10 +20,16 @@ export function TerminationForm({
 }: TerminationFormProps) {
   const { formId, terminationBag } = useTerminationContext();
 
+  // casting handleValidation and checkFieldUpdates to the correct type
+  // my reasoning is partners could use these functions directly and I want to avoid breaking changes on types
   const form = useJSONSchemaForm({
-    handleValidation: terminationBag.handleValidation,
+    handleValidation: terminationBag.handleValidation as (
+      values: FieldValues,
+    ) => Promise<ValidationResult | null>,
     defaultValues: defaultValues || {},
-    checkFieldUpdates: terminationBag.checkFieldUpdates,
+    checkFieldUpdates: terminationBag.checkFieldUpdates as (
+      values: FieldValues,
+    ) => void,
   });
 
   const jsonSchemaFields = fields ? fields : (terminationBag?.fields ?? []);

--- a/src/flows/Termination/TerminationForm.tsx
+++ b/src/flows/Termination/TerminationForm.tsx
@@ -1,16 +1,15 @@
 import { JSFFields } from '@/src/types/remoteFlows';
 import { JSONSchemaFormFields } from '@/src/components/form/JSONSchemaForm';
 import { Form } from '@/src/components/ui/form';
-import { useEffect } from 'react';
 import { useTerminationContext } from './context';
 import { TerminationFormValues } from '@/src/flows/Termination/types';
-import { useForm } from 'react-hook-form';
-import { useJsonSchemasValidationFormResolver } from '@/src/components/form/validationResolver';
+import { useJSONSchemaForm } from '@/src/components/form/useJSONSchemaForm';
+import { FieldValues } from 'react-hook-form';
 
 type TerminationFormProps = {
   onSubmit: (payload: TerminationFormValues) => void;
   fields?: JSFFields;
-  defaultValues?: TerminationFormValues;
+  defaultValues?: FieldValues;
 };
 
 export function TerminationForm({
@@ -20,31 +19,11 @@ export function TerminationForm({
 }: TerminationFormProps) {
   const { formId, terminationBag } = useTerminationContext();
 
-  const resolver = useJsonSchemasValidationFormResolver(
-    terminationBag.handleValidation,
-  );
-
-  const form = useForm({
-    resolver,
-    defaultValues: defaultValues,
-    shouldUnregister: false,
-    mode: 'onBlur',
+  const form = useJSONSchemaForm({
+    handleValidation: terminationBag.handleValidation,
+    defaultValues: defaultValues || {},
+    checkFieldUpdates: terminationBag.checkFieldUpdates,
   });
-
-  useEffect(() => {
-    const subscription = form?.watch((values) => {
-      const isAnyFieldDirty = Object.keys(values).some(
-        (key) =>
-          values[key as keyof TerminationFormValues] !==
-          terminationBag?.initialValues?.[key as keyof TerminationFormValues],
-      );
-      if (isAnyFieldDirty) {
-        terminationBag?.checkFieldUpdates(values as TerminationFormValues);
-      }
-    });
-    return () => subscription?.unsubscribe();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const jsonSchemaFields = fields ? fields : (terminationBag?.fields ?? []);
 

--- a/src/flows/Termination/hooks.tsx
+++ b/src/flows/Termination/hooks.tsx
@@ -44,6 +44,7 @@ import { AcknowledgeInformationFees } from '@/src/flows/Termination/components/A
 import { usePayrollCalendars } from '@/src/common/api/payroll-calendars';
 import { isInProbationPeriod } from '@/src/common/employment';
 import { ZendeskTriggerButton } from '@/src/components/shared/zendesk-drawer/ZendeskTriggerButton';
+import { FieldValues } from 'react-hook-form';
 
 type TerminationHookProps = Omit<TerminationFlowProps, 'render'>;
 
@@ -53,7 +54,7 @@ export const useTermination = ({
   initialValues: terminationInitialValues,
 }: TerminationHookProps) => {
   const { fieldValues, setFieldValues, stepState, previousStep, nextStep } =
-    useStepState<keyof typeof STEPS, TerminationFormValues>(STEPS);
+    useStepState<keyof typeof STEPS, FieldValues>(STEPS);
 
   const { data: employment, isLoading: isLoadingEmployment } =
     useEmploymentQuery({ employmentId, queryParams: { exclude_files: true } });
@@ -479,7 +480,7 @@ export const useTermination = ({
      * @param values - Form values to validate
      * @returns Validation result or null if no schema is available
      */
-    handleValidation: async (values: TerminationFormValues) => {
+    handleValidation: async (values: FieldValues) => {
       if (terminationHeadlessForm) {
         const parsedValues = await parseJSFToValidate(
           values,

--- a/src/flows/Termination/hooks.tsx
+++ b/src/flows/Termination/hooks.tsx
@@ -44,7 +44,6 @@ import { AcknowledgeInformationFees } from '@/src/flows/Termination/components/A
 import { usePayrollCalendars } from '@/src/common/api/payroll-calendars';
 import { isInProbationPeriod } from '@/src/common/employment';
 import { ZendeskTriggerButton } from '@/src/components/shared/zendesk-drawer/ZendeskTriggerButton';
-import { FieldValues } from 'react-hook-form';
 
 type TerminationHookProps = Omit<TerminationFlowProps, 'render'>;
 
@@ -54,7 +53,7 @@ export const useTermination = ({
   initialValues: terminationInitialValues,
 }: TerminationHookProps) => {
   const { fieldValues, setFieldValues, stepState, previousStep, nextStep } =
-    useStepState<keyof typeof STEPS, FieldValues>(STEPS);
+    useStepState<keyof typeof STEPS, TerminationFormValues>(STEPS);
 
   const { data: employment, isLoading: isLoadingEmployment } =
     useEmploymentQuery({ employmentId, queryParams: { exclude_files: true } });
@@ -480,7 +479,7 @@ export const useTermination = ({
      * @param values - Form values to validate
      * @returns Validation result or null if no schema is available
      */
-    handleValidation: async (values: FieldValues) => {
+    handleValidation: async (values: TerminationFormValues) => {
       if (terminationHeadlessForm) {
         const parsedValues = await parseJSFToValidate(
           values,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches form validation and change-detection behavior by switching to a shared hook (deep-equal based), which could subtly alter when `checkFieldUpdates` fires. No auth/security or data persistence logic changes.
> 
> **Overview**
> `TerminationForm` now delegates `react-hook-form` setup (resolver wiring and change watching) to the shared `useJSONSchemaForm` hook, removing the inline `useForm` + custom `useEffect` dirty-check logic.
> 
> The component’s `defaultValues` prop is tightened to a required `Record<string, unknown>`, and `terminationBag.handleValidation` / `checkFieldUpdates` are type-cast to `FieldValues`-based signatures to preserve partner-facing types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63dd6751985a67cc8f14cfaa153252a3cd0ae6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->