### PR TITLE
fix(money) - parse values before prettifying

### DIFF
--- a/example/src/ReviewOnboardingStep.tsx
+++ b/example/src/ReviewOnboardingStep.tsx
@@ -243,17 +243,23 @@ export const ReviewOnboardingStep = ({
       >
         Edit Basic Information
       </button>
-      <h2 className='title'>Engagement Agreement Details</h2>
-      <ReviewMeta
-        meta={onboardingBag.meta.fields.engagement_agreement_details}
-      />
-      <button
-        className='back-button'
-        onClick={() => onboardingBag.goTo('engagement_agreement_details')}
-        disabled={onboardingBag.isEmploymentReadOnly}
-      >
-        Edit Engagement Agreement Details
-      </button>
+      {Object.keys(onboardingBag.meta.fields.engagement_agreement_details)
+        .length > 0 && (
+        <>
+          <h2 className='title'>Engagement Agreement Details</h2>
+          <ReviewMeta
+            meta={onboardingBag.meta.fields.engagement_agreement_details}
+          />
+          <button
+            className='back-button'
+            onClick={() => onboardingBag.goTo('engagement_agreement_details')}
+            disabled={onboardingBag.isEmploymentReadOnly}
+          >
+            Edit Engagement Agreement Details
+          </button>
+        </>
+      )}
+
       <h2 className='title'>Contract Details</h2>
       <ReviewMeta meta={onboardingBag.meta.fields.contract_details} />
       <button

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -248,14 +248,6 @@ export const fieldTypesTransformations: Record<string, $TSFixMe> = {
       convertFromCents(value) ?? '',
     transformValueToAPI: () => convertToCents,
   },
-  [supportedTypes.RADIO]: {
-    transformValueToAPI: (field: $TSFixMe) => (value: string) => {
-      if (field.transformToBool) {
-        return value === 'yes';
-      }
-      return value;
-    },
-  },
   [supportedTypes.CHECKBOX]: {
     transformValueToAPI: (field: $TSFixMe) => (value: string | boolean) => {
       if (value === undefined) {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -811,26 +811,32 @@ export const useContractorOnboarding = ({
         select_country: prettifyFormValues(
           selectCountryInitialValues,
           stepFields.select_country,
+          { skipMoneyConversion: true },
         ),
         basic_information: prettifyFormValues(
           basicInformationInitialValues,
           stepFields.basic_information,
+          { skipMoneyConversion: true },
         ),
         contract_details: prettifyFormValues(
           contractDetailsInitialValues,
           stepFields.contract_details,
+          { skipMoneyConversion: true },
         ),
         contract_preview: prettifyFormValues(
           contractPreviewInitialValues,
           stepFields.contract_preview,
+          { skipMoneyConversion: true },
         ),
         pricing_plan: prettifyFormValues(
           pricingPlanInitialValues,
           stepFields.pricing_plan,
+          { skipMoneyConversion: true },
         ),
         eligibility_questionnaire: prettifyFormValues(
           eligibilityQuestionnaireInitialValues,
           stepFields.eligibility_questionnaire,
+          { skipMoneyConversion: true },
         ),
       };
 

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -953,12 +953,13 @@ export const useContractorOnboarding = ({
 
   async function onSubmit(values: FieldValues) {
     const currentStepName = stepState.currentStep.name;
+    const parsedValues = await parseFormValues(values);
+
     if (currentStepName in fieldsMetaRef.current) {
       fieldsMetaRef.current[
         currentStepName as keyof typeof fieldsMetaRef.current
-      ] = prettifyFormValues(values, stepFields[currentStepName]);
+      ] = prettifyFormValues(parsedValues, stepFields[currentStepName]);
     }
-    const parsedValues = await parseFormValues(values);
     switch (stepState.currentStep.name) {
       case 'select_country': {
         setInternalCountryCode(parsedValues.country);

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -48,43 +48,11 @@ import {
 } from '@/src/common/api/fixtures/contractors-subscriptions';
 import { mockBlockedEligibilityQuestionnaireResponse } from '@/src/common/api/fixtures/eligibility-questionnaire';
 import { mockContractorBasicInformationSchema } from '@/src/common/api/fixtures/contractors';
+import { PrettifiedValuesRenderer } from '@/src/tests/components/PrettifiedValuesRenderer';
 
 const mockOnSubmit = vi.fn();
 const mockOnSuccess = vi.fn();
 const mockOnError = vi.fn();
-
-// Helper component to display employment data in tests
-function Review({ values }: { values: Record<string, unknown> }) {
-  return (
-    <div className='onboarding-values'>
-      {Object.entries(values).map(([key, value]) => {
-        if (Array.isArray(value)) {
-          return (
-            <pre key={key}>
-              {key}: {value.join(', ')}
-            </pre>
-          );
-        }
-        if (typeof value === 'object') {
-          return (
-            <pre key={key}>
-              {key}: {JSON.stringify(value)}
-            </pre>
-          );
-        }
-        if (typeof value === 'string' || typeof value === 'number') {
-          return (
-            <pre key={key}>
-              {key}: {value}
-            </pre>
-          );
-        }
-
-        return null;
-      })}
-    </div>
-  );
-}
 
 const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [0]: 'Select Country',
@@ -211,19 +179,19 @@ describe('ContractorOnboardingFlow', () => {
           <div className='contractor-onboarding-review'>
             <h2 className='title'>Review</h2>
             <h2 className='title'>Basic Information</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 contractorOnboardingBag.meta.fields?.basic_information || {}
               }
             />
             <h2 className='title'>Pricing Plan</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 contractorOnboardingBag.meta.fields?.pricing_plan_details || {}
               }
             />
             <h2 className='title'>Contract Details</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 contractorOnboardingBag.meta.fields?.contract_details || {}
               }
@@ -342,21 +310,21 @@ describe('ContractorOnboardingFlow', () => {
           <div className='contractor-onboarding-review'>
             <h2 className='title'>Review</h2>
             <h2 className='title'>Basic Information</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 contractorOnboardingBag.stepState.values?.basic_information ||
                 {}
               }
             />
             <h2 className='title'>Pricing Plan</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 contractorOnboardingBag.stepState.values
                   ?.pricing_plan_details || {}
               }
             />
             <h2 className='title'>Contract Details</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 contractorOnboardingBag.stepState.values?.contract_details || {}
               }

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -213,21 +213,19 @@ describe('ContractorOnboardingFlow', () => {
             <h2 className='title'>Basic Information</h2>
             <Review
               values={
-                contractorOnboardingBag.stepState.values?.basic_information ||
-                {}
+                contractorOnboardingBag.meta.fields?.basic_information || {}
               }
             />
             <h2 className='title'>Pricing Plan</h2>
             <Review
               values={
-                contractorOnboardingBag.stepState.values
-                  ?.pricing_plan_details || {}
+                contractorOnboardingBag.meta.fields?.pricing_plan_details || {}
               }
             />
             <h2 className='title'>Contract Details</h2>
             <Review
               values={
-                contractorOnboardingBag.stepState.values?.contract_details || {}
+                contractorOnboardingBag.meta.fields?.contract_details || {}
               }
             />
             <BackButton>Back</BackButton>

--- a/src/flows/CostCalculator/CostCalculatorForm.tsx
+++ b/src/flows/CostCalculator/CostCalculatorForm.tsx
@@ -107,7 +107,7 @@ export function CostCalculatorForm({
 
       if (costCalculatorBag?.meta?.fields) {
         costCalculatorBag.meta.fields = prettifyFormValues(
-          values,
+          parsedValues,
           costCalculatorBag.fields,
         );
         costCalculatorBag.meta.fields['employer_currency_slug'] =

--- a/src/flows/CreateCompany/hooks.ts
+++ b/src/flows/CreateCompany/hooks.ts
@@ -173,12 +173,13 @@ export const useCreateCompany = ({
 
   async function onSubmit(values: FieldValues) {
     const currentStepName = stepState.currentStep.name;
+    const parsedValues = await parseFormValues(values);
     if (currentStepName in fieldsMetaRef.current) {
       fieldsMetaRef.current[
         currentStepName as keyof typeof fieldsMetaRef.current
-      ] = prettifyFormValues(values, stepFields[currentStepName]);
+      ] = prettifyFormValues(parsedValues, stepFields[currentStepName]);
     }
-    const parsedValues = await parseFormValues(values);
+
     switch (stepState.currentStep.name) {
       case 'company_basic_information': {
         setInternalCountryCode(parsedValues.country_code);

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -817,13 +817,13 @@ export const useOnboarding = ({
   async function onSubmit(values: FieldValues) {
     // Prettify values for the current step
     const currentStepName = stepState.currentStep.name;
+    const parsedValues = await parseFormValues(values);
     if (currentStepName in fieldsMetaRef.current) {
       fieldsMetaRef.current[
         currentStepName as keyof typeof fieldsMetaRef.current
-      ] = prettifyFormValues(values, stepFields[currentStepName]);
+      ] = prettifyFormValues(parsedValues, stepFields[currentStepName]);
     }
 
-    const parsedValues = await parseFormValues(values);
     refetchCompany();
     switch (stepState.currentStep.name) {
       case 'select_country': {

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -724,22 +724,27 @@ export const useOnboarding = ({
         select_country: prettifyFormValues(
           selectCountryInitialValues,
           stepFields.select_country,
+          { skipMoneyConversion: true },
         ),
         basic_information: prettifyFormValues(
           basicInformationInitialValues,
           stepFields.basic_information,
+          { skipMoneyConversion: true },
         ),
         engagement_agreement_details: prettifyFormValues(
           engagementAgreementDetailsInitialValues,
           stepFields.engagement_agreement_details,
+          { skipMoneyConversion: true },
         ),
         contract_details: prettifyFormValues(
           contractDetailsInitialValues,
           stepFields.contract_details,
+          { skipMoneyConversion: true },
         ),
         benefits: prettifyFormValues(
           benefitsInitialValues,
           stepFields.benefits,
+          { skipMoneyConversion: true },
         ),
       };
 

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -37,42 +37,11 @@ import {
 import userEvent from '@testing-library/user-event';
 import { OnboardingRenderProps } from '@/src/flows/Onboarding/types';
 import { getYearMonthDate } from '@/src/common/dates';
+import { PrettifiedValuesRenderer } from '@/src/tests/components/PrettifiedValuesRenderer';
 
 const mockOnSubmit = vi.fn();
 const mockOnSuccess = vi.fn();
 const mockOnError = vi.fn();
-
-function Review({ values }: { values: Record<string, unknown> }) {
-  return (
-    <div className='onboarding-values'>
-      {Object.entries(values).map(([key, value]) => {
-        if (Array.isArray(value)) {
-          return (
-            <pre>
-              {key}: {value.join(', ')}
-            </pre>
-          );
-        }
-        if (typeof value === 'object') {
-          return (
-            <pre>
-              {key}: {JSON.stringify(value)}
-            </pre>
-          );
-        }
-        if (typeof value === 'string' || typeof value === 'number') {
-          return (
-            <pre>
-              {key}: {value}
-            </pre>
-          );
-        }
-
-        return null;
-      })}
-    </div>
-  );
-}
 
 describe('OnboardingFlow', () => {
   const MultiStepFormWithCountry = ({
@@ -153,15 +122,17 @@ describe('OnboardingFlow', () => {
         return (
           <div className='onboarding-review'>
             <h2 className='title'>Basic Information</h2>
-            <Review
-              values={onboardingBag.stepState.values?.basic_information || {}}
+            <PrettifiedValuesRenderer
+              values={onboardingBag.meta.fields.basic_information || {}}
             />
             <h2 className='title'>Contract Details</h2>
-            <Review
-              values={onboardingBag.stepState.values?.contract_details || {}}
+            <PrettifiedValuesRenderer
+              values={onboardingBag.meta.fields.contract_details || {}}
             />
             <h2 className='title'>Benefits</h2>
-            <Review values={onboardingBag.stepState.values?.benefits || {}} />
+            <PrettifiedValuesRenderer
+              values={onboardingBag.meta.fields.benefits || {}}
+            />
             <BackButton>Back</BackButton>
             <OnboardingInvite
               render={({
@@ -241,15 +212,17 @@ describe('OnboardingFlow', () => {
         return (
           <div className='onboarding-review'>
             <h2 className='title'>Basic Information</h2>
-            <Review
-              values={onboardingBag.stepState.values?.basic_information || {}}
+            <PrettifiedValuesRenderer
+              values={onboardingBag.meta.fields?.basic_information || {}}
             />
             <h2 className='title'>Contract Details</h2>
-            <Review
-              values={onboardingBag.stepState.values?.contract_details || {}}
+            <PrettifiedValuesRenderer
+              values={onboardingBag.meta.fields?.contract_details || {}}
             />
             <h2 className='title'>Benefits</h2>
-            <Review values={onboardingBag.stepState.values?.benefits || {}} />
+            <PrettifiedValuesRenderer
+              values={onboardingBag.meta.fields?.benefits || {}}
+            />
             <BackButton>Back</BackButton>
             <OnboardingInvite
               render={() => 'Invite Employee'}
@@ -2446,6 +2419,151 @@ describe('OnboardingFlow', () => {
       expect(screen.getByLabelText(/Meal allowance per month/i)).toHaveValue(
         '0',
       );
+    });
+  });
+
+  it('should correctly prettify money fields in review step after submitting contract details', async () => {
+    const uniqueEmploymentId = generateUniqueEmploymentId();
+
+    // Mock with Portugal since it has money fields (annual_gross_salary)
+    server.use(
+      http.get(`*/v1/employments/${uniqueEmploymentId}`, () => {
+        return HttpResponse.json({
+          ...employmentDefaultResponse,
+          data: {
+            ...employmentDefaultResponse.data,
+            employment: {
+              ...employmentDefaultResponse.data.employment,
+              id: uniqueEmploymentId,
+              status: 'created',
+            },
+          },
+        });
+      }),
+    );
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+        if (onboardingBag.isLoading) {
+          return <div data-testid='spinner'>Loading...</div>;
+        }
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        employmentId={uniqueEmploymentId}
+        skipSteps={['select_country']}
+        {...defaultProps}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+    await screen.findByText(/Step: Contract Details/i);
+
+    await waitFor(() => {
+      const salaryInput = screen.getByRole('textbox', {
+        name: /Annual gross salary/i,
+      });
+      expect(salaryInput).toHaveValue('20000');
+    });
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+    await screen.findByText(/Step: Benefits/i);
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Review/i);
+    await waitFor(() => {
+      expect(
+        screen.getByText('annual_gross_salary: 20000'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should correctly prettify money fields when employment is invited and navigates directly to review', async () => {
+    const uniqueEmploymentId = generateUniqueEmploymentId();
+
+    // Mock with invited status so it auto-navigates to review
+    server.use(
+      http.get(`*/v1/employments/${uniqueEmploymentId}`, () => {
+        return HttpResponse.json({
+          ...employmentDefaultResponse,
+          data: {
+            ...employmentDefaultResponse.data,
+            employment: {
+              ...employmentDefaultResponse.data.employment,
+              id: uniqueEmploymentId,
+              status: 'invited', // Auto-navigate to review
+              contract_details: {
+                ...employmentDefaultResponse.data.employment.contract_details,
+                annual_gross_salary: 2000000, // 20000 in normal units
+              },
+            },
+          },
+        });
+      }),
+    );
+
+    mockRender.mockImplementation(
+      ({ onboardingBag, components }: OnboardingRenderProps) => {
+        const currentStepIndex = onboardingBag.stepState.currentStep.index;
+        const steps: Record<number, string> = {
+          [0]: 'Basic Information',
+          [1]: 'Contract Details',
+          [2]: 'Benefits',
+          [3]: 'Review',
+        };
+        if (onboardingBag.isLoading) {
+          return <div data-testid='spinner'>Loading...</div>;
+        }
+        return (
+          <>
+            <h1>Step: {steps[currentStepIndex]}</h1>
+            <MultiStepFormWithoutCountry
+              onboardingBag={onboardingBag}
+              components={components}
+            />
+          </>
+        );
+      },
+    );
+
+    render(
+      <OnboardingFlow
+        employmentId={uniqueEmploymentId}
+        skipSteps={['select_country']}
+        {...defaultProps}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Review/i);
+    await waitFor(() => {
+      expect(
+        screen.getByText('annual_gross_salary: 20000'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/flows/Onboarding/tests/OnboardingFlowGermanyDynamicSteps.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlowGermanyDynamicSteps.test.tsx
@@ -22,42 +22,11 @@ import { fillRadio, queryClient, TestProviders } from '@/src/tests/testHelpers';
 import { generateUniqueEmploymentId } from '@/src/flows/Onboarding/tests/helpers';
 import { OnboardingRenderProps } from '@/src/flows/Onboarding/types';
 import { mockBaseResponse } from '@/src/common/api/fixtures/base';
+import { PrettifiedValuesRenderer } from '@/src/tests/components/PrettifiedValuesRenderer';
 
 const mockOnSubmit = vi.fn();
 const mockOnSuccess = vi.fn();
 const mockOnError = vi.fn();
-
-function Review({ values }: { values: Record<string, unknown> }) {
-  return (
-    <div className='onboarding-values'>
-      {Object.entries(values).map(([key, value]) => {
-        if (Array.isArray(value)) {
-          return (
-            <pre key={key}>
-              {key}: {value.join(', ')}
-            </pre>
-          );
-        }
-        if (typeof value === 'object') {
-          return (
-            <pre key={key}>
-              {key}: {JSON.stringify(value)}
-            </pre>
-          );
-        }
-        if (typeof value === 'string' || typeof value === 'number') {
-          return (
-            <pre key={key}>
-              {key}: {value}
-            </pre>
-          );
-        }
-
-        return null;
-      })}
-    </div>
-  );
-}
 
 const phoneNumberMock = '1701234567';
 describe('OnboardingFlow - Germany with dynamic_steps', () => {
@@ -135,11 +104,11 @@ describe('OnboardingFlow - Germany with dynamic_steps', () => {
         return (
           <div className='onboarding-review'>
             <h2 className='title'>Basic Information</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={onboardingBag.meta.fields?.basic_information || {}}
             />
             <h2 className='title'>Engagement Agreement Details</h2>
-            <Review
+            <PrettifiedValuesRenderer
               values={
                 onboardingBag.meta.fields?.engagement_agreement_details || {}
               }

--- a/src/flows/Onboarding/tests/OnboardingFlowGermanyDynamicSteps.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlowGermanyDynamicSteps.test.tsx
@@ -136,13 +136,12 @@ describe('OnboardingFlow - Germany with dynamic_steps', () => {
           <div className='onboarding-review'>
             <h2 className='title'>Basic Information</h2>
             <Review
-              values={onboardingBag.stepState.values?.basic_information || {}}
+              values={onboardingBag.meta.fields?.basic_information || {}}
             />
             <h2 className='title'>Engagement Agreement Details</h2>
             <Review
               values={
-                onboardingBag.stepState.values?.engagement_agreement_details ||
-                {}
+                onboardingBag.meta.fields?.engagement_agreement_details || {}
               }
             />
             <BackButton>Back</BackButton>

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -190,7 +190,8 @@ describe('utils lib', () => {
     });
 
     it('handles money field', () => {
-      const values = { salary: 100000 };
+      // value must be in cents
+      const values = { salary: 100_000_00 };
       const fields: JSFFields = [
         {
           name: 'salary',

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -210,6 +210,43 @@ describe('utils lib', () => {
       });
     });
 
+    it('should not convert money field to cents if skipMoneyConversion is true', () => {
+      const values = { salary: 100000 };
+      const fields: JSFFields = [
+        { name: 'salary', type: 'money', label: 'Salary', currency: 'USD' },
+      ];
+      expect(
+        prettifyFormValues(values, fields, { skipMoneyConversion: true }),
+      ).toEqual({
+        salary: {
+          prettyValue: 100000,
+          label: 'Salary',
+          inputType: 'money',
+          currency: 'USD',
+        },
+      });
+    });
+
+    it('handles money field with null value', () => {
+      const values = { salary: null };
+      const fields: JSFFields = [
+        {
+          name: 'salary',
+          type: 'money',
+          label: 'Salary',
+          currency: 'USD',
+        },
+      ];
+      expect(prettifyFormValues(values, fields)).toEqual({
+        salary: {
+          prettyValue: null,
+          label: 'Salary',
+          inputType: 'money',
+          currency: 'USD',
+        },
+      });
+    });
+
     it('handles fieldset field', () => {
       const values = {
         address: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -216,6 +216,7 @@ export function prettifyFormValues(
           const prettiedFieldset = prettifyFormValues(
             value as Record<string, unknown>,
             field.fields as JSFFields,
+            options,
           );
 
           // Handles benefits fieldset in specific

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -176,11 +176,6 @@ export function prettifyFormValues(
         }
 
         if (field?.type === 'radio' || field?.type === 'select') {
-          console.log('field', {
-            name: field?.name,
-            value,
-            options: field?.options,
-          });
           const option = (
             field.options as Array<{ value: string; label: string }>
           ).find((option) => option.value === value);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -176,6 +176,11 @@ export function prettifyFormValues(
         }
 
         if (field?.type === 'radio' || field?.type === 'select') {
+          console.log('field', {
+            name: field?.name,
+            value,
+            options: field?.options,
+          });
           const option = (
             field.options as Array<{ value: string; label: string }>
           ).find((option) => option.value === value);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,7 @@ import {
   NormalizedFieldError,
   normalizeFieldErrors,
 } from '@/src/lib/mutations';
+import { convertFromCents } from '@/src/components/form/utils';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -230,10 +231,15 @@ export function prettifyFormValues(
         }
 
         if (field?.type === 'money') {
+          // value can be a string | number | null the values should come in cents
+          // we convert to normal format and not use formatCurrency as consumers are expecting normal number
           return [
             key,
             {
-              prettyValue: value,
+              prettyValue:
+                typeof value === 'string' || typeof value === 'number'
+                  ? convertFromCents(value)
+                  : '',
               label: field.label,
               inputType: field?.type,
               currency: field?.currency,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -156,6 +156,7 @@ export const clearBase64Data = (base64Data: string) => {
 export function prettifyFormValues(
   values: Record<string, unknown>,
   fields: JSFFields | undefined,
+  options?: { skipMoneyConversion?: boolean },
 ) {
   if (!fields) {
     return {};
@@ -237,9 +238,10 @@ export function prettifyFormValues(
             key,
             {
               prettyValue:
-                typeof value === 'string' || typeof value === 'number'
+                !options?.skipMoneyConversion &&
+                (typeof value === 'string' || typeof value === 'number')
                   ? convertFromCents(value)
-                  : '',
+                  : value,
               label: field.label,
               inputType: field?.type,
               currency: field?.currency,

--- a/src/tests/components/PrettifiedValuesRenderer.tsx
+++ b/src/tests/components/PrettifiedValuesRenderer.tsx
@@ -1,0 +1,51 @@
+export function PrettifiedValuesRenderer({
+  values,
+}: {
+  values: Record<string, unknown>;
+}) {
+  return (
+    <div className='onboarding-values'>
+      {Object.entries(values).map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return (
+            <pre key={key}>
+              {key}: {value.join(', ')}
+            </pre>
+          );
+        }
+
+        // Handle prettified values from meta.fields
+        if (
+          typeof value === 'object' &&
+          value !== null &&
+          'prettyValue' in value
+        ) {
+          const prettyObj = value as { prettyValue: unknown };
+          return (
+            <pre key={key}>
+              {key}: {String(prettyObj.prettyValue)}
+            </pre>
+          );
+        }
+
+        // Handle nested objects (like fieldsets)
+        if (typeof value === 'object') {
+          return (
+            <pre key={key}>
+              {key}: {JSON.stringify(value)}
+            </pre>
+          );
+        }
+
+        if (typeof value === 'string' || typeof value === 'number') {
+          return (
+            <pre key={key}>
+              {key}: {value}
+            </pre>
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## The problem
When users use the onboarding for Belgium, the contract details has some fields like eco_voucher and yearly premium rendered incorrectly

<img width="576" height="70" alt="image" src="https://github.com/user-attachments/assets/1d6c502f-1fa9-4807-9726-d3aeb8b9b528" />

## The solution
The solution is to pass to prettifyFormValues in the onSubmit, the values already parsed and that way in prettifyFormValues we can convert always trusting that the input will be always in cents

the problem was the values of the form was mixing cents && normal values in different inputs

We builld a escape hatch when we call prettifyFormValues when an employee has been invited


https://www.loom.com/share/2efa29079483435f8c160faef9a7ba81

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared form value transformation and review metadata rendering, which can affect how money amounts and some field values are displayed across multiple flows. Main risk is incorrect unit conversion (cents vs. major units) in review screens or tests if any step bypasses the new parsing/prettifying order.
> 
> **Overview**
> **Review metadata now uses parsed values** (API-shaped) when calling `prettifyFormValues` in `Onboarding`, `ContractorOnboarding`, `CreateCompany`, and `CostCalculator`, preventing mismatches between what is submitted and what is shown in the review/meta UI.
> 
> **Money prettification is corrected**: `prettifyFormValues` now converts `money` values *from cents* via `convertFromCents`, supports `null`, and adds an option `skipMoneyConversion` used when building review metadata from initial (already-normalized) values during auto-navigation to review.
> 
> **UI/test updates**: review step rendering is adjusted to hide empty `engagement_agreement_details`, introduces a shared `PrettifiedValuesRenderer` for tests, and adds/updates tests to assert correct money display in review (including direct-to-review invited employments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e368313834b63d2ebd51cb9ca8258042894010e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->