### PR TITLE
1.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @remoteoss/remote-flows
 
+## 1.33.1
+
+### Patch Changes
+
+- migrate comments (#1008) [#1008](https://github.com/remoteoss/remote-flows/pull/1008)
+- remove stale files (#1007) [#1007](https://github.com/remoteoss/remote-flows/pull/1007)
+- handle not nested errors (#1012) [#1012](https://github.com/remoteoss/remote-flows/pull/1012)
+- fix submission (#1017) [#1017](https://github.com/remoteoss/remote-flows/pull/1017)
+- fix eor card appear when subscriptions returned by BE less than 3 (#1015) [#1015](https://github.com/remoteoss/remote-flows/pull/1015)
+
 ## 1.33.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - migrate to oxlint comments (#1008) [#1008](https://github.com/remoteoss/remote-flows/pull/1008)
 - remove stale prettier files (#1007) [#1007](https://github.com/remoteoss/remote-flows/pull/1007)
 
-
 ## 1.33.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@
 
 ### Patch Changes
 
-- migrate comments (#1008) [#1008](https://github.com/remoteoss/remote-flows/pull/1008)
-- remove stale files (#1007) [#1007](https://github.com/remoteoss/remote-flows/pull/1007)
+#### Fixes
+
 - handle not nested errors (#1012) [#1012](https://github.com/remoteoss/remote-flows/pull/1012)
-- fix submission (#1017) [#1017](https://github.com/remoteoss/remote-flows/pull/1017)
-- fix eor card appear when subscriptions returned by BE less than 3 (#1015) [#1015](https://github.com/remoteoss/remote-flows/pull/1015)
+- fix arabia saudi non-national submission (#1017) [#1017](https://github.com/remoteoss/remote-flows/pull/1017)
+- fix eor card appear when subscriptions returned by BE is less than 3 (#1015) [#1015](https://github.com/remoteoss/remote-flows/pull/1015)
+
+#### Chores
+
+- migrate to oxlint comments (#1008) [#1008](https://github.com/remoteoss/remote-flows/pull/1008)
+- remove stale prettier files (#1007) [#1007](https://github.com/remoteoss/remote-flows/pull/1007)
+
 
 ## 1.33.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.33.1

### Patch Changes

#### Fixes

- handle not nested errors (#1012) [#1012](https://github.com/remoteoss/remote-flows/pull/1012)
- fix arabia saudi non-national submission (#1017) [#1017](https://github.com/remoteoss/remote-flows/pull/1017)
- fix eor card appear when subscriptions returned by BE is less than 3 (#1015) [#1015](https://github.com/remoteoss/remote-flows/pull/1015)

#### Chores

- migrate to oxlint comments (#1008) [#1008](https://github.com/remoteoss/remote-flows/pull/1008)
- remove stale prettier files (#1007) [#1007](https://github.com/remoteoss/remote-flows/pull/1007)
---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates the package version and changelog without changing runtime code.
> 
> **Overview**
> Bumps the package from `1.33.0` to `1.33.1` in `package.json` and `package-lock.json`.
> 
> Updates `CHANGELOG.md` with the `1.33.1` patch release entry listing the included fixes and chores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19e480560dff0d1b5ca8a4f79db8e76ee36a159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->