### PR TITLE
fix(contractor-onboarding) - handle empty contractor subscriptions

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -64,7 +64,18 @@ const PricingPlanCards = ({
   const hasError = !!fieldState.error;
 
   // Group options by separator
-  const groups = groupOptionsBySeparator(fieldData.options);
+  const groups =
+    fieldData.options.length > 0
+      ? groupOptionsBySeparator(fieldData.options)
+      : [];
+
+  if (groups.length === 0) {
+    return (
+      <div className='flex flex-col gap-6 text-center'>
+        <p>No available subscriptions</p>
+      </div>
+    );
+  }
 
   return (
     <div className='flex flex-col gap-6'>
@@ -540,6 +551,7 @@ export const ContractorOnboardingWithProps = ({
               // excludeProducts: ['eor'] // Hide EOR option
               // excludeProducts: ['eor', 'cor'] // Hide both EOR and COR
               // excludeProducts: ['cm+'] // Hide Contractor Management Plus
+              excludeProducts: ['eor', 'cor', 'cm+', 'cm'], // Hide all products
               jsfModify: {
                 contract_details: {
                   fields: {

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -551,7 +551,7 @@ export const ContractorOnboardingWithProps = ({
               // excludeProducts: ['eor'] // Hide EOR option
               // excludeProducts: ['eor', 'cor'] // Hide both EOR and COR
               // excludeProducts: ['cm+'] // Hide Contractor Management Plus
-              excludeProducts: ['eor', 'cor', 'cm+', 'cm'], // Hide all products
+              //excludeProducts: ['eor', 'cor', 'cm+', 'cm'], // Hide all products
               jsfModify: {
                 contract_details: {
                   fields: {

--- a/src/common/createHeadlessForm.tsx
+++ b/src/common/createHeadlessForm.tsx
@@ -29,10 +29,17 @@ export const createHeadlessForm = (
     jsfSchema = schema;
 
     if (required) {
-      jsfSchema.required = [
-        ...(Array.isArray(schema.required) ? schema.required : []),
-        ...required,
-      ];
+      const baseRequired = Array.isArray(schema.required)
+        ? schema.required
+        : [];
+
+      if (typeof required === 'function') {
+        // Function: allows full control over required fields
+        jsfSchema.required = required(baseRequired);
+      } else {
+        // Array: merge with existing required fields (backwards compatible)
+        jsfSchema.required = [...baseRequired, ...required];
+      }
     }
 
     if (allOf) {

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -452,10 +452,25 @@ export const useContractorSubscriptionSchemaField = (
       enabled: showEorSubscription,
     });
 
+  const hasAvailableOptions =
+    filteredContractorSubscriptions.length > 0 || showEorSubscription;
+
   const form = createHeadlessForm(
     selectContractorSubscriptionStepSchema.data.schema,
     {},
-    options,
+    {
+      ...options,
+      jsfModify: {
+        ...options?.jsfModify,
+        // If no filtered subscriptions are available, make the subscription field optional
+        required: hasAvailableOptions
+          ? options?.jsfModify?.required
+          : (existingRequired: string[]) =>
+              existingRequired.filter(
+                (fieldName: string) => fieldName !== 'subscription',
+              ),
+      },
+    },
   );
 
   const field: JSFField | undefined = form.fields.find(

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -408,7 +408,7 @@ export const useContractorSubscriptionSchemaField = (
 ) => {
   const {
     data: contractorSubscriptions,
-    isLoading: isLoading,
+    isLoading,
     refetch,
   } = useGetContractorSubscriptions({
     employmentId: employmentId,
@@ -417,9 +417,23 @@ export const useContractorSubscriptionSchemaField = (
     },
   });
 
-  const isEmptyContractorSubscriptions = contractorSubscriptions?.length === 0;
+  const filteredContractorSubscriptions = useMemo(
+    () =>
+      contractorSubscriptions?.filter((subscription) =>
+        shouldIncludeProduct(
+          subscription.product.identifier ?? '',
+          options?.excludeProducts,
+        ),
+      ) ?? [],
+    [contractorSubscriptions, options?.excludeProducts],
+  );
 
-  const isSingleSubscription = contractorSubscriptions?.length === 1;
+  // maximum number of subscriptions
+  const MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT = 3;
+
+  const isMissingSubscriptions = contractorSubscriptions
+    ? contractorSubscriptions?.length < MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
+    : false;
 
   const corSubscription = contractorSubscriptions?.find(
     (subscription) => subscription.product.short_name === 'COR',
@@ -429,10 +443,9 @@ export const useContractorSubscriptionSchemaField = (
     corSubscription?.eligibility_questionnaire?.is_blocking;
 
   const showEorSubscription =
-    (isSingleSubscription ||
-      isEligibilityQuestionnaireBlocked === true ||
-      isEmptyContractorSubscriptions) &&
-    selectedCountry?.eor_onboarding;
+    (isMissingSubscriptions || isEligibilityQuestionnaireBlocked) &&
+    selectedCountry?.eor_onboarding &&
+    !options?.excludeProducts?.includes('eor');
 
   const { eorSubscription, isLoading: isLoadingEorSubscription } =
     useEorSubscription({
@@ -445,83 +458,75 @@ export const useContractorSubscriptionSchemaField = (
     options,
   );
 
-  if (contractorSubscriptions) {
-    const field: JSFField | undefined = form.fields.find(
-      (field) => field.name === 'subscription',
-    ) as JSFField | undefined;
+  const field: JSFField | undefined = form.fields.find(
+    (field) => field.name === 'subscription',
+  ) as JSFField | undefined;
 
-    if (field) {
-      // Start with contractor management options
-      const contractorOptions = contractorSubscriptions
-        .filter((opts) =>
-          shouldIncludeProduct(
-            opts.product.identifier ?? '',
-            options?.excludeProducts,
-          ),
-        )
-        .map((opts) => {
-          const product = opts.product;
-          const price = opts.price.amount;
-          const currencyCode = opts.currency.code;
-          const title =
-            CONTRACT_PRODUCT_TITLES[
-              product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
-            ] ?? '';
-          const label = title;
-          const value = product.identifier ?? '';
-          const description = product.description ?? '';
-          const features = product.features ?? [];
-          const meta = {
-            features,
-            price: {
-              amount: convertFromCents(price),
-              currencyCode: currencyCode,
-            },
-          };
-          return {
-            label,
-            value,
-            description,
-            meta,
-            disabled:
-              isEligibilityQuestionnaireBlocked &&
-              product.identifier !== contractorStandardProductIdentifier,
-          };
-        });
+  if (field) {
+    // Start with contractor management options
+    const contractorOptions = filteredContractorSubscriptions.map((opts) => {
+      const product = opts.product;
+      const price = opts.price.amount;
+      const currencyCode = opts.currency.code;
+      const title =
+        CONTRACT_PRODUCT_TITLES[
+          product.identifier as keyof typeof CONTRACT_PRODUCT_TITLES
+        ] ?? '';
+      const label = title;
+      const value = product.identifier ?? '';
+      const description = product.description ?? '';
+      const features = product.features ?? [];
+      const meta = {
+        features,
+        price: {
+          amount: convertFromCents(price),
+          currencyCode: currencyCode,
+        },
+      };
+      return {
+        label,
+        value,
+        description,
+        meta,
+        disabled:
+          isEligibilityQuestionnaireBlocked &&
+          product.identifier !== contractorStandardProductIdentifier,
+      };
+    });
 
-      // Sort contractor options
-      contractorOptions.sort((a, b) => a.label.localeCompare(b.label));
+    // Sort contractor options
+    contractorOptions.sort((a, b) => a.label.localeCompare(b.label));
 
-      // Build otherSubscriptions (EOR) with separator metadata
-      const otherOptions: $TSFixMe[] = [];
-      if (showEorSubscription) {
-        addEorToFieldOptions(
-          otherOptions as unknown as $TSFixMe[],
-          eorSubscription,
-          options?.excludeProducts,
-        );
+    // Build otherSubscriptions (EOR) with separator metadata
+    const otherOptions: $TSFixMe[] = [];
+    if (showEorSubscription) {
+      addEorToFieldOptions(
+        otherOptions as unknown as $TSFixMe[],
+        eorSubscription,
+        options?.excludeProducts,
+      );
 
-        // Add separator metadata to first "other" option
-        // only the first option to avoid problems when iterating over the options
-        if (otherOptions.length > 0) {
-          otherOptions[0].meta = {
-            ...otherOptions[0].meta,
-            groupSeparator: {
-              show: true,
-            },
-          };
-        }
+      // Add separator metadata to first "other" option
+      // only the first option to avoid problems when iterating over the options
+      if (otherOptions.length > 0) {
+        otherOptions[0].meta = {
+          ...otherOptions[0].meta,
+          groupSeparator: {
+            show: true,
+          },
+        };
       }
-
-      // Combine all options into the single field
-      field.options = [...contractorOptions, ...otherOptions];
     }
+
+    // Combine all options into the single field
+    field.options = [...contractorOptions, ...otherOptions];
   }
 
   return {
     isLoading: isLoading || isLoadingEorSubscription,
     form,
     contractorSubscriptions,
+    filteredContractorSubscriptions,
     refetch,
     isEligibilityQuestionnaireBlocked,
   };

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -431,9 +431,8 @@ export const useContractorSubscriptionSchemaField = (
   // maximum number of subscriptions
   const MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT = 3;
 
-  const isMissingSubscriptions = filteredContractorSubscriptions
-    ? filteredContractorSubscriptions?.length <
-      MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
+  const isMissingSubscriptions = contractorSubscriptions
+    ? contractorSubscriptions?.length < MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
     : false;
 
   const corSubscription = contractorSubscriptions?.find(

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -431,8 +431,9 @@ export const useContractorSubscriptionSchemaField = (
   // maximum number of subscriptions
   const MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT = 3;
 
-  const isMissingSubscriptions = contractorSubscriptions
-    ? contractorSubscriptions?.length < MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
+  const isMissingSubscriptions = filteredContractorSubscriptions
+    ? filteredContractorSubscriptions?.length <
+      MAXIMUM_CONTRACTOR_SUBSCRIPTIONS_COUNT
     : false;
 
   const corSubscription = contractorSubscriptions?.find(

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -281,6 +281,7 @@ export const useContractorOnboarding = ({
     form: selectContractorSubscriptionForm,
     isLoading: isLoadingContractorSubscriptions,
     contractorSubscriptions,
+    filteredContractorSubscriptions,
     refetch: refetchContractorSubscriptions,
     isEligibilityQuestionnaireBlocked,
   } = useContractorSubscriptionSchemaField(
@@ -474,6 +475,15 @@ export const useContractorOnboarding = ({
       hasEligibilityQuestionnaireSubmitted
     ) {
       return contractorStandardProductIdentifier;
+    }
+
+    // Fifth: If there are no available subscriptions, return undefined
+    const hasAvailableSubscriptions =
+      filteredContractorSubscriptions &&
+      filteredContractorSubscriptions.length > 0;
+
+    if (!hasAvailableSubscriptions) {
+      return undefined;
     }
 
     // FALLBACK: Employment contractor_type or default
@@ -1115,6 +1125,26 @@ export const useContractorOnboarding = ({
         return response;
       }
       case 'pricing_plan': {
+        if (values.subscription === eorProductIdentifier) {
+          // EOR selection - no API call needed at this step
+          return Promise.resolve({
+            data: {
+              subscription: values.subscription,
+            },
+          });
+        }
+        // If there are no available contractor subscriptions, throw an error
+        if (filteredContractorSubscriptions.length === 0) {
+          throw createStructuredError('No available subscriptions.');
+        }
+
+        if (
+          !values.subscription &&
+          filteredContractorSubscriptions.length > 0
+        ) {
+          throw createStructuredError('Please select a subscription plan.');
+        }
+
         const blockedProductsEligibility = [
           corProductIdentifier,
           contractorPlusProductIdentifier,

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -498,6 +498,7 @@ export const useContractorOnboarding = ({
     hasEligibilityQuestionnaireSubmitted,
     employment?.contractor_type,
     isEligibilityQuestionnaireBlocked,
+    filteredContractorSubscriptions,
   ]);
 
   useEffect(() => {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1163,15 +1163,6 @@ export const useContractorOnboarding = ({
             }.`,
           );
         }
-        // Handle EOR selection (from merged options)
-        if (values.subscription === eorProductIdentifier) {
-          // EOR selection - no API call needed at this step
-          return Promise.resolve({
-            data: {
-              subscription: values.subscription,
-            },
-          });
-        }
 
         if (
           hasEligibilityQuestionnaireSubmitted &&

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -2201,6 +2201,76 @@ describe('ContractorOnboardingFlow', () => {
       expect(cmOption).toBeInTheDocument();
     });
 
+    it('should prevent progression when all products are excluded', async () => {
+      mockRender.mockImplementation(
+        createMockRenderImplementation(MultiStepFormWithoutCountry),
+      );
+
+      render(
+        <ContractorOnboardingFlow
+          countryCode='PRT'
+          skipSteps={['select_country']}
+          employmentId='test-employment-id'
+          options={{ excludeProducts: ['eor', 'cor', 'cm+', 'cm'] }}
+          {...defaultProps}
+        />,
+        { wrapper: TestProviders },
+      );
+
+      await screen.findByText(/Step: Basic Information/i);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Full name/i)).toBeInTheDocument();
+      });
+
+      await fillBasicInformation();
+
+      const nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Pricing Plan/i);
+
+      // Verify no subscription radio options are visible
+      const cmOption = screen.queryByRole('radio', {
+        name: /^Contractor Management$/,
+      });
+      const cmPlusOption = screen.queryByRole('radio', {
+        name: /Contractor Management Plus/i,
+      });
+      const corOption = screen.queryByRole('radio', {
+        name: /^Contractor of Record$/,
+      });
+      const eorOption = screen.queryByRole('radio', {
+        name: /Employer of Record/i,
+      });
+
+      expect(cmOption).not.toBeInTheDocument();
+      expect(cmPlusOption).not.toBeInTheDocument();
+      expect(corOption).not.toBeInTheDocument();
+      expect(eorOption).not.toBeInTheDocument();
+
+      // Try to submit with no selection
+      const submitButton = screen.getByText(/Next Step/i);
+      submitButton.click();
+
+      // Verify error callback was called
+      await waitFor(() => {
+        expect(mockOnError).toHaveBeenCalled();
+      });
+
+      // Verify we stay on pricing plan step (cannot progress)
+      await waitFor(() => {
+        expect(screen.getByText(/Step: Pricing Plan/i)).toBeInTheDocument();
+      });
+
+      // Verify we did NOT advance to subsequent steps
+      expect(
+        screen.queryByText(/Step: Eligibility Questionnaire/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Step: Contract Details/i),
+      ).not.toBeInTheDocument();
+    });
+
     it('should show all products when excludeProducts is not provided', async () => {
       mockRender.mockImplementation(
         createMockRenderImplementation(MultiStepFormWithoutCountry),

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -78,8 +78,10 @@ export type JSONSchemaFormType =
 export type JSFModify = ModifyConfig & {
   /**
    * allows to specify additional required fields for the form.
+   * Can be either an array of field names to add, or a function that receives
+   * the existing required fields and returns a new array.
    */
-  required?: string[];
+  required?: string[] | ((existingRequired: string[]) => string[]);
   /**
    * allows to specify additional allOf rules for the form.
    */


### PR DESCRIPTION
Handles empty contractor subscriptions and avoids letting people advance...

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches pricing-plan selection/validation and dynamically alters JSON-schema `required` behavior, which can affect onboarding progression and form validation flows. Changes are localized and covered by a new regression test, but mistakes could block users from continuing.
> 
> **Overview**
> Handles cases where contractor subscription options are empty after filtering/exclusions.
> 
> The pricing-plan UI now renders an explicit empty state ("No available subscriptions") when no options exist, and the contractor subscription schema builder conditionally removes `subscription` from `required` via a new `jsfModify.required` function capability.
> 
> On submission, the `pricing_plan` step now blocks progression with clearer errors when there are no available contractor subscriptions or when a selection is missing, and tests add coverage to ensure users cannot advance when all products are excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72cdc882ed6badf2d55ece735623267fcde88f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->