### PR TITLE
1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,23 @@
 
 ### Minor Changes
 
+#### Features
+
+- use useJSONSchemaForm abstraction (#943) [#943](https://github.com/remoteoss/remote-flows/pull/943)
+- make some improvements to the diff tool (#941) [#941](https://github.com/remoteoss/remote-flows/pull/941)
+- upgrade to npm release remote-json-schema-form-kit (#918) [#918](https://github.com/remoteoss/remote-flows/pull/918)
+- remove package.json carets (#936) [#936](https://github.com/remoteoss/remote-flows/pull/936)
+
+
+#### Chores
+
 - update dependency @tanstack/react-query to ^5.99.0 (#939) [#939](https://github.com/remoteoss/remote-flows/pull/939)
 - update dependency oxfmt to ^0.45.0 (#948) [#948](https://github.com/remoteoss/remote-flows/pull/948)
 - update opeanpi types (#942) [#942](https://github.com/remoteoss/remote-flows/pull/942)
-- use useJSONSchemaForm abstraction (#943) [#943](https://github.com/remoteoss/remote-flows/pull/943)
-- upgrade to npm release (#918) [#918](https://github.com/remoteoss/remote-flows/pull/918)
 - update dependency msw to ^2.13.3 (#949) [#949](https://github.com/remoteoss/remote-flows/pull/949)
 - update dependency oxlint to ^1.60.0 (#947) [#947](https://github.com/remoteoss/remote-flows/pull/947)
-- remove carets (#936) [#936](https://github.com/remoteoss/remote-flows/pull/936)
 - update dependency dotenv to v17.4.2 (#950) [#950](https://github.com/remoteoss/remote-flows/pull/950)
-- make some improvements (#941) [#941](https://github.com/remoteoss/remote-flows/pull/941)
+
 
 ## 1.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - upgrade to npm release remote-json-schema-form-kit (#918) [#918](https://github.com/remoteoss/remote-flows/pull/918)
 - remove package.json carets (#936) [#936](https://github.com/remoteoss/remote-flows/pull/936)
 
-
 #### Chores
 
 - update dependency @tanstack/react-query to ^5.99.0 (#939) [#939](https://github.com/remoteoss/remote-flows/pull/939)
@@ -20,7 +19,6 @@
 - update dependency msw to ^2.13.3 (#949) [#949](https://github.com/remoteoss/remote-flows/pull/949)
 - update dependency oxlint to ^1.60.0 (#947) [#947](https://github.com/remoteoss/remote-flows/pull/947)
 - update dependency dotenv to v17.4.2 (#950) [#950](https://github.com/remoteoss/remote-flows/pull/950)
-
 
 ## 1.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @remoteoss/remote-flows
 
+## 1.27.0
+
+### Minor Changes
+
+- update dependency @tanstack/react-query to ^5.99.0 (#939) [#939](https://github.com/remoteoss/remote-flows/pull/939)
+- update dependency oxfmt to ^0.45.0 (#948) [#948](https://github.com/remoteoss/remote-flows/pull/948)
+- update opeanpi types (#942) [#942](https://github.com/remoteoss/remote-flows/pull/942)
+- use useJSONSchemaForm abstraction (#943) [#943](https://github.com/remoteoss/remote-flows/pull/943)
+- upgrade to npm release (#918) [#918](https://github.com/remoteoss/remote-flows/pull/918)
+- update dependency msw to ^2.13.3 (#949) [#949](https://github.com/remoteoss/remote-flows/pull/949)
+- update dependency oxlint to ^1.60.0 (#947) [#947](https://github.com/remoteoss/remote-flows/pull/947)
+- remove carets (#936) [#936](https://github.com/remoteoss/remote-flows/pull/936)
+- update dependency dotenv to v17.4.2 (#950) [#950](https://github.com/remoteoss/remote-flows/pull/950)
+- make some improvements (#941) [#941](https://github.com/remoteoss/remote-flows/pull/941)
+
 ## 1.26.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.27.0

### Minor Changes

#### Features

- use useJSONSchemaForm abstraction (#943) [#943](https://github.com/remoteoss/remote-flows/pull/943)
- make some improvements to the diff tool (#941) [#941](https://github.com/remoteoss/remote-flows/pull/941)
- upgrade to npm release remote-json-schema-form-kit (#918) [#918](https://github.com/remoteoss/remote-flows/pull/918)
- remove package.json carets (#936) [#936](https://github.com/remoteoss/remote-flows/pull/936)


#### Chores

- update dependency @tanstack/react-query to ^5.99.0 (#939) [#939](https://github.com/remoteoss/remote-flows/pull/939)
- update dependency oxfmt to ^0.45.0 (#948) [#948](https://github.com/remoteoss/remote-flows/pull/948)
- update opeanpi types (#942) [#942](https://github.com/remoteoss/remote-flows/pull/942)
- update dependency msw to ^2.13.3 (#949) [#949](https://github.com/remoteoss/remote-flows/pull/949)
- update dependency oxlint to ^1.60.0 (#947) [#947](https://github.com/remoteoss/remote-flows/pull/947)
- update dependency dotenv to v17.4.2 (#950) [#950](https://github.com/remoteoss/remote-flows/pull/950)


---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version bump + changelog update) with no runtime code changes.
> 
> **Overview**
> Updates the package release metadata to `1.27.0` by bumping the version in `package.json` and `package-lock.json`.
> 
> Adds a new `CHANGELOG.md` entry for `1.27.0` documenting the included feature work and dependency/tooling updates for this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58057097a7419b2bf17faf9f08429835bb8b600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->