### PR TITLE
fix(contractor-onboarding) - fix eor card appear when subscriptions returned by BE less than 3

### DIFF
--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -408,7 +408,7 @@ export const useContractorSubscriptionSchemaField = (
 ) => {
   const {
     data: contractorSubscriptions,
-    isLoading: isLoading,
+    isLoading,
     refetch,
   } = useGetContractorSubscriptions({
     employmentId: employmentId,
@@ -417,9 +417,23 @@ export const useContractorSubscriptionSchemaField = (
     },
   });
 
-  const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
+  const filteredContractorSubscriptions = useMemo(
+    () =>
+      contractorSubscriptions?.filter((subscription) =>
+        shouldIncludeProduct(
+          subscription.product.identifier ?? '',
+          options?.excludeProducts,
+        ),
+      ) ?? [],
+    [contractorSubscriptions, options?.excludeProducts],
+  );
 
-  const isSingleSubscription = contractorSubscriptions?.length === 1;
+  // maximum number of subscriptions
+  const MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT = 3;
+
+  const isMissingSubscriptions = contractorSubscriptions
+    ? contractorSubscriptions?.length < MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
+    : false;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',
@@ -429,10 +443,9 @@ export const useContractorSubscriptionSchemaField = (
     corSubscription?.eligibility_questionnaire?.is_blocking;
 
   const showEorSubscription =
-    (isSingleSubscription ||
-      isEligibilityQuestionnaireBlocked === true ||
-      isEmptyContractorSubscriptions) &&
-    selectedCountry?.eor_onboarding;
+    (isMissingSubscriptions || isEligibilityQuestionnaireBlocked) &&
+    selectedCountry?.eor_onboarding &&
+    !options?.excludeProducts?.includes('eor');
 
   const { eorSubscription, isLoading: isLoadingEorSubscription } =
     useEorSubscription({
@@ -445,83 +458,75 @@ export const useContractorSubscriptionSchemaField = (
     options,
   );
 
-  if (contractorSubscriptions) {
-    const field: JSFField | undefined = form.fields.find(
-      (field) => field.name === 'subscription',
-    ) as JSFField | undefined;
+  const field: JSFField | undefined = form.fields.find(
+    (field) => field.name === 'subscription',
+  ) as JSFField | undefined;
 
-    if (field) {
-      // Start with contractor management options
-      const contractorOptions = contractorSubscriptions
-        .filter((opts) =>
-          shouldIncludeProduct(
-            opts.product.identifier ?? '',
-            options?.excludeProducts,
-          ),
-        )
-        .map((opts) => {
-          const product = opts.product;
-          const price = opts.price.amount;
-          const currencyCode = opts.currency.code;
-          const title =
-            CONTRACT_PRODUCT_TITLES[
-              product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
-            ] ?? '';
-          const label = title;
-          const value = product.identifier ?? '';
-          const description = product.description ?? '';
-          const features = product.features ?? [];
-          const meta = {
-            features,
-            price: {
-              amount: convertFromCents(price),
-              currencyCode: currencyCode,
-            },
-          };
-          return {
-            label,
-            value,
-            description,
-            meta,
-            disabled:
-              isEligibilityQuestionnaireBlocked &&
-              product.identifier !== contractorStandardProductIdentifier,
-          };
-        });
+  if (field) {
+    // Start with contractor management options
+    const contractorOptions = filteredContractorSubscriptions.map((opts) => {
+      const product = opts.product;
+      const price = opts.price.amount;
+      const currencyCode = opts.currency.code;
+      const title =
+        CONTRACT_PRODUCT_TITLES[
+          product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
+        ] ?? '';
+      const label = title;
+      const value = product.identifier ?? '';
+      const description = product.description ?? '';
+      const features = product.features ?? [];
+      const meta = {
+        features,
+        price: {
+          amount: convertFromCents(price),
+          currencyCode: currencyCode,
+        },
+      };
+      return {
+        label,
+        value,
+        description,
+        meta,
+        disabled:
+          isEligibilityQuestionnaireBlocked &&
+          product.identifier !== contractorStandardProductIdentifier,
+      };
+    });
 
-      // Sort contractor options
-      contractorOptions.sort((a, b) => a.label.localeCompare(b.label));
+    // Sort contractor options
+    contractorOptions.sort((a, b) => a.label.localeCompare(b.label));
 
-      // Build otherSubscriptions (EOR) with separator metadata
-      const otherOptions: $TSFixMe[] = [];
-      if (showEorSubscription) {
-        addEorToFieldOptions(
-          otherOptions as unknown as $TSFixMe[],
-          eorSubscription,
-          options?.excludeProducts,
-        );
+    // Build otherSubscriptions (EOR) with separator metadata
+    const otherOptions: $TSFixMe[] = [];
+    if (showEorSubscription) {
+      addEorToFieldOptions(
+        otherOptions as unknown as $TSFixMe[],
+        eorSubscription,
+        options?.excludeProducts,
+      );
 
-        // Add separator metadata to first "other" option
-        // only the first option to avoid problems when iterating over the options
-        if (otherOptions.length > 0) {
-          otherOptions[0].meta = {
-            ...otherOptions[0].meta,
-            groupSeparator: {
-              show: true,
-            },
-          };
-        }
+      // Add separator metadata to first "other" option
+      // only the first option to avoid problems when iterating over the options
+      if (otherOptions.length > 0) {
+        otherOptions[0].meta = {
+          ...otherOptions[0].meta,
+          groupSeparator: {
+            show: true,
+          },
+        };
       }
-
-      // Combine all options into the single field
-      field.options = [...contractorOptions, ...otherOptions];
     }
+
+    // Combine all options into the single field
+    field.options = [...contractorOptions, ...otherOptions];
   }
 
   return {
     isLoading: isLoading || isLoadingEorSubscription,
     form,
     contractorSubscriptions,
+    filteredContractorSubscriptions,
     refetch,
     isEligibilityQuestionnaireBlocked,
   };

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -431,9 +431,8 @@ export const useContractorSubscriptionSchemaField = (
   // maximum number of subscriptions
   const MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT = 3;
 
-  const isMissingSubscriptions = filteredContractorSubscriptions
-    ? filteredContractorSubscriptions?.length <
-      MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
+  const isMissingSubscriptions = contractorSubscriptions
+    ? contractorSubscriptions?.length < MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
     : false;
 
   const corSubscription = contractorSubscriptions?.find(

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -431,8 +431,9 @@ export const useContractorSubscriptionSchemaField = (
   // maximum number of subscriptions
   const MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT = 3;
 
-  const isMissingSubscriptions = contractorSubscriptions
-    ? contractorSubscriptions?.length < MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
+  const isMissingSubscriptions = filteredContractorSubscriptions
+    ? filteredContractorSubscriptions?.length <
+      MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
     : false;
 
   const corSubscription = contractorSubscriptions?.find(


### PR DESCRIPTION
When the subscriptions is less than 3 hardcoded yes. we make the contractor onboarding card to appear 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the decision logic that controls which subscription options (including EOR) are shown during contractor onboarding, which can affect user plan selection and downstream onboarding flow. Risk is limited to UI/business logic with no auth or data model changes.
> 
> **Overview**
> Fixes the contractor onboarding pricing-plan step so the `subscription` field options are built from a memoized, consistently filtered subscription list and returned as `filteredContractorSubscriptions`.
> 
> Updates the EOR option visibility logic to key off a “missing subscriptions” threshold (max 3) and eligibility-questionnaire blocking, and explicitly suppresses EOR when `excludeProducts` includes `eor`, while keeping the option grouping/separator behavior intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cdaa34f9c6bc195f3a5b49a91baeae9c5018173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->