### PR TITLE
feat(radio-group) - implement recommended badge

### DIFF
--- a/src/components/form/fields/default/RadioGroupFieldDefault.tsx
+++ b/src/components/form/fields/default/RadioGroupFieldDefault.tsx
@@ -8,14 +8,15 @@ import {
 } from '@/src/components/ui/form';
 import { RadioGroup, RadioGroupItem } from '@/src/components/ui/radio-group';
 import { cn } from '@/src/lib/utils';
-import { FieldComponentProps } from '@/src/types/fields';
+import { RadioGroupComponentProps } from '@/src/types/fields';
 import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
+import { Badge } from '@/src/components/ui/badge';
 
 export const RadioGroupFieldDefault = ({
   field,
   fieldData,
   fieldState,
-}: FieldComponentProps) => {
+}: RadioGroupComponentProps) => {
   const { name, label, description, options } = fieldData;
   return (
     <fieldset
@@ -38,24 +39,32 @@ export const RadioGroupFieldDefault = ({
               field.onChange(value);
             }}
             value={field.value}
-            className='flex flex-col space-y-3'
+            className='flex flex-col'
           >
             {options?.map((option) => (
               <Fragment key={option.value}>
                 <FormItem
                   data-field={name}
-                  className='flex items-start space-x-3 space-y-0 gap-0 RemoteFlows__RadioField__Item'
+                  className='flex items-start space-x-3 space-y-0 gap-0 min-h-[24px] RemoteFlows__RadioField__Item'
                 >
                   <FormControl>
                     <RadioGroupItem
                       value={option.value}
-                      className='RemoteFlows__RadioField__Input'
+                      className={cn(
+                        'RemoteFlows__RadioField__Input',
+                        option.recommended && 'mt-1',
+                      )}
                       disabled={option.disabled}
                     />
                   </FormControl>
                   <div>
                     <FormLabel className='font-normal mb-0 RemoteFlows__RadioField__Label'>
-                      {option.label}
+                      {option.label}{' '}
+                      {option.recommended && (
+                        <Badge variant='secondary' className='ml-2'>
+                          Recommended
+                        </Badge>
+                      )}
                     </FormLabel>
                     {option.description && (
                       <FormDescription className='mt-2'>

--- a/src/components/form/fields/tests/RadioGroupField.test.tsx
+++ b/src/components/form/fields/tests/RadioGroupField.test.tsx
@@ -228,4 +228,20 @@ describe('RadioGroupField Component', () => {
     fireEvent.click(enabledRadio);
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('displays recommended badge when option.recommended is true', () => {
+    const propsWithRecommendedOption: RadioGroupFieldProps = {
+      ...defaultProps,
+      options: [
+        { value: 'option1', label: 'Option 1', recommended: true },
+        { value: 'option2', label: 'Option 2', recommended: false },
+        { value: 'option3', label: 'Option 3' }, // no recommended property
+      ],
+    };
+    renderWithFormContext(propsWithRecommendedOption);
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -138,6 +138,8 @@ export type {
   WorkScheduleComponentProps,
   PricingPlanComponentProps,
   PricingPlanDataProps,
+  RadioGroupComponentProps,
+  TelFieldComponentProps,
 } from '@/src/types/fields';
 
 export type {

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -147,3 +147,22 @@ export type PricingPlanComponentProps = Omit<
 export type TelFieldComponentProps = Omit<FieldComponentProps, 'fieldData'> & {
   fieldData: TelFieldDataProps;
 };
+
+type RadioGroupDataProps = Omit<FieldDataProps, 'options'> & {
+  options?: Array<{
+    value: string;
+    label: string;
+    description?: string;
+    disabled?: boolean;
+    recommended?: boolean;
+    nested_field?: string;
+    meta?: Record<string, unknown>;
+  }>;
+};
+
+export type RadioGroupComponentProps = Omit<
+  FieldComponentProps,
+  'fieldData'
+> & {
+  fieldData: RadioGroupDataProps;
+};

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -14,6 +14,7 @@ import {
   TextFieldComponentProps,
   WorkScheduleComponentProps,
   TelFieldComponentProps,
+  RadioGroupComponentProps,
 } from '@/src/types/fields';
 
 type AuthResponse = {
@@ -137,6 +138,7 @@ type FieldComponentTypes = Exclude<
   | 'money'
   | 'date'
   | 'tel'
+  | 'radio'
 >;
 
 export type Components = {
@@ -155,6 +157,7 @@ export type Components = {
   'work-schedule'?: React.ComponentType<WorkScheduleComponentProps>;
   pdfViewer?: React.ComponentType<PDFPreviewComponentProps>;
   tel?: React.ComponentType<TelFieldComponentProps>;
+  radio?: React.ComponentType<RadioGroupComponentProps>;
 };
 
 export type RemoteFlowsSDKProps = Omit<ThemeProviderProps, 'children'> & {


### PR DESCRIPTION
Adds the recommended badge to our implementation and improves types to support it

I exported a missing type from previous PRs

<img width="973" height="164" alt="Probation netonal" src="https://github.com/user-attachments/assets/a12a0763-9206-4dbc-9f5f-62c378f8d972" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only enhancement plus TypeScript typing/export changes; low behavioral risk aside from potential minor styling/consumer type adjustments.
> 
> **Overview**
> The default `RadioGroupFieldDefault` now supports an `option.recommended` flag, rendering a **"Recommended"** `Badge` next to the option label (with small layout tweaks to align the radio input).
> 
> Type support was extended by introducing `RadioGroupComponentProps`/`RadioGroupDataProps` (including `recommended` on options), wiring `Components['radio']` to use this prop type, and exporting the new types from `src/index.tsx` for SDK consumers. A test was added to assert the recommended badge is displayed when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2011499d5a478468fc8055c72f2d65038799f38b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->