### PR TITLE
fix(saudi-arabia) - fix submission

### DIFF
--- a/src/flows/ContractorOnboarding/jsfModify.tsx
+++ b/src/flows/ContractorOnboarding/jsfModify.tsx
@@ -263,7 +263,7 @@ export const buildBasicInformationJsfModify = (
             title: 'Yes',
           },
           {
-            const: 'non-national',
+            const: 'non_national',
             description: descriptionNonNationalRadio,
             title: 'No',
           },


### PR DESCRIPTION
Discover that the `non_national` value was not accepted by the BE strange 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk single-field change, but it can affect form submissions/workflows that depend on the exact `nationality_status` value.
> 
> **Overview**
> Updates the contractor onboarding basic information schema so the `nationality_status` "No" option submits `non_national` instead of `non-national`, aligning the enum value with the expected backend/validation format (notably for Saudi Arabia-related flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 005b1d5624df9fc1b7991b6a8da8276d4dbc1229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->