### PR TITLE
feat(benefits) - surface benefits x-jsf-presentation

### DIFF
--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -27,12 +27,13 @@ const BenefitsAboutSection = ({
   description,
   url,
 }: {
-  description: string;
-  url: string;
+  description?: string;
+  url?: string;
 }) => {
-  if (!description || !url) {
+  if (!description) {
     return null;
   }
+
   return (
     <Card className='space-y-4 p-6 mb-4'>
       <h2 className='text-xl font-semibold text-gray-900'>About</h2>
@@ -40,17 +41,19 @@ const BenefitsAboutSection = ({
         className='prose prose-sm max-w-none text-xs text-gray-700 leading-relaxed space-y-4'
         dangerouslySetInnerHTML={{ __html: sanitizeHtml(description) }}
       />
-      <p className='text-xs text-gray-700 leading-relaxed space-y-4'>
-        Want more details on benefits?{' '}
-        <a
-          href={url}
-          className='inline-block text-blue-600 hover:text-blue-700 hover:underline text-xs mt-2'
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          Check our guide
-        </a>
-      </p>
+      {url && (
+        <p className='text-xs text-gray-700 leading-relaxed space-y-4'>
+          Want more details on benefits?{' '}
+          <a
+            href={url}
+            className='inline-block text-blue-600 hover:text-blue-700 hover:underline text-xs mt-2'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            Check our guide
+          </a>
+        </p>
+      )}
     </Card>
   );
 };

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -20,31 +20,37 @@ import { ReviewOnboardingStep } from './ReviewOnboardingStep';
 import { OnboardingAlertStatuses } from './OnboardingAlertStatuses';
 import { RemoteFlows } from './RemoteFlows';
 import { AlertError } from './AlertError';
+import { sanitizeHtml } from '@remoteoss/remote-flows/internals';
 import './css/main.css';
 
 const BenefitsAboutSection = ({
-  title,
   description,
-  finePrint,
   url,
 }: {
-  title: string;
   description: string;
-  finePrint: string;
   url: string;
 }) => {
-  console.log('title', title);
-  console.log('description', description);
-  console.log('finePrint', finePrint);
-  console.log('url', url);
+  if (!description || !url) {
+    return null;
+  }
   return (
-    <Card className='benefits-about-section'>
-      <h2 className='benefits-about-title'>About</h2>
-      <p className='benefits-about-description'>{description}</p>
-      <p className='benefits-about-fine-print'>{finePrint}</p>
-      <a href={url} className='benefits-about-url'>
-        {url}
-      </a>
+    <Card className='space-y-4 p-6'>
+      <h2 className='text-xl font-semibold text-gray-900'>About</h2>
+      <div
+        className='prose prose-sm max-w-none text-xs text-gray-700 leading-relaxed space-y-4'
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(description) }}
+      />
+      <p className='text-xs text-gray-700 leading-relaxed space-y-4'>
+        Want more details on benefits?{' '}
+        <a
+          href={url}
+          className='inline-block text-blue-600 hover:text-blue-700 hover:underline text-xs mt-2'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          Check our guide
+        </a>
+      </p>
     </Card>
   );
 };
@@ -222,9 +228,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
       return (
         <div className='benefits-container'>
           <BenefitsAboutSection
-            title={benefitsPresentation?.title as string}
             description={benefitsPresentation?.description as string}
-            finePrint={benefitsPresentation?.fine_print as string}
             url={benefitsPresentation?.url as string}
           />
 

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -15,12 +15,39 @@ import {
   zendeskArticles,
 } from '@remoteoss/remote-flows';
 import React, { useState } from 'react';
+import { Card } from '@remoteoss/remote-flows/internals';
 import { ReviewOnboardingStep } from './ReviewOnboardingStep';
 import { OnboardingAlertStatuses } from './OnboardingAlertStatuses';
 import { RemoteFlows } from './RemoteFlows';
 import { AlertError } from './AlertError';
 import './css/main.css';
 
+const BenefitsAboutSection = ({
+  title,
+  description,
+  finePrint,
+  url,
+}: {
+  title: string;
+  description: string;
+  finePrint: string;
+  url: string;
+}) => {
+  console.log('title', title);
+  console.log('description', description);
+  console.log('finePrint', finePrint);
+  console.log('url', url);
+  return (
+    <Card className='benefits-about-section'>
+      <h2 className='benefits-about-title'>About</h2>
+      <p className='benefits-about-description'>{description}</p>
+      <p className='benefits-about-fine-print'>{finePrint}</p>
+      <a href={url} className='benefits-about-url'>
+        {url}
+      </a>
+    </Card>
+  );
+};
 export const InviteSection = ({
   title,
   description,
@@ -188,9 +215,19 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
         </>
       );
 
-    case 'benefits':
+    case 'benefits': {
+      // Example: Access schema-level presentation metadata
+      const benefitsPresentation = onboardingBag.meta.presentation;
+
       return (
         <div className='benefits-container'>
+          <BenefitsAboutSection
+            title={benefitsPresentation?.title as string}
+            description={benefitsPresentation?.description as string}
+            finePrint={benefitsPresentation?.fine_print as string}
+            url={benefitsPresentation?.url as string}
+          />
+
           <BenefitsStep
             onSubmit={(payload: BenefitsFormPayload) =>
               console.log('payload', payload)
@@ -204,6 +241,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
             }) => setErrors({ apiError: error.message, fieldErrors })}
             onSuccess={(data: SuccessResponse) => console.log('data', data)}
           />
+
           <AlertError errors={errors} />
           <div className='buttons-container'>
             <BackButton
@@ -221,6 +259,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
           </div>
         </div>
       );
+    }
     case 'review':
       return (
         <ReviewOnboardingStep

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -34,7 +34,7 @@ const BenefitsAboutSection = ({
     return null;
   }
   return (
-    <Card className='space-y-4 p-6'>
+    <Card className='space-y-4 p-6 mb-4'>
       <h2 className='text-xl font-semibold text-gray-900'>About</h2>
       <div
         className='prose prose-sm max-w-none text-xs text-gray-700 leading-relaxed space-y-4'

--- a/src/common/createHeadlessForm.tsx
+++ b/src/common/createHeadlessForm.tsx
@@ -70,6 +70,9 @@ export const createHeadlessForm = (
   return {
     meta: {
       'x-jsf-fieldsets': jsfSchema['x-jsf-fieldsets'] as JSFFieldset,
+      'x-jsf-presentation': jsfSchema['x-jsf-presentation'] as
+        | Record<string, unknown>
+        | undefined,
     },
     ...baseCreateHeadlessForm(jsfSchema, {
       initialValues,

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -639,6 +639,22 @@ export const useContractorOnboarding = ({
     review: null,
   };
 
+  const stepPresentation: Record<
+    StepKeys,
+    Record<string, unknown> | null | undefined
+  > = {
+    select_country: selectCountryForm?.meta?.['x-jsf-presentation'],
+    basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
+    pricing_plan:
+      selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
+    eligibility_questionnaire:
+      eligibilityQuestionnaireForm?.meta?.['x-jsf-presentation'],
+    contract_details:
+      contractorOnboardingDetailsForm?.meta?.['x-jsf-presentation'],
+    contract_preview: signatureSchemaForm?.meta?.['x-jsf-presentation'],
+    review: null,
+  };
+
   const {
     country,
     basic_information: employmentBasicInformation = {},
@@ -1269,6 +1285,7 @@ export const useContractorOnboarding = ({
     meta: {
       fields: fieldsMetaRef.current,
       fieldsets: stepFieldsWithFlatFieldsets[stepState.currentStep.name],
+      presentation: stepPresentation[stepState.currentStep.name],
     },
 
     /**

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -570,6 +570,19 @@ export const useOnboarding = ({
     review: null,
   };
 
+  const stepPresentation: Record<
+    StepKeys,
+    Record<string, unknown> | null | undefined
+  > = {
+    select_country: selectCountryForm?.meta?.['x-jsf-presentation'],
+    basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
+    engagement_agreement_details:
+      engagementAgreementDetailsSchema?.meta?.['x-jsf-presentation'],
+    contract_details: contractDetailsForm?.meta?.['x-jsf-presentation'],
+    benefits: benefitOffersSchema?.meta?.['x-jsf-presentation'],
+    review: null,
+  };
+
   const {
     country,
     basic_information: employmentBasicInformation = {},
@@ -1081,6 +1094,7 @@ export const useOnboarding = ({
     meta: {
       fields: fieldsMetaRef.current,
       fieldsets: stepFieldsWithFlatFieldsets[stepState.currentStep.name],
+      presentation: stepPresentation[stepState.currentStep.name],
     },
 
     /**

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -2611,7 +2611,6 @@ describe('OnboardingFlow', () => {
 
     await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
 
-    // Navigate to benefits step
     let nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
     await screen.findByText(/Step: Contract Details/i);
@@ -2620,7 +2619,6 @@ describe('OnboardingFlow', () => {
     nextButton.click();
     await screen.findByText(/Step: Benefits/i);
 
-    // Verify presentation metadata structure
     expect(capturedPresentation).toEqual({
       benefits_service_fee: {
         amount: 15.0,
@@ -2682,10 +2680,6 @@ describe('OnboardingFlow', () => {
     await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
     await screen.findByText(/Step: Basic Information/i);
 
-    // Verify basic_information step has no presentation
-    expect(
-      capturedBasicInfoPresentation === null ||
-        capturedBasicInfoPresentation === undefined,
-    ).toBe(true);
+    expect(capturedBasicInfoPresentation).toBeUndefined();
   });
 });

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -2566,4 +2566,126 @@ describe('OnboardingFlow', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('should include description, fine_print, and benefits_service_fee in benefits presentation', async () => {
+    let capturedPresentation: Record<string, unknown> | null | undefined = null;
+
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+
+        if (onboardingBag.stepState.currentStep.name === 'benefits') {
+          capturedPresentation = onboardingBag.meta.presentation;
+        }
+
+        if (onboardingBag.isLoading) {
+          return <div data-testid='spinner'>Loading...</div>;
+        }
+
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        employmentId={generateUniqueEmploymentId()}
+        skipSteps={['select_country']}
+        {...defaultProps}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    // Navigate to benefits step
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+    await screen.findByText(/Step: Contract Details/i);
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+    await screen.findByText(/Step: Benefits/i);
+
+    // Verify presentation metadata structure
+    expect(capturedPresentation).toEqual({
+      benefits_service_fee: {
+        amount: 15.0,
+        currency: 'USD',
+      },
+      description:
+        'We offer our employees supplemental benefits - Meal and Health Insurance (In partnership with Advance Care/Tranquilidade and Coverflex)',
+      fine_print:
+        'New: Health Insurance is now optional for new hires in Portugal.\r\nPlease note that all local payroll deductions for required coverages are included in the TCE.\r\nAny pricing changes will be communicated in advance of updated billing.',
+      url: 'https://remote.com/benefits-guide/portugal',
+    });
+  });
+
+  it('should have null or undefined presentation for basic_information step', async () => {
+    let capturedBasicInfoPresentation:
+      | Record<string, unknown>
+      | null
+      | undefined = undefined;
+
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+
+        if (onboardingBag.stepState.currentStep.name === 'basic_information') {
+          capturedBasicInfoPresentation = onboardingBag.meta.presentation;
+        }
+
+        if (onboardingBag.isLoading) {
+          return <div data-testid='spinner'>Loading...</div>;
+        }
+
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        employmentId={generateUniqueEmploymentId()}
+        skipSteps={['select_country']}
+        {...defaultProps}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+    await screen.findByText(/Step: Basic Information/i);
+
+    // Verify basic_information step has no presentation
+    expect(
+      capturedBasicInfoPresentation === null ||
+        capturedBasicInfoPresentation === undefined,
+    ).toBe(true);
+  });
 });

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -107,5 +107,6 @@ type FormResult = FormResultNext | FormResultLegacy;
 export type JSONSchemaFormResultWithFieldsets = FormResult & {
   meta: {
     'x-jsf-fieldsets': JSFFieldset;
+    'x-jsf-presentation'?: Record<string, unknown>;
   };
 };

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -8,7 +8,7 @@
  */
 
 // Internal utilities
-export { cn } from './lib/utils';
+export { cn, sanitizeHtml } from './lib/utils';
 
 // UI Components for internal use
 export { Button, buttonVariants } from './components/ui/button';


### PR DESCRIPTION
We weren't surfacing some benefits details in the Onboarding

The way we do as x-jsf-presentation is dynamic, we surface it for both contractor management and onboarding

We did some work to make correct the data on the BE for the partners and sandbox env  

<img width="963" height="404" alt="image" src="https://github.com/user-attachments/assets/4a99025d-580f-4d53-92bb-cdc7e06979fa" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new schema-driven `presentation` metadata surfaced to flow consumers and adds HTML rendering (sanitized) in the example benefits UI, which could affect downstream consumers and has some XSS/regression risk if misused.
> 
> **Overview**
> Surfaces JSON Schema `x-jsf-presentation` through `createHeadlessForm` and exposes it on the `onboardingBag.meta.presentation` for both employee `Onboarding` and `ContractorOnboarding` steps.
> 
> Updates the example Benefits step to render an **About** card using this presentation data (sanitizing HTML via newly exported `sanitizeHtml` from `internals`). Adds tests asserting benefits presentation payload is passed through and that other steps can have `undefined` presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1a567e68647f1cffcaa5b42021fafede495f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->