### PR TITLE
fix(force-value-field) - avoid rendering statements without a description

### DIFF
--- a/src/components/form/fields/ForcedValueField.tsx
+++ b/src/components/form/fields/ForcedValueField.tsx
@@ -69,13 +69,12 @@ export function ForcedValueField({
     ? sanitizeHtml(statement?.title)
     : sanitizeHtml(label);
 
-  const isHiddenValue = !descriptionSanitized && !statement?.title;
-
   useEffect(() => {
-    if (!isHiddenValue) {
-      setValue(name, value);
-    }
-  }, [isHiddenValue, name, value, setValue]);
+    setValue(name, value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const isHiddenValue = !descriptionSanitized && !statement?.title;
 
   if (isHiddenValue) {
     return null;

--- a/src/components/form/fields/ForcedValueField.tsx
+++ b/src/components/form/fields/ForcedValueField.tsx
@@ -64,14 +64,22 @@ export function ForcedValueField({
   const descriptionSanitized = sanitizeHtml(
     statement?.description || description,
   );
-  useEffect(() => {
-    setValue(name, value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const titleSanitized = statement?.title
     ? sanitizeHtml(statement?.title)
     : sanitizeHtml(label);
+
+  const isHiddenValue = !descriptionSanitized && !statement?.title;
+
+  useEffect(() => {
+    if (!isHiddenValue) {
+      setValue(name, value);
+    }
+  }, [isHiddenValue, name, value, setValue]);
+
+  if (isHiddenValue) {
+    return null;
+  }
 
   return (
     <div>

--- a/src/components/form/fields/tests/ForcedValueField.test.tsx
+++ b/src/components/form/fields/tests/ForcedValueField.test.tsx
@@ -264,10 +264,10 @@ describe('ForcedValueField Component', () => {
         return (
           <FormProvider {...methods}>
             <ForcedValueField
-              name="testField"
-              value="forced-value"
-              description=""
-              label="Test Label"
+              name='testField'
+              value='forced-value'
+              description=''
+              label='Test Label'
             />
           </FormProvider>
         );

--- a/src/components/form/fields/tests/ForcedValueField.test.tsx
+++ b/src/components/form/fields/tests/ForcedValueField.test.tsx
@@ -173,7 +173,7 @@ describe('ForcedValueField Component', () => {
   });
 
   describe('form integration', () => {
-    it('sets the form value using setValue from useFormContext when field is visible', () => {
+    it('sets the form value using setValue from useFormContext', () => {
       const mockSetValue = vi.fn();
 
       const TestComponent = () => {

--- a/src/components/form/fields/tests/ForcedValueField.test.tsx
+++ b/src/components/form/fields/tests/ForcedValueField.test.tsx
@@ -173,7 +173,7 @@ describe('ForcedValueField Component', () => {
   });
 
   describe('form integration', () => {
-    it('sets the form value using setValue from useFormContext', () => {
+    it('sets the form value using setValue from useFormContext when field is visible', () => {
       const mockSetValue = vi.fn();
 
       const TestComponent = () => {
@@ -184,6 +184,31 @@ describe('ForcedValueField Component', () => {
         return (
           <FormProvider {...methods}>
             <ForcedValueField {...defaultProps} />
+          </FormProvider>
+        );
+      };
+
+      render(<TestComponent />);
+
+      expect(mockSetValue).toHaveBeenCalledWith('testField', 'forced-value');
+    });
+
+    it('still sets form value even when field is hidden (no description and no title)', () => {
+      const mockSetValue = vi.fn();
+
+      const TestComponent = () => {
+        const methods = {
+          ...useForm(),
+          setValue: mockSetValue,
+        };
+        return (
+          <FormProvider {...methods}>
+            <ForcedValueField
+              name='testField'
+              value='forced-value'
+              description=''
+              label='Test Label'
+            />
           </FormProvider>
         );
       };
@@ -250,32 +275,6 @@ describe('ForcedValueField Component', () => {
 
       const { container } = renderWithFormContext(props);
 
-      expect(container.firstChild).toBeNull();
-    });
-
-    it('does not set form value when returning null', () => {
-      const mockSetValue = vi.fn();
-
-      const TestComponent = () => {
-        const methods = {
-          ...useForm(),
-          setValue: mockSetValue,
-        };
-        return (
-          <FormProvider {...methods}>
-            <ForcedValueField
-              name='testField'
-              value='forced-value'
-              description=''
-              label='Test Label'
-            />
-          </FormProvider>
-        );
-      };
-
-      const { container } = render(<TestComponent />);
-
-      expect(mockSetValue).not.toHaveBeenCalled();
       expect(container.firstChild).toBeNull();
     });
   });

--- a/src/components/form/fields/tests/ForcedValueField.test.tsx
+++ b/src/components/form/fields/tests/ForcedValueField.test.tsx
@@ -225,4 +225,58 @@ describe('ForcedValueField Component', () => {
       expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
     });
   });
+
+  describe('when component returns null (no rendering)', () => {
+    it('returns null when description is empty and no statement provided', () => {
+      const props: ForcedValueFieldProps = {
+        ...defaultProps,
+        description: '',
+      };
+
+      const { container } = renderWithFormContext(props);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('returns null when both descriptions are empty and statement.title is empty', () => {
+      const props: ForcedValueFieldProps = {
+        ...defaultProps,
+        description: '',
+        statement: {
+          title: '',
+          description: '',
+        },
+      };
+
+      const { container } = renderWithFormContext(props);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('does not set form value when returning null', () => {
+      const mockSetValue = vi.fn();
+
+      const TestComponent = () => {
+        const methods = {
+          ...useForm(),
+          setValue: mockSetValue,
+        };
+        return (
+          <FormProvider {...methods}>
+            <ForcedValueField
+              name="testField"
+              value="forced-value"
+              description=""
+              label="Test Label"
+            />
+          </FormProvider>
+        );
+      };
+
+      const { container } = render(<TestComponent />);
+
+      expect(mockSetValue).not.toHaveBeenCalled();
+      expect(container.firstChild).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
I was testing GER contract details v3 and I notice a force value field rendering...

I observe in our platform we have a hidden logic to avoid this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to `ForcedValueField` rendering conditions, covered by new tests; main impact is that some fields will no longer display when content is empty.
> 
> **Overview**
> `ForcedValueField` now **renders nothing** when there’s no sanitized description and no `statement.title`, preventing empty/placeholder forced-value statements from showing up while still calling `setValue` on mount.
> 
> Tests were expanded to assert the hidden-render behavior (`container.firstChild` is `null`) and to ensure the form value is still set even when the component doesn’t render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9872dcd4217048604342d67c599914183b4852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->