### PR TITLE
docs(onboarding) - add netherlands changelog

### DIFF
--- a/docs/schema-changes/eor/contract-details/countries/NLD.md
+++ b/docs/schema-changes/eor/contract-details/countries/NLD.md
@@ -1,0 +1,35 @@
+# Netherlands (NLD)
+
+Schema versions for employee onboarding in Nigeria.
+
+## Current Version
+
+**Contract Details:** v2 (Since SDK 1.29.0)
+
+## Contract Details
+
+### v2 - Current (Since SDK 1.29.0, May 2026)
+
+**What changed:**
+
+- Probation periods are now correctly limited based on contract type (fixed-term vs indefinite)
+- Non-compete clauses are only enforced for indefinite contracts
+- Notice period presentation adapts to contract type
+
+**Migration:**
+
+```tsx
+<OnboardingFlow
+  options={{
+    jsonSchemaVersionByCountry: {
+      NLD: { contract_details: 2 },
+    },
+  }}
+/>
+```
+
+---
+
+### v1 (SDK 1.0.0)
+
+Initial version with basic contract details fields.

--- a/docs/schema-changes/eor/contract-details/countries/README.md
+++ b/docs/schema-changes/eor/contract-details/countries/README.md
@@ -59,6 +59,7 @@ These countries have upgraded to different versions, check each guide to know ho
 | Mauritius            | MUS  | v2               | March 2026   |
 | Malaysia             | MYS  | v2               | March 2026   |
 | Mexico               | MEX  | v2               | March 2026   |
+| Netherlands          | NLD  | v2               | May 2026     |
 | Nigeria              | NGA  | v2               | March 2026   |
 | Norway               | NOR  | v2               | March 2026   |
 | New Zealand          | NZL  | v2               | March 2026   |


### PR DESCRIPTION
Add docs for netherlands schema changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is minor documentation accuracy issues (e.g., country name typo) that could confuse integrators.
> 
> **Overview**
> Adds a new Netherlands (`NLD`) contract-details schema changelog documenting the move to **v2** (SDK `1.29.0`) and the related behavior changes around probation, non-compete, and notice periods, including a migration snippet.
> 
> Updates the country version matrix in `docs/schema-changes/eor/contract-details/countries/README.md` to include `NLD` at `v2` (May 2026).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887afd5c222a56826b1101d18d3e4880cf233614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->