### PR TITLE
feat(fieldsets) - support transformation using the base description

### DIFF
--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { Fragment, useEffect, useRef } from 'react';
 import omit from 'lodash.omit';
 import { baseFields } from '@/src/components/form/fields/baseFields';
-import { cn, sanitizeHtml } from '@/src/lib/utils';
+import { cn } from '@/src/lib/utils';
 import { $TSFixMe, Components } from '@/src/types/remoteFlows';
 import { Statement } from '@/src/components/form/Statement';
 import { useFormFields } from '@/src/context';
@@ -12,6 +12,7 @@ import { BaseTypes, SupportedTypes } from './types';
 import { StatementComponentProps } from '@/src/types/fields';
 import { checkFieldHasForcedValue } from '@/src/components/form/utils';
 import { ForcedValueField } from '@/src/components/form/fields/ForcedValueField';
+import { BaseFormDescription } from '@/src/components/ui/form';
 
 type FieldBase = {
   label: string;
@@ -210,10 +211,9 @@ export function FieldSetField({
       {isExpanded && (
         <div id={contentId} aria-labelledby={headerId} role='region'>
           {description ? (
-            <div
-              className='mb-5 RemoteFlows__FieldSetField__Description'
-              dangerouslySetInnerHTML={{ __html: sanitizeHtml(description) }}
-            />
+            <BaseFormDescription className='mb-5 RemoteFlows__FieldSetField__Description'>
+              {description}
+            </BaseFormDescription>
           ) : null}
           <div className='grid gap-4'>
             {fields.map((field: $TSFixMe) => {

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -211,7 +211,10 @@ export function FieldSetField({
       {isExpanded && (
         <div id={contentId} aria-labelledby={headerId} role='region'>
           {description ? (
-            <BaseFormDescription className='mb-5 RemoteFlows__FieldSetField__Description'>
+            <BaseFormDescription
+              as='div'
+              className='mb-5 RemoteFlows__FieldSetField__Description'
+            >
               {description}
             </BaseFormDescription>
           ) : null}


### PR DESCRIPTION
Instead of using a new pattern we reuse the base description that will help us on transforming later html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how fieldset descriptions are rendered and sanitized (moving away from direct `dangerouslySetInnerHTML`), which could affect formatting or HTML handling and has light XSS/regression risk.
> 
> **Overview**
> Fieldset descriptions in `FieldSetField` are now rendered through the shared `BaseFormDescription` component instead of manually sanitizing and injecting HTML.
> 
> This standardizes description rendering to the form UI layer (enabling future HTML-to-component transformations) and removes the fieldset’s direct dependency on `sanitizeHtml`/`dangerouslySetInnerHTML`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 710d31998387f80aed0e12b22fdaa40729cb5c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->