### PR TITLE
chore(infra) - Add openapi-ts:local script for local API development

### DIFF
--- a/openapi-ts.config.local.ts
+++ b/openapi-ts.config.local.ts
@@ -1,0 +1,8 @@
+import { defineConfig, defaultPlugins } from '@hey-api/openapi-ts';
+
+export default defineConfig({
+  // Local gateway with new endpoints
+  input: 'http://localhost:4000/api/eor/openapi',
+  output: 'src/client',
+  plugins: defaultPlugins,
+});

--- a/openapi-ts.config.ts
+++ b/openapi-ts.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, defaultPlugins } from '@hey-api/openapi-ts';
 
 export default defineConfig({
+  // Production gateway - use npm run openapi-ts for production generation
+  // For local gateway with new endpoints, use npm run openapi-ts:local instead
   input: 'https://gateway.remote.com/v1/docs/openapi.json',
   output: 'src/client',
   plugins: defaultPlugins,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:workflows:fix": "zizmor --fix .github/workflows/",
     "format": "oxfmt",
     "openapi-ts": "openapi-ts && npm run format",
+    "openapi-ts:local": "openapi-ts -f openapi-ts.config.local.ts && tsx scripts/cleanup-local-openapi.ts && npm run format",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "coverage:extract": "tsx scripts/extract-coverage.ts",

--- a/scripts/cleanup-local-openapi.ts
+++ b/scripts/cleanup-local-openapi.ts
@@ -18,11 +18,8 @@ function cleanupApiEorPrefix() {
       let content = readFileSync(filePath, 'utf-8');
       const originalContent = content;
 
-      // Replace /api/eor/v1/ with /v1/
-      content = content.replace(/url: '\/api\/eor\/v1\//g, "url: '/v1/");
-
-      // Replace /api/eor/v2/ with /v2/
-      content = content.replace(/url: '\/api\/eor\/v2\//g, "url: '/v2/");
+      // Replace /api/eor/ prefix with / (handles v1/, v2/, auth/, and any other paths)
+      content = content.replace(/url: '\/api\/eor\//g, "url: '/");
 
       if (content !== originalContent) {
         writeFileSync(filePath, content, 'utf-8');

--- a/scripts/cleanup-local-openapi.ts
+++ b/scripts/cleanup-local-openapi.ts
@@ -1,0 +1,50 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Removes /api/eor prefix from generated OpenAPI client files
+ * This is needed when generating from local OpenAPI spec that includes the prefix
+ */
+function cleanupApiEorPrefix() {
+  const files = [
+    resolve(process.cwd(), 'src/client/sdk.gen.ts'),
+    resolve(process.cwd(), 'src/client/types.gen.ts'),
+  ];
+
+  let totalReplacements = 0;
+
+  for (const filePath of files) {
+    try {
+      let content = readFileSync(filePath, 'utf-8');
+      const originalContent = content;
+
+      // Replace /api/eor/v1/ with /v1/
+      content = content.replace(/url: '\/api\/eor\/v1\//g, "url: '/v1/");
+
+      // Replace /api/eor/v2/ with /v2/
+      content = content.replace(/url: '\/api\/eor\/v2\//g, "url: '/v2/");
+
+      if (content !== originalContent) {
+        writeFileSync(filePath, content, 'utf-8');
+        const fileName = filePath.split('/').pop();
+        const replacements = (originalContent.match(/\/api\/eor\//g) || [])
+          .length;
+        console.log(`✓ Cleaned ${replacements} URLs in ${fileName}`);
+        totalReplacements += replacements;
+      }
+    } catch (error) {
+      console.error(`Error processing ${filePath}:`, error);
+      process.exit(1);
+    }
+  }
+
+  if (totalReplacements > 0) {
+    console.log(
+      `\n✓ Successfully removed /api/eor prefix from ${totalReplacements} URLs`,
+    );
+  } else {
+    console.log('\n✓ No /api/eor prefixes found');
+  }
+}
+
+cleanupApiEorPrefix();


### PR DESCRIPTION
## Human Explanation

This script can help us any time we have to generate types / endpoints locally, this helps us to test BE branches faster

When generating types with this script, avoid merging it to the main branch, types / endpoints should be always generated from the openapi-ts script which generates from production


## Summary

This PR extracts the `openapi-ts:local` script and its dependencies from PR #1009 into a standalone change that can be reviewed and merged independently.

The new script allows developers to generate TypeScript client code from a local OpenAPI gateway instance, which is useful for testing new API endpoints before they're deployed to production.

## Changes

- **New script**: `npm run openapi-ts:local` - Generates client code from local gateway
- **New file**: `openapi-ts.config.local.ts` - Configuration for local gateway (localhost:4000)
- **New file**: `scripts/cleanup-local-openapi.ts` - Post-processing script to remove `/api/eor` prefix from generated URLs
- **Updated**: `openapi-ts.config.ts` - Added clarifying comments about production vs local usage
- **Updated**: `package.json` - Added the new script

## Usage

### Production API (existing)
```bash
npm run openapi-ts
```

### Local Development API (new)
```bash
npm run openapi-ts:local
```

The local script will:
1. Generate TypeScript client from `http://localhost:4000/api/eor/openapi`
2. Remove `/api/eor` prefix from generated URLs (since the local gateway includes it but production doesn't)
3. Format the code using oxfmt

## Dependencies

This PR only includes the infrastructure for the script. No functional changes to the application code.

## Related

- Extracted from #1009

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new local-only OpenAPI generation path and a simple post-processing script without changing runtime application behavior; main risk is incorrect URL rewriting in generated clients.
> 
> **Overview**
> Adds a new `npm run openapi-ts:local` flow to generate `src/client` from a local OpenAPI spec (`openapi-ts.config.local.ts` pointing at `http://localhost:4000/api/eor/openapi`).
> 
> After generation, a new script (`scripts/cleanup-local-openapi.ts`) rewrites generated `url: '/api/eor/...` entries in `sdk.gen.ts`/`types.gen.ts` to remove the `/api/eor` prefix, and `openapi-ts.config.ts` now documents when to use production vs local generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fca6ddd09bde09b39c3a27956e4c300d2a38a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->