### PR TITLE
1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,11 @@
 
 - add engagement step for Germany (#946) [#946](https://github.com/remoteoss/remote-flows/pull/946)
 
-
 #### Chores
 
 - remove vercel deployment (#952) [#952](https://github.com/remoteoss/remote-flows/pull/952)
 - update amondnet/vercel-action action to v42 (#940) [#940](https://github.com/remoteoss/remote-flows/pull/940)
 - update dependency postcss to v8.5.10 (#954) [#954](https://github.com/remoteoss/remote-flows/pull/954)
-
 
 ## 1.27.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @remoteoss/remote-flows
 
+## 1.28.0
+
+### Minor Changes
+
+- remove vercel deployment (#952) [#952](https://github.com/remoteoss/remote-flows/pull/952)
+- update amondnet/vercel-action action to v42 (#940) [#940](https://github.com/remoteoss/remote-flows/pull/940)
+- update dependency postcss to v8.5.10 (#954) [#954](https://github.com/remoteoss/remote-flows/pull/954)
+- add engagement form for Germany (#946) [#946](https://github.com/remoteoss/remote-flows/pull/946)
+
 ## 1.27.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@
 
 ### Minor Changes
 
+#### Features
+
+- add engagement step for Germany (#946) [#946](https://github.com/remoteoss/remote-flows/pull/946)
+
+
+#### Chores
+
 - remove vercel deployment (#952) [#952](https://github.com/remoteoss/remote-flows/pull/952)
 - update amondnet/vercel-action action to v42 (#940) [#940](https://github.com/remoteoss/remote-flows/pull/940)
 - update dependency postcss to v8.5.10 (#954) [#954](https://github.com/remoteoss/remote-flows/pull/954)
-- add engagement form for Germany (#946) [#946](https://github.com/remoteoss/remote-flows/pull/946)
+
 
 ## 1.27.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.28.0

### Minor Changes

#### Features

- add engagement step for Germany (#946) [#946](https://github.com/remoteoss/remote-flows/pull/946)


#### Chores

- remove vercel deployment (#952) [#952](https://github.com/remoteoss/remote-flows/pull/952)
- update amondnet/vercel-action action to v42 (#940) [#940](https://github.com/remoteoss/remote-flows/pull/940)
- update dependency postcss to v8.5.10 (#954) [#954](https://github.com/remoteoss/remote-flows/pull/954)
---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes: version bumps and changelog updates, with no functional code modifications in this diff. Low risk aside from ensuring published package metadata aligns with the intended release contents.
> 
> **Overview**
> Updates the project to **v1.28.0** by adding the `1.28.0` entry to `CHANGELOG.md` (noting the Germany engagement step and related chores) and bumping the package version from `1.27.0` to `1.28.0` in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff1b7a140b54cee7d1d37d0680f983bc599a4bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->