### PR TITLE
1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @remoteoss/remote-flows
 
+## 1.29.0
+
+### Minor Changes
+
+- update dependency node to v24.15.0 (#957) [#957](https://github.com/remoteoss/remote-flows/pull/957)
+- update dependency msw to v2.13.4 (#958) [#958](https://github.com/remoteoss/remote-flows/pull/958)
+- update dependency typescript to v6.0.3 (#959) [#959](https://github.com/remoteoss/remote-flows/pull/959)
+- make cursor run tasks (#962) [#962](https://github.com/remoteoss/remote-flows/pull/962)
+- highlight errors (#961) [#961](https://github.com/remoteoss/remote-flows/pull/961)
+- avoid signing the document if it was already signed (#960) [#960](https://github.com/remoteoss/remote-flows/pull/960)
+
 ## 1.28.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@
 
 ### Minor Changes
 
+#### Features
+
+- highlight errors on fields in contractor onboarding (#961) [#961](https://github.com/remoteoss/remote-flows/pull/961)
+
+#### Fixes
+
+- avoid signing the document if it was already signed (#960) [#960](https://github.com/remoteoss/remote-flows/pull/960)
+
+#### Chores
+
 - update dependency node to v24.15.0 (#957) [#957](https://github.com/remoteoss/remote-flows/pull/957)
 - update dependency msw to v2.13.4 (#958) [#958](https://github.com/remoteoss/remote-flows/pull/958)
 - update dependency typescript to v6.0.3 (#959) [#959](https://github.com/remoteoss/remote-flows/pull/959)
 - make cursor run tasks (#962) [#962](https://github.com/remoteoss/remote-flows/pull/962)
-- highlight errors (#961) [#961](https://github.com/remoteoss/remote-flows/pull/961)
-- avoid signing the document if it was already signed (#960) [#960](https://github.com/remoteoss/remote-flows/pull/960)
 
 ## 1.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - highlight errors on fields in contractor onboarding (#961) [#961](https://github.com/remoteoss/remote-flows/pull/961)
 
-#### Fixes
+#### Fixes
 
 - avoid signing the document if it was already signed (#960) [#960](https://github.com/remoteoss/remote-flows/pull/960)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.29.0

### Minor Changes

#### Features

- highlight errors on fields in contractor onboarding (#961) [#961](https://github.com/remoteoss/remote-flows/pull/961)

#### Fixes

- avoid signing the document if it was already signed (#960) [#960](https://github.com/remoteoss/remote-flows/pull/960)

#### Chores

- update dependency node to v24.15.0 (#957) [#957](https://github.com/remoteoss/remote-flows/pull/957)
- update dependency msw to v2.13.4 (#958) [#958](https://github.com/remoteoss/remote-flows/pull/958)
- update dependency typescript to v6.0.3 (#959) [#959](https://github.com/remoteoss/remote-flows/pull/959)
- make cursor run tasks (#962) [#962](https://github.com/remoteoss/remote-flows/pull/962)
---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version and updates the changelog/package lockfile for the `1.29.0` release, with no functional code changes.
> 
> **Overview**
> Prepares release `1.29.0` by bumping the package version in `package.json` and `package-lock.json`.
> 
> Updates `CHANGELOG.md` with the `1.29.0` release notes (feature, fix, and dependency chore entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafd077c063f0c5d839350724a368c401172ce07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->