### PR TITLE
fix(onboarding) - 0 values weren't saved

### DIFF
--- a/src/components/form/utils.test.ts
+++ b/src/components/form/utils.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { parseJSFToValidate } from './utils';
+
+/**
+ * Tests for parseJSFToValidate - the main entry point for form value parsing.
+ * This function calls parseSubmitValues -> parseFormValuesToAPI internally.
+ *
+ * The key fix being tested: Fields with falsy-but-valid values (0, false, '')
+ * should be preserved during parsing, while null/undefined should be filtered out.
+ */
+describe('parseJSFToValidate', () => {
+  describe('falsy values', () => {
+    it('should preserve zero values', async () => {
+      const formValues = {
+        probation_length: 0,
+        salary: 5000,
+      };
+
+      const fields = [
+        { name: 'probation_length', type: 'number' },
+        { name: 'salary', type: 'number' },
+      ];
+
+      const result = await parseJSFToValidate(formValues, fields, {
+        isPartialValidation: false,
+      });
+
+      // This is the core fix: 0 should not be filtered out
+      expect(result).toHaveProperty('probation_length', 0);
+      expect(result).toHaveProperty('salary', 5000);
+    });
+
+    it('should preserve false boolean values', async () => {
+      const formValues = {
+        is_active: false,
+        is_verified: true,
+      };
+
+      const fields = [
+        { name: 'is_active', type: 'checkbox' },
+        { name: 'is_verified', type: 'checkbox' },
+      ];
+
+      const result = await parseJSFToValidate(formValues, fields, {
+        isPartialValidation: false,
+      });
+
+      expect(result).toHaveProperty('is_active', false);
+      expect(result).toHaveProperty('is_verified', true);
+    });
+  });
+
+  describe('empty value filtering', () => {
+    it('should remove empty strings (by removeEmptyValues)', async () => {
+      const formValues = {
+        optional_note: '',
+        name: 'test',
+      };
+
+      const fields = [
+        { name: 'optional_note', type: 'text' },
+        { name: 'name', type: 'text' },
+      ];
+
+      const result = await parseJSFToValidate(formValues, fields, {
+        isPartialValidation: false,
+      });
+
+      // removeEmptyValues filters out empty strings
+      expect(result).not.toHaveProperty('optional_note');
+      expect(result).toHaveProperty('name', 'test');
+    });
+
+    it('should remove null and undefined values', async () => {
+      const formValues = {
+        name: 'test',
+        nullable_field: null,
+        undefined_field: undefined,
+      };
+
+      const fields = [
+        { name: 'name', type: 'text' },
+        { name: 'nullable_field', type: 'text' },
+        { name: 'undefined_field', type: 'text' },
+      ];
+
+      const result = await parseJSFToValidate(formValues, fields, {
+        isPartialValidation: false,
+      });
+
+      expect(result).toHaveProperty('name', 'test');
+      // removeEmptyValues filters out null and undefined
+      expect(result).not.toHaveProperty('nullable_field');
+      expect(result).not.toHaveProperty('undefined_field');
+    });
+  });
+
+  describe('real-world scenario', () => {
+    it('should handle the original bug: computed probation_length = 0', async () => {
+      const formValues = {
+        probation_length_recommended: 'recommended',
+        probation_length: 0, // Computed value - the bug filtered this out!
+        contract_end_date: '2027-01-01',
+        is_remote: false, // Also a falsy value
+        annual_gross_salary: 50000,
+      };
+
+      const fields = [
+        { name: 'probation_length_recommended', type: 'radio' },
+        { name: 'probation_length', type: 'number' },
+        { name: 'contract_end_date', type: 'date' },
+        { name: 'is_remote', type: 'checkbox' },
+        { name: 'annual_gross_salary', type: 'number' },
+      ];
+
+      const result = await parseJSFToValidate(formValues, fields, {
+        isPartialValidation: false,
+      });
+
+      // All falsy-but-valid values should be preserved
+      expect(result).toHaveProperty('probation_length', 0);
+      expect(result).toHaveProperty('is_remote', false);
+      expect(result).toHaveProperty(
+        'probation_length_recommended',
+        'recommended',
+      );
+      expect(result).toHaveProperty('contract_end_date', '2027-01-01');
+      expect(result).toHaveProperty('annual_gross_salary', 50000);
+    });
+  });
+});

--- a/src/components/form/utils.test.ts
+++ b/src/components/form/utils.test.ts
@@ -1,13 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseJSFToValidate } from './utils';
 
-/**
- * Tests for parseJSFToValidate - the main entry point for form value parsing.
- * This function calls parseSubmitValues -> parseFormValuesToAPI internally.
- *
- * The key fix being tested: Fields with falsy-but-valid values (0, false, '')
- * should be preserved during parsing, while null/undefined should be filtered out.
- */
 describe('parseJSFToValidate', () => {
   describe('falsy values', () => {
     it('should preserve zero values', async () => {
@@ -25,7 +18,6 @@ describe('parseJSFToValidate', () => {
         isPartialValidation: false,
       });
 
-      // This is the core fix: 0 should not be filtered out
       expect(result).toHaveProperty('probation_length', 0);
       expect(result).toHaveProperty('salary', 5000);
     });
@@ -66,7 +58,6 @@ describe('parseJSFToValidate', () => {
         isPartialValidation: false,
       });
 
-      // removeEmptyValues filters out empty strings
       expect(result).not.toHaveProperty('optional_note');
       expect(result).toHaveProperty('name', 'test');
     });
@@ -86,7 +77,6 @@ describe('parseJSFToValidate', () => {
         isPartialValidation: false,
       });
 
-      // Empty string should be omitted, NOT converted to 0
       expect(result).not.toHaveProperty('optional_years');
       expect(result).toHaveProperty('required_salary', 50000);
     });
@@ -109,7 +99,6 @@ describe('parseJSFToValidate', () => {
       });
 
       expect(result).toHaveProperty('name', 'test');
-      // removeEmptyValues filters out null and undefined
       expect(result).not.toHaveProperty('nullable_field');
       expect(result).not.toHaveProperty('undefined_field');
     });

--- a/src/components/form/utils.test.ts
+++ b/src/components/form/utils.test.ts
@@ -51,7 +51,7 @@ describe('parseJSFToValidate', () => {
   });
 
   describe('empty value filtering', () => {
-    it('should remove empty strings (by removeEmptyValues)', async () => {
+    it('should remove empty strings from text fields', async () => {
       const formValues = {
         optional_note: '',
         name: 'test',
@@ -69,6 +69,26 @@ describe('parseJSFToValidate', () => {
       // removeEmptyValues filters out empty strings
       expect(result).not.toHaveProperty('optional_note');
       expect(result).toHaveProperty('name', 'test');
+    });
+
+    it('should NOT convert empty string number fields to zero', async () => {
+      const formValues = {
+        optional_years: '', // User left this blank
+        required_salary: 50000,
+      };
+
+      const fields = [
+        { name: 'optional_years', type: 'number' },
+        { name: 'required_salary', type: 'number' },
+      ];
+
+      const result = await parseJSFToValidate(formValues, fields, {
+        isPartialValidation: false,
+      });
+
+      // Empty string should be omitted, NOT converted to 0
+      expect(result).not.toHaveProperty('optional_years');
+      expect(result).toHaveProperty('required_salary', 50000);
     });
 
     it('should remove null and undefined values', async () => {

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -232,6 +232,12 @@ export const fieldTypesTransformations: Record<string, $TSFixMe> = {
   },
   [supportedTypes.NUMBER]: {
     transformValueToAPI: () => (value: string) => {
+      // Return empty string as-is so removeEmptyValues can filter it out
+      // This prevents empty optional number fields from being converted to 0
+      if (value === '') {
+        return value;
+      }
+
       // this prevents values with letters such as "2r" from being considered valid
       // if the input is invalid, number().cast will return NaN
       const castValue = Number(value);

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -293,7 +293,8 @@ export async function parseFormValuesToAPI(
 ) {
   const filteredFields = fields.filter(
     (field) =>
-      formValues[field.name!] ||
+      (formValues[field.name!] !== undefined &&
+        formValues[field.name!] !== null) ||
       (field.type === supportedTypes.FIELDSET && field.valueGroupingDisabled),
   );
 

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -761,6 +761,7 @@ describe('OnboardingFlow', () => {
       has_bonus: 'no',
       has_commissions: 'no',
       has_signing_bonus: 'no',
+      probation_length: 0,
       probation_length_days: 40,
       role_description:
         employmentDefaultResponse.data.employment.contract_details

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -761,7 +761,6 @@ describe('OnboardingFlow', () => {
       has_bonus: 'no',
       has_commissions: 'no',
       has_signing_bonus: 'no',
-      probation_length: 0,
       probation_length_days: 40,
       role_description:
         employmentDefaultResponse.data.employment.contract_details


### PR DESCRIPTION
## Problem

I was testing Germany and I found that when computed properties were set, for example 0, the parseFormValues was filtering them out...

## Solution

Add tests to make sure we don't have regressions in the future, it was more difficult finding what's wrong than fixing it

## Loom

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the form-value serialization/filtering logic used across submissions, which could alter what data gets sent for many forms (especially around optional numeric fields and previously-dropped falsy values). Scope is small but touches a central utility path.
> 
> **Overview**
> Fixes a bug where form submission parsing could drop valid falsy values like `0` and `false` by changing `parseFormValuesToAPI`’s field filtering from a truthy check to explicit `null`/`undefined` checks.
> 
> Adjusts number-to-API transformation to **preserve empty strings** (so optional blank numeric inputs are filtered out later) instead of converting them to `0`, and adds a `vitest` suite covering these falsy/empty-value scenarios via `parseJSFToValidate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f768daa0809c1d2b93bcc251e2561ab25976c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->