### PR TITLE
fix(zizmor) - static analyze github actions

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,10 +10,12 @@ jobs:
     name: Lint and Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -33,10 +35,12 @@ jobs:
     name: Build and Check Exports
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -53,10 +57,12 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -70,10 +76,12 @@ jobs:
     name: Example App Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -99,11 +107,13 @@ jobs:
     name: Deploy Remote Flows Preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Deploy remote-flows to vercel
         id: vercel-remote-flows
-        uses: amondnet/vercel-action@v42.2.0
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
@@ -114,10 +124,12 @@ jobs:
 
       - name: Save deployment URL
         run: |
-          echo "${{ steps.vercel-remote-flows.outputs.preview-url }}" > remote-flows-url.txt
+          echo "${STEPS_VERCEL_REMOTE_FLOWS_OUTPUTS_PREVIEW_URL}" > remote-flows-url.txt
+        env:
+          STEPS_VERCEL_REMOTE_FLOWS_OUTPUTS_PREVIEW_URL: ${{ steps.vercel-remote-flows.outputs.preview-url }}
 
       - name: Upload deployment URL
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: remote-flows-url
           path: remote-flows-url.txt
@@ -134,10 +146,12 @@ jobs:
         deploy-remote-flows,
       ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -153,7 +167,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Download remote-flows URL
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: remote-flows-url
 
@@ -170,7 +184,7 @@ jobs:
         working-directory: ./example
         run: npx playwright test --project=chromium
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -183,10 +197,12 @@ jobs:
       [lint-and-format, build-and-exports, tests, example-checks, e2e-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Promote remote-flows to production
-        uses: amondnet/vercel-action@v42.2.0
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,10 +10,12 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -24,7 +26,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage/
@@ -34,10 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: coverage
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -45,7 +49,7 @@ jobs:
         run: npm ci --include=optional --ignore-scripts
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-report
           path: coverage/
@@ -59,7 +63,7 @@ jobs:
           echo "Coverage: $COVERAGE%"
 
       - name: Create coverage badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: ${{ secrets.COVERAGE_GIST_ID }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -232,7 +232,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -232,7 +232,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,12 @@ jobs:
     name: Lint and Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -34,10 +36,12 @@ jobs:
     name: Build and Check Exports
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -54,10 +58,12 @@ jobs:
     name: Tests with Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -74,7 +80,7 @@ jobs:
         run: npm run coverage:extract -- --output out/current-coverage.json
 
       - name: Upload current coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: current-coverage
           path: out/current-coverage.json
@@ -84,7 +90,9 @@ jobs:
     name: Generate Base Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Check if coverage scripts exist
         id: check-scripts
@@ -98,7 +106,7 @@ jobs:
       - name: Check cache for base coverage
         if: steps.check-scripts.outputs.exists == 'true'
         id: cache-base
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: base-coverage.json
           key: coverage-${{ github.base_ref }}-${{ github.event.pull_request.base.sha }}
@@ -106,8 +114,8 @@ jobs:
       - name: Checkout base branch
         if: steps.check-scripts.outputs.exists == 'true' && steps.cache-base.outputs.cache-hit != 'true'
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
+          git fetch origin ${GITHUB_BASE_REF}
+          git checkout origin/${GITHUB_BASE_REF}
 
       - name: Check if coverage scripts exist in base branch
         if: steps.check-scripts.outputs.exists == 'true' && steps.cache-base.outputs.cache-hit != 'true'
@@ -121,7 +129,7 @@ jobs:
 
       - name: Use Node.js
         if: steps.check-scripts.outputs.exists == 'true' && steps.cache-base.outputs.cache-hit != 'true' && steps.check-base-scripts.outputs.exists == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -139,7 +147,7 @@ jobs:
 
       - name: Upload base coverage
         if: steps.check-scripts.outputs.exists == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: base-coverage
           path: base-coverage.json
@@ -149,10 +157,12 @@ jobs:
     name: Example App Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -182,10 +192,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -196,13 +208,13 @@ jobs:
         run: mkdir -p out
 
       - name: Download current coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: current-coverage
           path: out
 
       - name: Download base coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: base-coverage
           path: out
@@ -220,7 +232,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -261,7 +273,7 @@ jobs:
           COVERAGE_REPORT: ${{ steps.compare.outputs.report }}
 
       - name: Upload coverage analysis
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: coverage-analysis
@@ -275,11 +287,13 @@ jobs:
     name: Deploy Remote Flows Preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Deploy remote-flows to vercel
         id: vercel-remote-flows
-        uses: amondnet/vercel-action@v42.2.0
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
@@ -290,10 +304,12 @@ jobs:
 
       - name: Save deployment URL
         run: |
-          echo "${{ steps.vercel-remote-flows.outputs.preview-url }}" > remote-flows-url.txt
+          echo "${STEPS_VERCEL_REMOTE_FLOWS_OUTPUTS_PREVIEW_URL}" > remote-flows-url.txt
+        env:
+          STEPS_VERCEL_REMOTE_FLOWS_OUTPUTS_PREVIEW_URL: ${{ steps.vercel-remote-flows.outputs.preview-url }}
 
       - name: Upload deployment URL
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: remote-flows-url
           path: remote-flows-url.txt
@@ -310,10 +326,12 @@ jobs:
         deploy-remote-flows,
       ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
 
@@ -329,7 +347,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Download remote-flows URL
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: remote-flows-url
 
@@ -346,7 +364,7 @@ jobs:
         working-directory: ./example
         run: npx playwright test --project=chromium
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,8 @@ jobs:
 
           gh release create v${STEPS_VERSION_CHECK_OUTPUTS_VERSION} \
             --title "v${STEPS_VERSION_CHECK_OUTPUTS_VERSION}" \
-            --notes "$CHANGELOG_CONTENT"
+            --notes "$CHANGELOG_CONTENT" \
+            --target "$(git rev-parse HEAD)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STEPS_VERSION_CHECK_OUTPUTS_VERSION: ${{ steps.version-check.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,14 +110,6 @@ jobs:
         env:
           STEPS_NPM_TAG_OUTPUTS_TAG: ${{ steps.npm-tag.outputs.tag }}
 
-      - name: Create git tag
-        if: steps.version-check.outputs.changed == 'true'
-        run: |
-          git tag v${STEPS_VERSION_CHECK_OUTPUTS_VERSION}
-          git push origin v${STEPS_VERSION_CHECK_OUTPUTS_VERSION}
-        env:
-          STEPS_VERSION_CHECK_OUTPUTS_VERSION: ${{ steps.version-check.outputs.version }}
-
       - name: Create GitHub release
         if: steps.version-check.outputs.changed == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || '' }}
+          persist-credentials: false
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
@@ -42,8 +43,8 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./package.json').version")
 
           # Check if this is a manual dispatch with ref input
-          if [ -n "${{ inputs.ref }}" ]; then
-            echo "Manual release triggered for ref: ${{ inputs.ref }}"
+          if [ -n "${INPUTS_REF}" ]; then
+            echo "Manual release triggered for ref: ${INPUTS_REF}"
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
             echo "Version to release: $CURRENT_VERSION"
@@ -65,6 +66,8 @@ jobs:
               echo "No version change detected"
             fi
           fi
+        env:
+          INPUTS_REF: ${{ inputs.ref }}
 
       - name: Build and test
         if: steps.version-check.outputs.changed == 'true'
@@ -76,7 +79,7 @@ jobs:
         if: steps.version-check.outputs.changed == 'true'
         id: npm-tag
         run: |
-          CURRENT_VERSION="${{ steps.version-check.outputs.version }}"
+          CURRENT_VERSION="${STEPS_VERSION_CHECK_OUTPUTS_VERSION}"
 
           # Get the latest version from npm registry
           LATEST_VERSION=$(npm view @remoteoss/remote-flows dist-tags.latest 2>/dev/null || echo "0.0.0")
@@ -93,33 +96,40 @@ jobs:
             echo "tag=" >> $GITHUB_OUTPUT
             echo "Publishing with default tag (will become latest)"
           fi
+        env:
+          STEPS_VERSION_CHECK_OUTPUTS_VERSION: ${{ steps.version-check.outputs.version }}
 
       - name: Publish to npm
         if: steps.version-check.outputs.changed == 'true'
         run: |
-          if [ -n "${{ steps.npm-tag.outputs.tag }}" ]; then
-            npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
+          if [ -n "${STEPS_NPM_TAG_OUTPUTS_TAG}" ]; then
+            npm publish --provenance --access public --tag ${STEPS_NPM_TAG_OUTPUTS_TAG}
           else
             npm publish --provenance --access public
           fi
+        env:
+          STEPS_NPM_TAG_OUTPUTS_TAG: ${{ steps.npm-tag.outputs.tag }}
 
       - name: Create git tag
         if: steps.version-check.outputs.changed == 'true'
         run: |
-          git tag v${{ steps.version-check.outputs.version }}
-          git push origin v${{ steps.version-check.outputs.version }}
+          git tag v${STEPS_VERSION_CHECK_OUTPUTS_VERSION}
+          git push origin v${STEPS_VERSION_CHECK_OUTPUTS_VERSION}
+        env:
+          STEPS_VERSION_CHECK_OUTPUTS_VERSION: ${{ steps.version-check.outputs.version }}
 
       - name: Create GitHub release
         if: steps.version-check.outputs.changed == 'true'
         run: |
           # Get the changelog content for this version
-          CHANGELOG_CONTENT=$(awk '/^## [0-9]/ {if (p) exit} /^## '"${{ steps.version-check.outputs.version }}"'$/ {p=1; next} p' CHANGELOG.md)
+          CHANGELOG_CONTENT=$(awk '/^## [0-9]/ {if (p) exit} /^## '"${STEPS_VERSION_CHECK_OUTPUTS_VERSION}"'$/ {p=1; next} p' CHANGELOG.md)
 
-          gh release create v${{ steps.version-check.outputs.version }} \
-            --title "v${{ steps.version-check.outputs.version }}" \
+          gh release create v${STEPS_VERSION_CHECK_OUTPUTS_VERSION} \
+            --title "v${STEPS_VERSION_CHECK_OUTPUTS_VERSION}" \
             --notes "$CHANGELOG_CONTENT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_VERSION_CHECK_OUTPUTS_VERSION: ${{ steps.version-check.outputs.version }}
 
       - name: No release needed
         if: steps.version-check.outputs.changed == 'false'

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -22,10 +22,12 @@ jobs:
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
           cache: 'npm'
@@ -40,10 +42,11 @@ jobs:
         run: npm run size -- --output out/current-bundle.json
 
       - name: Checkout base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.base_ref }}
           path: base
+          persist-credentials: false
 
       - name: Check if comparison script exists on base
         id: check_script
@@ -74,7 +77,7 @@ jobs:
         id: compare
         run: |
           # Check if we have comparison data
-          if [ "${{ steps.check_script.outputs.exists }}" != "true" ]; then
+          if [ "${STEPS_CHECK_SCRIPT_OUTPUTS_EXISTS}" != "true" ]; then
             echo "⚠️ Comparison script not found in base branch. Showing current bundle size only."
             npm exec tsx scripts/format-current-size.ts out/current-bundle.json > out/size-report.md
           else
@@ -89,9 +92,11 @@ jobs:
           echo "report<<EOF" >> $GITHUB_OUTPUT
           echo "$REPORT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          STEPS_CHECK_SCRIPT_OUTPUTS_EXISTS: ${{ steps.check_script.outputs.exists }}
 
       - name: Post PR comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -135,7 +140,7 @@ jobs:
         run: npm run size:check
 
       - name: Upload bundle analysis
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: bundle-size-analysis

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -96,7 +96,7 @@ jobs:
           STEPS_CHECK_SCRIPT_OUTPUTS_EXISTS: ${{ steps.check_script.outputs.exists }}
 
       - name: Post PR comment
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -96,7 +96,7 @@ jobs:
           STEPS_CHECK_SCRIPT_OUTPUTS_EXISTS: ${{ steps.check_script.outputs.exists }}
 
       - name: Post PR comment
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -21,10 +21,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.15.0'
           cache: 'npm'
@@ -74,7 +76,7 @@ jobs:
           echo "✓ Updated gist with latest bundle size data"
 
       - name: Upload badge data artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bundle-size-badge
           path: out/size-data.json
@@ -94,8 +96,10 @@ jobs:
 
           echo "- **Total (gzipped):** ${GZIP_KB} KB" >> $GITHUB_STEP_SUMMARY
           echo "- **Total (raw):** ${RAW_KB} KB" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** ${{ steps.package-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${STEPS_PACKAGE_VERSION_OUTPUTS_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** \`${GITHUB_SHA:0:8}\`" >> $GITHUB_STEP_SUMMARY
+        env:
+          STEPS_PACKAGE_VERSION_OUTPUTS_VERSION: ${{ steps.package-version.outputs.version }}
 
       - name: Warn if secrets not configured
         if: env.GIST_ID == '' || env.GIST_TOKEN == ''

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -35,7 +35,24 @@ jobs:
         continue-on-error: true
       
       - name: Generate SARIF report
-        run: zizmor --format sarif .github/workflows/ > zizmor-results.sarif || true
+        run: |
+          # Run zizmor with SARIF output (stderr goes to console, stdout goes to file)
+          set +e
+          zizmor --format sarif .github/workflows/ > zizmor-results.sarif
+          EXIT_CODE=$?
+          set -e
+          
+          echo "Zizmor exit code: $EXIT_CODE"
+          
+          # Check if SARIF file was created and contains valid JSON start
+          if [ ! -s zizmor-results.sarif ] || ! grep -q '^\s*{' zizmor-results.sarif; then
+            echo "Error: SARIF file is empty or invalid"
+            echo '{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json","runs":[]}' > zizmor-results.sarif
+          else
+            echo "SARIF file generated successfully"
+          fi
+          
+          echo "SARIF file size: $(wc -c < zizmor-results.sarif) bytes"
       
       - name: Upload SARIF results to GitHub Security
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,9 +26,11 @@ jobs:
 
       - name: Install zizmor
         run: |
-          curl -L https://github.com/woodruffw/zizmor/releases/latest/download/zizmor-x86_64-unknown-linux-musl -o zizmor
+          curl -L https://github.com/woodruffw/zizmor/releases/latest/download/zizmor-x86_64-unknown-linux-gnu.tar.gz -o zizmor.tar.gz
+          tar -xzf zizmor.tar.gz
           chmod +x zizmor
           sudo mv zizmor /usr/local/bin/
+          zizmor --version
 
       - name: Run zizmor audit (console output)
         run: zizmor .github/workflows/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,14 +30,15 @@ jobs:
           chmod +x zizmor
           sudo mv zizmor /usr/local/bin/
 
-      - name: Run zizmor audit
-        run: |
-          zizmor --format sarif .github/workflows/ > zizmor-results.sarif
-          zizmor .github/workflows/
+      - name: Run zizmor audit (console output)
+        run: zizmor .github/workflows/
         continue-on-error: true
-
+      
+      - name: Generate SARIF report
+        run: zizmor --format sarif .github/workflows/ > zizmor-results.sarif || true
+      
       - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         if: always()
         with:
           sarif_file: zizmor-results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,30 +33,39 @@ jobs:
       - name: Run zizmor audit (console output)
         run: zizmor .github/workflows/
         continue-on-error: true
-      
+
       - name: Generate SARIF report
+        id: sarif
         run: |
           # Run zizmor with SARIF output (stderr goes to console, stdout goes to file)
           set +e
           zizmor --format sarif .github/workflows/ > zizmor-results.sarif
           EXIT_CODE=$?
           set -e
-          
+
           echo "Zizmor exit code: $EXIT_CODE"
-          
+
           # Check if SARIF file was created and contains valid JSON start
           if [ ! -s zizmor-results.sarif ] || ! grep -q '^\s*{' zizmor-results.sarif; then
             echo "Error: SARIF file is empty or invalid"
-            echo '{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json","runs":[]}' > zizmor-results.sarif
+            echo "has_results=false" >> $GITHUB_OUTPUT
           else
             echo "SARIF file generated successfully"
+            # Check if SARIF has any results
+            if grep -q '"results":\s*\[\s*\]' zizmor-results.sarif || [ $(wc -c < zizmor-results.sarif) -lt 300 ]; then
+              echo "SARIF file has no findings"
+              echo "has_results=false" >> $GITHUB_OUTPUT
+            else
+              echo "SARIF file has findings"
+              echo "has_results=true" >> $GITHUB_OUTPUT
+            fi
           fi
-          
+
           echo "SARIF file size: $(wc -c < zizmor-results.sarif) bytes"
-      
+
       - name: Upload SARIF results to GitHub Security
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-        if: always()
+        if: always() && steps.sarif.outputs.has_results == 'true'
         with:
           sarif_file: zizmor-results.sarif
           category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,50 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install zizmor
-        run: |
-          curl -L https://github.com/woodruffw/zizmor/releases/latest/download/zizmor-x86_64-unknown-linux-gnu.tar.gz -o zizmor.tar.gz
-          tar -xzf zizmor.tar.gz
-          chmod +x zizmor
-          sudo mv zizmor /usr/local/bin/
-          zizmor --version
-
-      - name: Run zizmor audit (console output)
-        run: zizmor .github/workflows/
-        continue-on-error: true
-
-      - name: Generate SARIF report
-        id: sarif
-        run: |
-          # Run zizmor with SARIF output (stderr goes to console, stdout goes to file)
-          set +e
-          zizmor --format sarif .github/workflows/ > zizmor-results.sarif
-          EXIT_CODE=$?
-          set -e
-
-          echo "Zizmor exit code: $EXIT_CODE"
-
-          # Check if SARIF file was created and contains valid JSON start
-          if [ ! -s zizmor-results.sarif ] || ! grep -q '^\s*{' zizmor-results.sarif; then
-            echo "Error: SARIF file is empty or invalid"
-            echo "has_results=false" >> $GITHUB_OUTPUT
-          else
-            echo "SARIF file generated successfully"
-            # Check if SARIF has any results
-            if grep -q '"results":\s*\[\s*\]' zizmor-results.sarif || [ $(wc -c < zizmor-results.sarif) -lt 300 ]; then
-              echo "SARIF file has no findings"
-              echo "has_results=false" >> $GITHUB_OUTPUT
-            else
-              echo "SARIF file has findings"
-              echo "has_results=true" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-          echo "SARIF file size: $(wc -c < zizmor-results.sarif) bytes"
-
-      - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-        if: always() && steps.sarif.outputs.has_results == 'true'
+      - name: Run zizmor security audit
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e
         with:
-          sarif_file: zizmor-results.sarif
-          category: zizmor
+          sarif-file: zizmor-results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,25 +17,25 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      
+
       - name: Install zizmor
         run: |
           curl -L https://github.com/woodruffw/zizmor/releases/latest/download/zizmor-x86_64-unknown-linux-musl -o zizmor
           chmod +x zizmor
           sudo mv zizmor /usr/local/bin/
-      
+
       - name: Run zizmor audit
         run: |
           zizmor --format sarif .github/workflows/ > zizmor-results.sarif
           zizmor .github/workflows/
         continue-on-error: true
-      
+
       - name: Upload SARIF results to GitHub Security
         uses: github/codeql-action/upload-sarif@c36f22e9e0e85e0993fb1124f11a8a1c290b5d42 # v3
         if: always()

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,44 @@
+name: GitHub Actions Security Audit
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*.yml'
+
+jobs:
+  zizmor:
+    name: Audit Workflows with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      
+      - name: Install zizmor
+        run: |
+          curl -L https://github.com/woodruffw/zizmor/releases/latest/download/zizmor-x86_64-unknown-linux-musl -o zizmor
+          chmod +x zizmor
+          sudo mv zizmor /usr/local/bin/
+      
+      - name: Run zizmor audit
+        run: |
+          zizmor --format sarif .github/workflows/ > zizmor-results.sarif
+          zizmor .github/workflows/
+        continue-on-error: true
+      
+      - name: Upload SARIF results to GitHub Security
+        uses: github/codeql-action/upload-sarif@c36f22e9e0e85e0993fb1124f11a8a1c290b5d42 # v3
+        if: always()
+        with:
+          sarif_file: zizmor-results.sarif
+          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@c36f22e9e0e85e0993fb1124f11a8a1c290b5d42 # v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         if: always()
         with:
           sarif_file: zizmor-results.sarif

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' NODE_ENV=development tsup --watch",
     "build:reset": "postcss src/styles/reset.css -o ./example/src/css/reset.css",
     "lint": "oxlint .",
+    "lint:workflows": "zizmor .github/workflows/",
+    "lint:workflows:fix": "zizmor --fix .github/workflows/",
     "format": "oxfmt",
     "openapi-ts": "openapi-ts && npm run format",
     "test": "vitest",


### PR DESCRIPTION
Another [supply chain attack](https://www.aikido.dev/blog/mini-shai-hulud-is-back-tanstack-compromised), we're putting more mechanism in place to avoid issues

Before we set up 

* lock versions in package.json
* have aikido to avoid installing fresh new packages
* renovate to make PRs to update the packages for us

Now we introduce a new tool called [zizmor](https://docs.zizmor.sh/) that helps us lint github actions, avoid security issues which are simple to introduce

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly CI/workflow hardening, but it touches release/publish and deployment workflows where misconfigurations could break publishing or CI execution.
> 
> **Overview**
> **Hardens GitHub Actions workflows** by pinning all third-party actions to immutable commit SHAs and setting `persist-credentials: false` on checkouts across CI, PR, coverage, size, and release pipelines.
> 
> **Reduces workflow injection risk** by moving `${{ ... }}` expressions out of shell interpolations into `env` variables (e.g., Vercel preview URL saving, base branch checkout, size/coverage compare, release tagging/publishing), and adds `--target $(git rev-parse HEAD)` when creating GitHub releases.
> 
> **Adds workflow security auditing** via a new `.github/workflows/zizmor.yml` job (SARIF output) and exposes `zizmor` via new `package.json` scripts `lint:workflows` and `lint:workflows:fix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8637ea1b1c95c874bb9cd26963d2e410165ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->