### PR TITLE
fix(contractor-onboarding)- avoid signing the document if it was already signed

### DIFF
--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -177,6 +177,35 @@ export const useGetShowContractDocument = ({
   });
 };
 
+export const useHasCompanySignedContract = ({
+  employmentId,
+  contractDocumentId,
+  options,
+}: {
+  employmentId: string;
+  contractDocumentId: string;
+  options?: { queryOptions?: { enabled?: boolean } };
+}) => {
+  const { data: documentPreviewPdf } = useGetShowContractDocument({
+    employmentId,
+    contractDocumentId,
+    options: {
+      queryOptions: {
+        enabled: options?.queryOptions?.enabled,
+      },
+    },
+  });
+
+  const hasCompanySignedContract =
+    documentPreviewPdf?.contract_document?.signatories?.some(
+      (signatory) =>
+        signatory.type === 'company' && signatory.status === 'signed',
+    );
+
+  return {
+    hasCompanySignedContract,
+  };
+};
 /**
  * Get the contractor subscriptions for the given employment id
  * @param employmentId - The employment ID

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -29,6 +29,7 @@ import {
   useCountriesSchemaField,
   useContractorOnboardingDetailsSchemaWithCurrencies,
   CONTRACT_PRODUCT_TITLES,
+  useHasCompanySignedContract,
 } from '@/src/flows/ContractorOnboarding/api';
 import {
   ContractorOnboardingFlowProps,
@@ -581,16 +582,29 @@ export const useContractorOnboarding = ({
     },
   });
 
-  const { data: documentPreviewPdf, isLoading: isLoadingDocumentPreviewForm } =
-    useGetShowContractDocument({
-      employmentId: internalEmploymentId as string,
-      contractDocumentId: internalContractDocumentId as string,
-      options: {
-        queryOptions: {
-          enabled: Boolean(internalContractDocumentId),
-        },
+  const {
+    data: documentPreviewPdf,
+    isLoading: isLoadingDocumentPreviewForm,
+    refetch: refetchDocumentPreviewForm,
+  } = useGetShowContractDocument({
+    employmentId: internalEmploymentId as string,
+    contractDocumentId: internalContractDocumentId as string,
+    options: {
+      queryOptions: {
+        enabled: Boolean(internalContractDocumentId),
       },
-    });
+    },
+  });
+
+  const { hasCompanySignedContract } = useHasCompanySignedContract({
+    employmentId: internalEmploymentId as string,
+    contractDocumentId: internalContractDocumentId as string,
+    options: {
+      queryOptions: {
+        enabled: Boolean(internalContractDocumentId),
+      },
+    },
+  });
 
   const stepFields: Record<StepKeys, JSFFields> = useMemo(
     () => ({
@@ -1046,6 +1060,15 @@ export const useContractorOnboarding = ({
       }
 
       case 'contract_preview': {
+        if (hasCompanySignedContract) {
+          return Promise.resolve({
+            data: {
+              contract_document: {
+                id: internalContractDocumentId,
+              },
+            },
+          });
+        }
         const response = await signContractDocumentMutationAsync({
           employmentId: internalEmploymentId as string,
           contractDocumentId: internalContractDocumentId as string,
@@ -1053,6 +1076,7 @@ export const useContractorOnboarding = ({
             signature: parsedValues.signature,
           },
         });
+        await refetchDocumentPreviewForm();
         return response;
       }
       case 'pricing_plan': {

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -2993,5 +2993,120 @@ describe('ContractorOnboardingFlow', () => {
       expect(screen.getByLabelText(/Enter full name/i)).toBeInTheDocument();
       expect(signatureField).toHaveValue('John Doe');
     });
+
+    it('should refetch contract document after signing and allow navigation back without errors', async () => {
+      const employmentId = generateUniqueEmploymentId();
+      const contractDocumentId = 'f4f32dbf-4d15-42ef-a960-fea60ab3b68c';
+      let getContractDocumentCallCount = 0;
+      const signContractSpy = vi.fn();
+
+      server.use(
+        http.post(
+          '*/v1/contractors/employments/*/contract-documents',
+          async () => {
+            return HttpResponse.json({
+              data: {
+                contract_document: {
+                  id: contractDocumentId,
+                },
+              },
+            });
+          },
+        ),
+        http.get(
+          '*/v1/contractors/employments/*/contract-documents/*',
+          async () => {
+            getContractDocumentCallCount++;
+            return HttpResponse.json({
+              data: {
+                contract_document: {
+                  name: '2025-10-23_TestContract.pdf',
+                  content: 'data:application/pdf;base64,JVBERi0xLjQ=',
+                  signatories: [
+                    {
+                      type: 'company',
+                      status:
+                        getContractDocumentCallCount > 2 ? 'signed' : 'pending',
+                    },
+                  ],
+                },
+              },
+            });
+          },
+        ),
+        http.post(
+          '*/v1/contractors/employments/*/contract-documents/*/sign',
+          async ({ request }) => {
+            const requestBody = await request.json();
+            signContractSpy(requestBody);
+            return HttpResponse.json(mockContractDocumentSignedResponse);
+          },
+        ),
+      );
+
+      mockRender.mockImplementation(
+        createMockRenderImplementation(MultiStepFormWithoutCountry),
+      );
+
+      render(
+        <ContractorOnboardingFlow
+          employmentId={employmentId}
+          countryCode='PRT'
+          skipSteps={['select_country']}
+          {...defaultProps}
+        />,
+        { wrapper: TestProviders },
+      );
+
+      await screen.findByText(/Step: Basic Information/i);
+      await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+      await fillBasicInformation();
+      let nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Pricing Plan/i);
+
+      await fillContractorSubscription();
+      nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Contract Details/i);
+      await fillContractDetails();
+
+      nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Contract Preview/i);
+      await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+      const countBeforeSigning = getContractDocumentCallCount;
+
+      await fillSignature();
+
+      nextButton = screen.getByText(/Continue/i);
+      nextButton.click();
+
+      // Wait for navigation to review step, which means signing AND refetching completed
+      await screen.findByText(/Step: Review/i);
+
+      // Verify signing happened
+      expect(signContractSpy).toHaveBeenCalledTimes(1);
+
+      // After signing, the refetch should have happened
+      expect(getContractDocumentCallCount).toBe(countBeforeSigning + 1);
+
+      // Now navigate back to contract preview
+      const backButton = screen.getByText(/Back/i);
+      backButton.click();
+
+      await screen.findByText(/Step: Contract Preview/i);
+
+      // Verify no errors occurred during navigation back
+      expect(mockOnError).not.toHaveBeenCalled();
+
+      // Count might be 3 now if going back triggers another fetch,
+      // or still 2 if it uses cached data
+      expect(getContractDocumentCallCount).toBeGreaterThanOrEqual(2);
+    });
   });
 });


### PR DESCRIPTION
There was this bug imagine you do the whole flow, get to review, click go back, you're on the sign step you try to sign

BE says -> contract already signed

what I am doing here if the contract is really signed no need to call the BE and we advance to the next step