### PR TITLE
fix(contractor-onboarding) - add card when a subscription is missing

### DIFF
--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -419,10 +419,12 @@ export const useContractorSubscriptionSchemaField = (
 
   const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
 
+  const EXPECTED_SUBSCRIPTION_COUNT = 3;
+
   const isASubscriptionMissing =
     contractorSubscriptions != null &&
     contractorSubscriptions.length > 0 &&
-    contractorSubscriptions.length < 3;
+    contractorSubscriptions.length < EXPECTED_SUBSCRIPTION_COUNT;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -419,7 +419,10 @@ export const useContractorSubscriptionSchemaField = (
 
   const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
 
-  const isASubscriptionMissing = (contractorSubscriptions?.length ?? 0) < 3;
+  const isASubscriptionMissing =
+    contractorSubscriptions != null &&
+    contractorSubscriptions.length > 0 &&
+    contractorSubscriptions.length < 3;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -437,9 +437,12 @@ export const useContractorSubscriptionSchemaField = (
       );
     }) ?? [];
 
+  const MAXIMUM_SUBSCRIPTIONS_COUNT = 3;
   // For each country, the number can vary
   const MAXIMUM_SUBSCRIPTIONS_BY_COUNTRY =
-    expectedSubscriptionsForCountry.length;
+    expectedSubscriptionsForCountry.length === 0
+      ? MAXIMUM_SUBSCRIPTIONS_COUNT
+      : expectedSubscriptionsForCountry.length;
 
   const isASubscriptionMissing =
     actualSubscriptions.length > 0 &&

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -469,70 +469,68 @@ export const useContractorSubscriptionSchemaField = (
     options,
   );
 
-  if (actualSubscriptions) {
-    const field: JSFField | undefined = form.fields.find(
-      (field) => field.name === 'subscription',
-    ) as JSFField | undefined;
+  const field: JSFField | undefined = form.fields.find(
+    (field) => field.name === 'subscription',
+  ) as JSFField | undefined;
 
-    if (field) {
-      // Start with contractor management options
-      const contractorOptions = actualSubscriptions.map((opts) => {
-        const product = opts.product;
-        const price = opts.price.amount;
-        const currencyCode = opts.currency.code;
-        const title =
-          CONTRACT_PRODUCT_TITLES[
-            product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
-          ] ?? '';
-        const label = title;
-        const value = product.identifier ?? '';
-        const description = product.description ?? '';
-        const features = product.features ?? [];
-        const meta = {
-          features,
-          price: {
-            amount: convertFromCents(price),
-            currencyCode: currencyCode,
+  if (field) {
+    // Start with contractor management options
+    const contractorOptions = actualSubscriptions.map((opts) => {
+      const product = opts.product;
+      const price = opts.price.amount;
+      const currencyCode = opts.currency.code;
+      const title =
+        CONTRACT_PRODUCT_TITLES[
+          product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
+        ] ?? '';
+      const label = title;
+      const value = product.identifier ?? '';
+      const description = product.description ?? '';
+      const features = product.features ?? [];
+      const meta = {
+        features,
+        price: {
+          amount: convertFromCents(price),
+          currencyCode: currencyCode,
+        },
+      };
+      return {
+        label,
+        value,
+        description,
+        meta,
+        disabled:
+          isEligibilityQuestionnaireBlocked &&
+          product.identifier !== contractorStandardProductIdentifier,
+      };
+    });
+
+    // Sort contractor options
+    contractorOptions.sort((a, b) => a.label.localeCompare(b.label));
+
+    // Build otherSubscriptions (EOR) with separator metadata
+    const otherOptions: $TSFixMe[] = [];
+    if (showEorSubscription) {
+      addEorToFieldOptions(
+        otherOptions as unknown as $TSFixMe[],
+        eorSubscription,
+        options?.excludeProducts,
+      );
+
+      // Add separator metadata to first "other" option
+      // only the first option to avoid problems when iterating over the options
+      if (otherOptions.length > 0) {
+        otherOptions[0].meta = {
+          ...otherOptions[0].meta,
+          groupSeparator: {
+            show: true,
           },
         };
-        return {
-          label,
-          value,
-          description,
-          meta,
-          disabled:
-            isEligibilityQuestionnaireBlocked &&
-            product.identifier !== contractorStandardProductIdentifier,
-        };
-      });
-
-      // Sort contractor options
-      contractorOptions.sort((a, b) => a.label.localeCompare(b.label));
-
-      // Build otherSubscriptions (EOR) with separator metadata
-      const otherOptions: $TSFixMe[] = [];
-      if (showEorSubscription) {
-        addEorToFieldOptions(
-          otherOptions as unknown as $TSFixMe[],
-          eorSubscription,
-          options?.excludeProducts,
-        );
-
-        // Add separator metadata to first "other" option
-        // only the first option to avoid problems when iterating over the options
-        if (otherOptions.length > 0) {
-          otherOptions[0].meta = {
-            ...otherOptions[0].meta,
-            groupSeparator: {
-              show: true,
-            },
-          };
-        }
       }
-
-      // Combine all options into the single field
-      field.options = [...contractorOptions, ...otherOptions];
     }
+
+    // Combine all options into the single field
+    field.options = [...contractorOptions, ...otherOptions];
   }
 
   return {

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -50,7 +50,10 @@ import {
 import { convertFromCents } from '@/src/components/form/utils';
 import { countriesOptions } from '@/src/common/api/countries';
 import { selectCountryStepSchema } from '@/src/flows/Onboarding/json-schemas/selectCountryStep';
-import { shouldIncludeProduct } from '@/src/flows/ContractorOnboarding/utils';
+import {
+  shouldIncludeProduct,
+  shouldIncludeProductByShortName,
+} from '@/src/flows/ContractorOnboarding/utils';
 import { useCompanyPricingPlans } from '@/src/common/api/companies';
 
 const useContractorCurrencies = ({
@@ -427,9 +430,12 @@ export const useContractorSubscriptionSchemaField = (
     ) ?? [];
 
   const expectedSubscriptionsForCountry =
-    selectedCountry?.contractor_products_available?.filter((productId) =>
-      shouldIncludeProduct(productId, options?.excludeProducts),
-    ) ?? [];
+    selectedCountry?.contractor_products_available?.filter((productId) => {
+      return shouldIncludeProductByShortName(
+        productId,
+        options?.excludeProducts,
+      );
+    }) ?? [];
 
   // For each country, the number can vary
   const MAXIMUM_SUBSCRIPTIONS_BY_COUNTRY =

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -419,8 +419,7 @@ export const useContractorSubscriptionSchemaField = (
 
   const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
 
-  const isASubscriptionMissing =
-    contractorSubscriptions?.length && contractorSubscriptions.length < 3;
+  const isASubscriptionMissing = (contractorSubscriptions?.length ?? 0) < 3;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -418,13 +418,26 @@ export const useContractorSubscriptionSchemaField = (
   });
 
   const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
-  // Maximum subscriptions allowed is 3 (COR, Standard, Plus)
-  const EXPECTED_SUBSCRIPTION_COUNT = 3;
+  const actualSubscriptions =
+    contractorSubscriptions?.filter((sub) =>
+      shouldIncludeProduct(
+        sub.product.identifier ?? '',
+        options?.excludeProducts,
+      ),
+    ) ?? [];
+
+  const expectedSubscriptionsForCountry =
+    selectedCountry?.contractor_products_available?.filter((productId) =>
+      shouldIncludeProduct(productId, options?.excludeProducts),
+    ) ?? [];
+
+  // For each country, the number can vary
+  const MAXIMUM_SUBSCRIPTIONS_BY_COUNTRY =
+    expectedSubscriptionsForCountry.length;
 
   const isASubscriptionMissing =
-    contractorSubscriptions != null &&
-    contractorSubscriptions.length > 0 &&
-    contractorSubscriptions.length < EXPECTED_SUBSCRIPTION_COUNT;
+    actualSubscriptions.length > 0 &&
+    actualSubscriptions.length < MAXIMUM_SUBSCRIPTIONS_BY_COUNTRY;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',
@@ -450,49 +463,42 @@ export const useContractorSubscriptionSchemaField = (
     options,
   );
 
-  if (contractorSubscriptions) {
+  if (actualSubscriptions) {
     const field: JSFField | undefined = form.fields.find(
       (field) => field.name === 'subscription',
     ) as JSFField | undefined;
 
     if (field) {
       // Start with contractor management options
-      const contractorOptions = contractorSubscriptions
-        .filter((opts) =>
-          shouldIncludeProduct(
-            opts.product.identifier ?? '',
-            options?.excludeProducts,
-          ),
-        )
-        .map((opts) => {
-          const product = opts.product;
-          const price = opts.price.amount;
-          const currencyCode = opts.currency.code;
-          const title =
-            CONTRACT_PRODUCT_TITLES[
-              product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
-            ] ?? '';
-          const label = title;
-          const value = product.identifier ?? '';
-          const description = product.description ?? '';
-          const features = product.features ?? [];
-          const meta = {
-            features,
-            price: {
-              amount: convertFromCents(price),
-              currencyCode: currencyCode,
-            },
-          };
-          return {
-            label,
-            value,
-            description,
-            meta,
-            disabled:
-              isEligibilityQuestionnaireBlocked &&
-              product.identifier !== contractorStandardProductIdentifier,
-          };
-        });
+      const contractorOptions = actualSubscriptions.map((opts) => {
+        const product = opts.product;
+        const price = opts.price.amount;
+        const currencyCode = opts.currency.code;
+        const title =
+          CONTRACT_PRODUCT_TITLES[
+            product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
+          ] ?? '';
+        const label = title;
+        const value = product.identifier ?? '';
+        const description = product.description ?? '';
+        const features = product.features ?? [];
+        const meta = {
+          features,
+          price: {
+            amount: convertFromCents(price),
+            currencyCode: currencyCode,
+          },
+        };
+        return {
+          label,
+          value,
+          description,
+          meta,
+          disabled:
+            isEligibilityQuestionnaireBlocked &&
+            product.identifier !== contractorStandardProductIdentifier,
+        };
+      });
 
       // Sort contractor options
       contractorOptions.sort((a, b) => a.label.localeCompare(b.label));

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -408,7 +408,7 @@ export const useContractorSubscriptionSchemaField = (
 ) => {
   const {
     data: contractorSubscriptions,
-    isLoading: isLoading,
+    isLoading,
     refetch,
   } = useGetContractorSubscriptions({
     employmentId: employmentId,
@@ -419,7 +419,8 @@ export const useContractorSubscriptionSchemaField = (
 
   const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
 
-  const isSingleSubscription = contractorSubscriptions?.length === 1;
+  const isASubscriptionMissing =
+    contractorSubscriptions?.length && contractorSubscriptions.length < 3;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',
@@ -429,7 +430,7 @@ export const useContractorSubscriptionSchemaField = (
     corSubscription?.eligibility_questionnaire?.is_blocking;
 
   const showEorSubscription =
-    (isSingleSubscription ||
+    (isASubscriptionMissing ||
       isEligibilityQuestionnaireBlocked === true ||
       isEmptyContractorSubscriptions) &&
     selectedCountry?.eor_onboarding;

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -418,7 +418,7 @@ export const useContractorSubscriptionSchemaField = (
   });
 
   const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
-
+  // Maximum subscriptions allowed is 3 (COR, Standard, Plus)
   const EXPECTED_SUBSCRIPTION_COUNT = 3;
 
   const isASubscriptionMissing =

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -2426,6 +2426,7 @@ describe('ContractorOnboardingFlow', () => {
                 code: 'PRT',
                 name: 'Portugal',
                 eor_onboarding: true,
+                contractor_products_available: ['standard', 'plus', 'cor'],
               },
             ],
           });

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -156,6 +156,12 @@ const SHORT_NAME_TO_IDENTIFIER_MAP: Record<string, string> = {
   cor: corProductIdentifier,
 };
 
+/**
+ * Checks if a product should be included based on the short name
+ * @param shortName - The short name of the product that comes from the v1/countries endpoint
+ * @param excludeProducts - Array of products to exclude
+ * @returns true if the product should be included, false otherwise
+ */
 export const shouldIncludeProductByShortName = (
   shortName: string,
   excludeProducts?: ProductType[],

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -6,6 +6,7 @@ import {
   PRODUCT_IDENTIFIER_MAP,
   REMOTE_AI_SERVICES_AND_DELIVERABLES_ERROR_MESSAGE,
   REMOTE_AI_SERVICES_AND_DELIVERABLES_COR_ERROR_MESSAGE,
+  corProductIdentifier,
 } from '@/src/flows/ContractorOnboarding/constants';
 import { Employment } from '@/src/flows/Onboarding/types';
 
@@ -147,6 +148,20 @@ export const shouldIncludeProduct = (
   return !excludeProducts.some(
     (excluded) => PRODUCT_IDENTIFIER_MAP[excluded] === productIdentifier,
   );
+};
+
+const SHORT_NAME_TO_IDENTIFIER_MAP: Record<string, string> = {
+  standard: contractorStandardProductIdentifier,
+  plus: contractorPlusProductIdentifier,
+  cor: corProductIdentifier,
+};
+
+export const shouldIncludeProductByShortName = (
+  shortName: string,
+  excludeProducts?: ProductType[],
+): boolean => {
+  const identifier = SHORT_NAME_TO_IDENTIFIER_MAP[shortName];
+  return shouldIncludeProduct(identifier, excludeProducts);
 };
 
 /**


### PR DESCRIPTION
## Problem

We were only showing the EOR card when contractorSubscriptions was one

## Solution

When a subscription is missing, we show the EOR card


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the pricing plan option-building logic to infer when expected contractor subscriptions are missing, which can alter which products are shown and when EOR pricing data is fetched. Risk is moderate due to potential impact on onboarding conversion and plan selection behavior across countries/exclusion configs.
> 
> **Overview**
> Updates the contractor onboarding Pricing Plan step to show the **Employer of Record (EOR)** option not only when subscriptions are empty/blocked, but also when the backend returns an incomplete set of expected contractor subscriptions for the selected country.
> 
> Adds `shouldIncludeProductByShortName` to map `v1/countries.contractor_products_available` short names to product identifiers (respecting `excludeProducts`), and uses this to compute whether a subscription is “missing” before appending the EOR option. Tests are updated to include `contractor_products_available` in the mocked country response for the EOR visibility scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c074722aee5f6612cce9f5ee7d25d5fd191c094d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->