### PR TITLE
chore(oxlint) - migrate comments

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -40,7 +40,6 @@ This project is a React component library (`@remoteoss/remote-flows`) that provi
 **Enforced by oxlint (Rust-based linter):**
 
 - React Hooks rules (exhaustive dependencies)
-- Only export components in flow files (react-refresh)
 - `no-console`: warn (only `console.warn` and `console.error` allowed)
 
 **Naming Conventions:**

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -16,7 +16,7 @@ This project is a React component library (`@remoteoss/remote-flows`) that provi
 ### TypeScript
 
 - **Strict mode enabled** - all strict TypeScript checks are enforced via `tsconfig.json`
-- **No `any` types** - except where explicitly needed with `/* eslint-disable @typescript-eslint/no-explicit-any */`
+- **No `any` types** - except where explicitly needed with `/* oxlint-disable @typescript-eslint/no-explicit-any */`
 - **Use `$TSFixMe` type** - for temporary type workarounds (defined in `src/types/remoteFlows.ts`)
 - **Export types** - all public types must be exported for consumer TypeScript support
 - **Type imports** - use `import type` for type-only imports where possible
@@ -29,7 +29,7 @@ This project is a React component library (`@remoteoss/remote-flows`) that provi
 
 ### Code Style
 
-**Enforced by Prettier:**
+**Enforced by oxfmt (Rust-based formatter):**
 
 - Single quotes (including JSX: `jsxSingleQuote: true`)
 - Semicolons required
@@ -37,7 +37,7 @@ This project is a React component library (`@remoteoss/remote-flows`) that provi
 - 80 character line width
 - 2 space indentation
 
-**Enforced by ESLint:**
+**Enforced by oxlint (Rust-based linter):**
 
 - React Hooks rules (exhaustive dependencies)
 - Only export components in flow files (react-refresh)
@@ -382,12 +382,12 @@ flows/[FlowName]/
 ### 2. React Hook Dependencies
 
 - Missing dependencies in `useEffect`, `useCallback`, `useMemo`
-- ESLint warnings for `react-hooks/exhaustive-deps` must be fixed
+- Oxlint warnings for `react-hooks/exhaustive-deps` must be fixed
 - Avoid disabling the rule - fix the dependency array instead
 
 ### 3. Type Safety Issues
 
-- Using `any` without `eslint-disable` comment
+- Using `any` without `oxlint-disable` comment
 - Type assertions (`as`) without clear justification
 - Missing null/undefined checks for optional values
 - Incorrect generic type parameters

--- a/src/RemoteFlowsProvider.tsx
+++ b/src/RemoteFlowsProvider.tsx
@@ -87,7 +87,7 @@ export function RemoteFlows({
   transformHtmlToComponents,
 }: PropsWithChildren<RemoteFlowsSDKProps>) {
   // WE NEED TO FIX: react-hooks/refs - Cannot access refs during render
-  // eslint-disable-next-line react-hooks/refs
+  // oxlint-disable-next-line react-hooks/refs
   const remoteApiClient = useRef(
     createClient(auth, { proxy, environment, credentials }),
   ).current;

--- a/src/common/hooks.ts
+++ b/src/common/hooks.ts
@@ -13,7 +13,7 @@ export function useDebounce(
 
   const debouncedFn = useRef(
     // WE NEED TO FIX: react-hooks/refs - Passing a ref to a function may read its value during render
-    // eslint-disable-next-line react-hooks/refs
+    // oxlint-disable-next-line react-hooks/refs
     debounce((value: string) => {
       callbackRef.current(value);
     }, delay),

--- a/src/components/JsonSchemaComparison/JsonSchemaComparison.tsx
+++ b/src/components/JsonSchemaComparison/JsonSchemaComparison.tsx
@@ -100,7 +100,7 @@ export const JsonSchemaComparison = () => {
 
     if (!availableVersionValues.includes(topVersion)) {
       // WE NEED TO FIX: react-hooks/set-state-in-effect - Calling setState synchronously within an effect can trigger cascading renders
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // oxlint-disable-next-line react-hooks/set-state-in-effect
       setTopVersion(versionOptions[0].value);
     }
     if (!availableVersionValues.includes(bottomVersion)) {

--- a/src/components/error-handling/useErrorReporting.ts
+++ b/src/components/error-handling/useErrorReporting.ts
@@ -10,7 +10,7 @@ export function useErrorReporting(initialContext: ErrorContextData) {
     if (initialContext) {
       errorContextRef.current = initialContext;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Clear context on unmount
@@ -31,7 +31,7 @@ export function useErrorReporting(initialContext: ErrorContextData) {
         errorContextRef.current = {};
       },
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 

--- a/src/components/form/fields/ForcedValueField.tsx
+++ b/src/components/form/fields/ForcedValueField.tsx
@@ -37,7 +37,7 @@ export function ForcedValueField({
 
   useEffect(() => {
     setValue(name, value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const isHiddenValue = !forcedValueDescription && !statement?.title;

--- a/src/components/form/fields/default/CountryFieldDefault.tsx
+++ b/src/components/form/fields/default/CountryFieldDefault.tsx
@@ -27,7 +27,7 @@ export function CountryFieldDefault({
   useEffect(() => {
     if (field.value && fieldData.options) {
       // WE NEED TO FIX: react-hooks/set-state-in-effect - Calling setState synchronously within an effect can trigger cascading renders
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // oxlint-disable-next-line react-hooks/set-state-in-effect
       setSelected(
         field.value.map(
           (value: $TSFixMe) =>

--- a/src/components/form/fields/default/MultiSelectFieldDefault.tsx
+++ b/src/components/form/fields/default/MultiSelectFieldDefault.tsx
@@ -22,7 +22,7 @@ export const MultiSelectFieldDefault = ({
 
   useEffect(() => {
     // WE NEED TO FIX: react-hooks/set-state-in-effect - Calling setState synchronously within an effect can trigger cascading renders
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // oxlint-disable-next-line react-hooks/set-state-in-effect
     setSelected(
       options?.filter((option) => field.value?.includes(option.value)) || [],
     );

--- a/src/components/form/useJSONSchemaForm.tsx
+++ b/src/components/form/useJSONSchemaForm.tsx
@@ -35,7 +35,7 @@ export function useJSONSchemaForm({
       }
     });
     return () => subscription?.unsubscribe();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return form;

--- a/src/components/ui/file-uploader.tsx
+++ b/src/components/ui/file-uploader.tsx
@@ -38,7 +38,7 @@ export function FileUploader({
     if (externalFiles && externalFiles !== syncedRef.current) {
       syncedRef.current = externalFiles;
       // effect is okay here, we just track with a ref to avoid unnecessary re-renders
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // oxlint-disable-next-line react-hooks/set-state-in-effect
       setFiles(externalFiles);
     }
   }, [externalFiles]);

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -125,7 +125,7 @@ const FormControl = React.forwardRef<
   return React.cloneElement(
     children as React.ReactElement<Record<string, unknown>>,
     // WE NEED TO FIX: react-hooks/refs - Passing a ref to a function may read its value during render
-    // eslint-disable-next-line react-hooks/refs
+    // oxlint-disable-next-line react-hooks/refs
     { ...(children.props as object), ...controlProps, ref },
   );
 });

--- a/src/flows/ContractAmendment/ContractAmendmentForm.tsx
+++ b/src/flows/ContractAmendment/ContractAmendmentForm.tsx
@@ -92,7 +92,7 @@ export function ContractAmendmentForm({
       }
     });
     return () => subscription?.unsubscribe();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSubmit = async (values: FieldValues) => {

--- a/src/flows/ContractorOnboarding/components/ContractorOnboardingForm.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractorOnboardingForm.tsx
@@ -55,7 +55,7 @@ export function ContractorOnboardingForm({
     if (contractorOnboardingBag.employmentId) {
       contractorOnboardingBag?.checkFieldUpdates(form.getValues());
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSubmit = async (

--- a/src/flows/CostCalculator/CostCalculatorFlow.tsx
+++ b/src/flows/CostCalculator/CostCalculatorFlow.tsx
@@ -203,7 +203,7 @@ export const CostCalculatorFlow = ({
       const currencyCode = currencyData?.label;
       if (currencyCode) {
         // WE NEED TO FIX: react-hooks/set-state-in-effect - Calling setState synchronously within an effect can trigger cascading renders
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+        // oxlint-disable-next-line react-hooks/set-state-in-effect
         setCurrency(currencyCode as CurrencyKey);
         const defaultManagementFee = getDefaultManagementFee(
           BASE_RATES,

--- a/src/flows/CostCalculator/README.md
+++ b/src/flows/CostCalculator/README.md
@@ -337,7 +337,7 @@ function CostCalculatorFormDemo() {
         onSuccess: (response) => {
           if (response?.data?.data?.content !== undefined) {
             const a = document.createElement('a');
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
             a.href = response.data.data.content as any;
             a.download = 'estimation.pdf';
             document.body.appendChild(a);
@@ -445,7 +445,7 @@ function CostCalculatorFormDemo() {
         onSuccess: (response) => {
           if (response?.data?.data?.content !== undefined) {
             const a = document.createElement('a');
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
             a.href = response.data.data.content as any;
             a.download = 'estimation.pdf';
             document.body.appendChild(a);

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -504,7 +504,7 @@ export const useCostCalculator = (
   }
 
   // WE NEED TO FIX: react-hooks/refs - Cannot access ref value during render
-  // eslint-disable-next-line react-hooks/refs
+  // oxlint-disable-next-line react-hooks/refs
   return {
     /**
      * Current step state containing the current step and total number of steps
@@ -613,10 +613,10 @@ export const useCostCalculator = (
      * Fields metadata
      */
     // WE NEED TO FIX: react-hooks/refs - Cannot access ref value during render
-    // eslint-disable-next-line react-hooks/refs
+    // oxlint-disable-next-line react-hooks/refs
     meta: {
       // WE NEED TO FIX: react-hooks/refs - Cannot access ref value during render
-      // eslint-disable-next-line react-hooks/refs
+      // oxlint-disable-next-line react-hooks/refs
       fields: fieldsMetaRef.current?.fields,
     },
   };

--- a/src/flows/CreateCompany/components/CreateCompanyForm.tsx
+++ b/src/flows/CreateCompany/components/CreateCompanyForm.tsx
@@ -44,7 +44,7 @@ export function CreateCompanyForm({
       }
     });
     return () => subscription?.unsubscribe();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSubmit = async (values: Record<string, unknown>) => {

--- a/src/flows/CreateCompany/hooks.ts
+++ b/src/flows/CreateCompany/hooks.ts
@@ -380,7 +380,7 @@ export const useCreateCompany = ({
      */
     meta: {
       // WE NEED TO FIX: react-hooks/refs - Cannot access ref value during render
-      // eslint-disable-next-line react-hooks/refs
+      // oxlint-disable-next-line react-hooks/refs
       fields: fieldsMetaRef.current,
       fieldsets: stepFieldsWithFlatFieldsets[stepState.currentStep.name],
     },

--- a/src/flows/Onboarding/components/OnboardingForm.tsx
+++ b/src/flows/Onboarding/components/OnboardingForm.tsx
@@ -45,7 +45,7 @@ export function OnboardingForm({
     if (onboardingBag.employmentId) {
       onboardingBag?.checkFieldUpdates(form.getValues());
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSubmit = async (

--- a/src/flows/useStepState.ts
+++ b/src/flows/useStepState.ts
@@ -46,7 +46,7 @@ export const useStepState = <T extends string, Fields = FieldValues>(
   // when onStepChange/steps references change
   useEffect(() => {
     onStepChange?.(initialStep);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function nextStep() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable react-refresh/only-export-components */
 // TODO: we can remove this import in the next major version, we can import styles with import '@remoteoss/remote-flows/styles.css'
 import './styles/global.css';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-refresh/only-export-components */
+/* oxlint-disable react-refresh/only-export-components */
 // TODO: we can remove this import in the next major version, we can import styles with import '@remoteoss/remote-flows/styles.css'
 import './styles/global.css';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to swapping `eslint-disable` directives to `oxlint-disable` comments and updating internal coding guidelines, with no functional logic changes expected.
> 
> **Overview**
> Updates the repo to align with the new Rust-based tooling by replacing `eslint-disable-next-line` suppression comments with `oxlint-disable-next-line` across providers, hooks, flows, and docs (notably for React Hooks and `no-explicit-any` rules).
> 
> Refreshes `.cursor/BUGBOT.md` to reference `oxfmt`/`oxlint` instead of Prettier/ESLint, and removes a top-level `react-refresh/only-export-components` eslint disable from `src/index.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1301f3a7e4243049f3782968820dd270fa9968bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->