### PR TITLE
chore(ci) - remove vercel deployment

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -122,33 +122,6 @@ jobs:
           name: remote-flows-url
           path: remote-flows-url.txt
 
-  deploy-example-app:
-    name: Deploy Example App Preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Deploy remote-flows-example-app to vercel
-        id: vercel-example-app
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_EXAMPLE_APP_PROJECT_ID }}
-          scope: ${{ secrets.VERCEL_ORG_ID }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: true
-
-      - name: Save deployment URL
-        run: |
-          echo "${{ steps.vercel-example-app.outputs.preview-url }}" > example-app-url.txt
-
-      - name: Upload deployment URL
-        uses: actions/upload-artifact@v7
-        with:
-          name: example-app-url
-          path: example-app-url.txt
-
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
@@ -218,32 +191,6 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_REMOTE_FLOWS_PROJECT_ID }}
-          scope: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-args: '--prod'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: true
-
-  deploy-example-app-production:
-    name: Deploy Example App to Production
-    needs:
-      [
-        lint-and-format,
-        build-and-exports,
-        tests,
-        example-checks,
-        deploy-example-app,
-        e2e-tests,
-      ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Promote example app to production
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_EXAMPLE_APP_PROJECT_ID }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
           vercel-args: '--prod'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -298,33 +298,6 @@ jobs:
           name: remote-flows-url
           path: remote-flows-url.txt
 
-  deploy-example-app:
-    name: Deploy Example App Preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Deploy remote-flows-example-app to vercel
-        id: vercel-example-app
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_EXAMPLE_APP_PROJECT_ID }}
-          scope: ${{ secrets.VERCEL_ORG_ID }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: true
-
-      - name: Save deployment URL
-        run: |
-          echo "${{ steps.vercel-example-app.outputs.preview-url }}" > example-app-url.txt
-
-      - name: Upload deployment URL
-        uses: actions/upload-artifact@v7
-        with:
-          name: example-app-url
-          path: example-app-url.txt
-
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
@@ -335,7 +308,6 @@ jobs:
         tests,
         example-checks,
         deploy-remote-flows,
-        deploy-example-app,
       ]
     steps:
       - uses: actions/checkout@v6
@@ -361,16 +333,10 @@ jobs:
         with:
           name: remote-flows-url
 
-      - name: Download example-app URL
-        uses: actions/download-artifact@v8
-        with:
-          name: example-app-url
-
       - name: Set deployment URLs
         id: set-urls
         run: |
           echo "REMOTE_FLOWS_URL=$(cat remote-flows-url.txt)" >> $GITHUB_ENV
-          echo "EXAMPLE_APP_URL=$(cat example-app-url.txt)" >> $GITHUB_ENV
 
       - name: Run Playwright tests
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk code-wise since this only changes GitHub Actions workflow configuration, but it will stop publishing the example app preview/production deployments and may affect any consumers expecting those URLs/artifacts.
> 
> **Overview**
> Removes the GitHub Actions jobs that deploy the example app to Vercel (both preview and production), along with the associated URL artifacts.
> 
> Updates the PR E2E workflow to no longer depend on the example app deployment or download/set `EXAMPLE_APP_URL`, running Playwright against only the `remote-flows` preview URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b54176a217ed286f6d5da716f885a534fdc5dc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->