### PR TITLE
1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @remoteoss/remote-flows
 
+## 1.33.0
+
+### Minor Changes
+
+- static analyze github actions (#1005) [#1005](https://github.com/remoteoss/remote-flows/pull/1005)
+- add example and expose props (#993) [#993](https://github.com/remoteoss/remote-flows/pull/993)
+- Add some docs (#994) [#994](https://github.com/remoteoss/remote-flows/pull/994)
+
 ## 1.32.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Minor Changes
 
+#### Features
+
+- add `transformHTMLToComponents` to RemoteFlows (#993) [#993](https://github.com/remoteoss/remote-flows/pull/993)
+
+#### Chores
+
 - static analyze github actions (#1005) [#1005](https://github.com/remoteoss/remote-flows/pull/1005)
-- add example and expose props (#993) [#993](https://github.com/remoteoss/remote-flows/pull/993)
-- Add some docs (#994) [#994](https://github.com/remoteoss/remote-flows/pull/994)
 
 ## 1.32.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.33.0

### Minor Changes

#### Features

- add `transformHTMLToComponents` to RemoteFlows (#993) [#993](https://github.com/remoteoss/remote-flows/pull/993)

#### Chores

- static analyze github actions (#1005) [#1005](https://github.com/remoteoss/remote-flows/pull/1005)


---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog entry updates, with no runtime code changes in this diff.
> 
> **Overview**
> **Release bump to `1.33.0`.** Updates `package.json`/`package-lock.json` versions from `1.32.0` to `1.33.0` and adds a `CHANGELOG.md` entry noting `transformHTMLToComponents` and GitHub Actions static analysis work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38672df734aa7249f048bb683485ea5c84802212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->