### PR TITLE
1.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @remoteoss/remote-flows
 
+## 1.29.1
+
+### Patch Changes
+
+- revert to previous version (#965) [#965](https://github.com/remoteoss/remote-flows/pull/965)
+
 ## 1.29.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Patch Changes
 
-- revert to previous version (#965) [#965](https://github.com/remoteoss/remote-flows/pull/965)
+#### Fixes
+
+- revert date-fns and react-day-picker to previous version (#965) [#965](https://github.com/remoteoss/remote-flows/pull/965)
 
 ## 1.29.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.29.1

### Patch Changes

#### Fixes

- revert date-fns and react-day-picker to previous version (#965) [#965](https://github.com/remoteoss/remote-flows/pull/965)

---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change: updates package version metadata and changelog entry with no functional code modifications.
> 
> **Overview**
> **Release metadata update:** bumps `@remoteoss/remote-flows` from `1.29.0` to `1.29.1` in `package.json` and `package-lock.json`.
> 
> **Changelog update:** adds a `1.29.1` patch entry noting a fix to revert `date-fns` and `react-day-picker` to a previous version (per #965).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae521e1ca408e1b672df720f5729198f62f0939a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->