### PR TITLE
1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,21 @@
 ### Minor Changes
 
 #### Features
+
 - Add transformer hook (#986) [#986](https://github.com/remoteoss/remote-flows/pull/986)
 - add transformHtml prop to let custom components transform html to components (#992) [#992](https://github.com/remoteoss/remote-flows/pull/992)
 
 #### Chores
+
 - use shared description component for fieldsets (#995) [#995](https://github.com/remoteoss/remote-flows/pull/995)
 
 #### Docs
+
 - add netherlands changelog (#990) [#990](https://github.com/remoteoss/remote-flows/pull/990)
 
 #### Fixes
+
 - parse values before prettifying for the review step (#1001) [#1001](https://github.com/remoteoss/remote-flows/pull/1001)
-
-
-
 
 ## 1.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @remoteoss/remote-flows
 
+## 1.31.0
+
+### Minor Changes
+
+- use base description (#995) [#995](https://github.com/remoteoss/remote-flows/pull/995)
+- add netherlands changelog (#990) [#990](https://github.com/remoteoss/remote-flows/pull/990)
+- Add transformer hook (#986) [#986](https://github.com/remoteoss/remote-flows/pull/986)
+- add transformHtml prop to let custom components transform html to components (#992) [#992](https://github.com/remoteoss/remote-flows/pull/992)
+- parse values before prettifying (#1001) [#1001](https://github.com/remoteoss/remote-flows/pull/1001)
+
 ## 1.30.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,21 @@
 
 ### Minor Changes
 
-- use base description (#995) [#995](https://github.com/remoteoss/remote-flows/pull/995)
-- add netherlands changelog (#990) [#990](https://github.com/remoteoss/remote-flows/pull/990)
+#### Features
 - Add transformer hook (#986) [#986](https://github.com/remoteoss/remote-flows/pull/986)
 - add transformHtml prop to let custom components transform html to components (#992) [#992](https://github.com/remoteoss/remote-flows/pull/992)
-- parse values before prettifying (#1001) [#1001](https://github.com/remoteoss/remote-flows/pull/1001)
+
+#### Chores
+- use shared description component for fieldsets (#995) [#995](https://github.com/remoteoss/remote-flows/pull/995)
+
+#### Docs
+- add netherlands changelog (#990) [#990](https://github.com/remoteoss/remote-flows/pull/990)
+
+#### Fixes
+- parse values before prettifying for the review step (#1001) [#1001](https://github.com/remoteoss/remote-flows/pull/1001)
+
+
+
 
 ## 1.30.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.31.0

### Minor Changes

#### Features

- Add transformer hook (#986) [#986](https://github.com/remoteoss/remote-flows/pull/986)
- add transformHtml prop to let custom components transform html to components (#992) [#992](https://github.com/remoteoss/remote-flows/pull/992)

#### Chores

- use shared description component for fieldsets (#995) [#995](https://github.com/remoteoss/remote-flows/pull/995)

#### Docs

- add netherlands changelog (#990) [#990](https://github.com/remoteoss/remote-flows/pull/990)

#### Fixes

- parse values before prettifying for the review step (#1001) [#1001](https://github.com/remoteoss/remote-flows/pull/1001)

---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates version numbers and adds release notes without changing runtime code.
> 
> **Overview**
> Bumps `@remoteoss/remote-flows` from `1.30.0` to `1.31.0` in `package.json` and `package-lock.json`.
> 
> Updates `CHANGELOG.md` with the `1.31.0` release notes (features, chores, docs, and fixes referenced by prior PRs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94479e31b6c42e6b063373d96f6fd4504f3deb68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->