### PR TITLE
1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @remoteoss/remote-flows
 
+## 1.30.0
+
+### Minor Changes
+
+- update dependency vite to v8.0.9 (#970) [#970](https://github.com/remoteoss/remote-flows/pull/970)
+- update dependency filesize to v11.0.16 (#969) [#969](https://github.com/remoteoss/remote-flows/pull/969)
+- update dependency oxfmt to v0.46.0 (#972) [#972](https://github.com/remoteoss/remote-flows/pull/972)
+- update dependency oxlint to v1.61.0 (#973) [#973](https://github.com/remoteoss/remote-flows/pull/973)
+- update dependency react-hook-form to v7.73.1 (#974) [#974](https://github.com/remoteoss/remote-flows/pull/974)
+- update tailwindcss monorepo to v4.2.3 (#971) [#971](https://github.com/remoteoss/remote-flows/pull/971)
+- avoid rendering statements without a description (#964) [#964](https://github.com/remoteoss/remote-flows/pull/964)
+- update vitest monorepo to v4.1.5 (#975) [#975](https://github.com/remoteoss/remote-flows/pull/975)
+- update dependency axios to v1.15.2 (#968) [#968](https://github.com/remoteoss/remote-flows/pull/968)
+- update dependency dompurify to v3.4.1 (#977) [#977](https://github.com/remoteoss/remote-flows/pull/977)
+- update tailwindcss monorepo to v4.2.4 (#976) [#976](https://github.com/remoteoss/remote-flows/pull/976)
+- implement recommended badge (#978) [#978](https://github.com/remoteoss/remote-flows/pull/978)
+- fix tel field props (#980) [#980](https://github.com/remoteoss/remote-flows/pull/980)
+- update dependency vite to v8.0.10 (#982) [#982](https://github.com/remoteoss/remote-flows/pull/982)
+- update dependency msw to v2.13.5 (#981) [#981](https://github.com/remoteoss/remote-flows/pull/981)
+- improve to use form description component (#984) [#984](https://github.com/remoteoss/remote-flows/pull/984)
+
 ## 1.29.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - fix tel field props (#980) [#980](https://github.com/remoteoss/remote-flows/pull/980)
 - improve force fields to use shared form description component (#984) [#984](https://github.com/remoteoss/remote-flows/pull/984)
 
-
 #### Chores
 
 - update dependency vite to v8.0.9 (#970) [#970](https://github.com/remoteoss/remote-flows/pull/970)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,31 @@
 
 ### Minor Changes
 
+#### Features
+
+- update dependency react-hook-form to v7.73.1 (#974) [#974](https://github.com/remoteoss/remote-flows/pull/974)
+- update dependency dompurify to v3.4.1 (#977) [#977](https://github.com/remoteoss/remote-flows/pull/977)
+- update tailwindcss monorepo to v4.2.4 (#976) [#976](https://github.com/remoteoss/remote-flows/pull/976)
+
+
+#### Fixes
+
+- avoid rendering statements without a description (#964) [#964](https://github.com/remoteoss/remote-flows/pull/964)
+- implement recommended badge (#978) [#978](https://github.com/remoteoss/remote-flows/pull/978)
+- fix tel field props (#980) [#980](https://github.com/remoteoss/remote-flows/pull/980)
+- improve force fields to use shared form description component (#984) [#984](https://github.com/remoteoss/remote-flows/pull/984)
+
+
+#### Chores
+
 - update dependency vite to v8.0.9 (#970) [#970](https://github.com/remoteoss/remote-flows/pull/970)
 - update dependency filesize to v11.0.16 (#969) [#969](https://github.com/remoteoss/remote-flows/pull/969)
 - update dependency oxfmt to v0.46.0 (#972) [#972](https://github.com/remoteoss/remote-flows/pull/972)
 - update dependency oxlint to v1.61.0 (#973) [#973](https://github.com/remoteoss/remote-flows/pull/973)
-- update dependency react-hook-form to v7.73.1 (#974) [#974](https://github.com/remoteoss/remote-flows/pull/974)
-- update tailwindcss monorepo to v4.2.3 (#971) [#971](https://github.com/remoteoss/remote-flows/pull/971)
-- avoid rendering statements without a description (#964) [#964](https://github.com/remoteoss/remote-flows/pull/964)
 - update vitest monorepo to v4.1.5 (#975) [#975](https://github.com/remoteoss/remote-flows/pull/975)
 - update dependency axios to v1.15.2 (#968) [#968](https://github.com/remoteoss/remote-flows/pull/968)
-- update dependency dompurify to v3.4.1 (#977) [#977](https://github.com/remoteoss/remote-flows/pull/977)
-- update tailwindcss monorepo to v4.2.4 (#976) [#976](https://github.com/remoteoss/remote-flows/pull/976)
-- implement recommended badge (#978) [#978](https://github.com/remoteoss/remote-flows/pull/978)
-- fix tel field props (#980) [#980](https://github.com/remoteoss/remote-flows/pull/980)
 - update dependency vite to v8.0.10 (#982) [#982](https://github.com/remoteoss/remote-flows/pull/982)
 - update dependency msw to v2.13.5 (#981) [#981](https://github.com/remoteoss/remote-flows/pull/981)
-- improve to use form description component (#984) [#984](https://github.com/remoteoss/remote-flows/pull/984)
 
 ## 1.29.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
 - update dependency react-hook-form to v7.73.1 (#974) [#974](https://github.com/remoteoss/remote-flows/pull/974)
 - update dependency dompurify to v3.4.1 (#977) [#977](https://github.com/remoteoss/remote-flows/pull/977)
 - update tailwindcss monorepo to v4.2.4 (#976) [#976](https://github.com/remoteoss/remote-flows/pull/976)
-
+- implement recommended badge (#978) [#978](https://github.com/remoteoss/remote-flows/pull/978)
 
 #### Fixes
 
 - avoid rendering statements without a description (#964) [#964](https://github.com/remoteoss/remote-flows/pull/964)
-- implement recommended badge (#978) [#978](https://github.com/remoteoss/remote-flows/pull/978)
+
 - fix tel field props (#980) [#980](https://github.com/remoteoss/remote-flows/pull/980)
 - improve force fields to use shared form description component (#984) [#984](https://github.com/remoteoss/remote-flows/pull/984)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.29.1",
+      "version": "1.30.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",
@@ -1752,9 +1752,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1772,9 +1769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1792,9 +1786,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1812,9 +1803,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1832,9 +1820,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1852,9 +1837,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1872,9 +1854,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,9 +1871,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,9 +2075,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,9 +2092,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2139,9 +2109,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2159,9 +2126,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,9 +2143,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2199,9 +2160,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2219,9 +2177,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2239,9 +2194,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4266,9 +4218,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4284,9 +4233,6 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4304,9 +4250,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4322,9 +4265,6 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.30.0

### Minor Changes

#### Features

- update dependency react-hook-form to v7.73.1 (#974) [#974](https://github.com/remoteoss/remote-flows/pull/974)
- update dependency dompurify to v3.4.1 (#977) [#977](https://github.com/remoteoss/remote-flows/pull/977)
- update tailwindcss monorepo to v4.2.4 (#976) [#976](https://github.com/remoteoss/remote-flows/pull/976)
- implement recommended badge (#978) [#978](https://github.com/remoteoss/remote-flows/pull/978)


#### Fixes

- avoid rendering statements without a description (#964) [#964](https://github.com/remoteoss/remote-flows/pull/964)
- fix tel field props (#980) [#980](https://github.com/remoteoss/remote-flows/pull/980)
- improve force fields to use shared form description component (#984) [#984](https://github.com/remoteoss/remote-flows/pull/984)


#### Chores

- update dependency vite to v8.0.9 (#970) [#970](https://github.com/remoteoss/remote-flows/pull/970)
- update dependency filesize to v11.0.16 (#969) [#969](https://github.com/remoteoss/remote-flows/pull/969)
- update dependency oxfmt to v0.46.0 (#972) [#972](https://github.com/remoteoss/remote-flows/pull/972)
- update dependency oxlint to v1.61.0 (#973) [#973](https://github.com/remoteoss/remote-flows/pull/973)
- update vitest monorepo to v4.1.5 (#975) [#975](https://github.com/remoteoss/remote-flows/pull/975)
- update dependency axios to v1.15.2 (#968) [#968](https://github.com/remoteoss/remote-flows/pull/968)
- update dependency vite to v8.0.10 (#982) [#982](https://github.com/remoteoss/remote-flows/pull/982)
- update dependency msw to v2.13.5 (#981) [#981](https://github.com/remoteoss/remote-flows/pull/981)
---

This release was automatically generated from conventional commits.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates versioning/release metadata and lockfile entries, with no source code changes.
> 
> **Overview**
> Cuts the `1.30.0` release by updating `package.json`/`package-lock.json` version fields and adding the corresponding `CHANGELOG.md` entry.
> 
> Regenerates parts of `package-lock.json`, including removing `libc` qualifiers from several platform-specific binary packages (e.g., `@oxfmt`, `@oxlint`, `@tailwindcss/oxide`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0623b59eba64ce4dad6ad4b2191ac21ce37fbb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->