### PR TITLE
fix(force-value-fields) - set force value field as much as json-schema wants

### DIFF
--- a/src/components/form/fields/ForcedValueField.tsx
+++ b/src/components/form/fields/ForcedValueField.tsx
@@ -37,8 +37,7 @@ export function ForcedValueField({
 
   useEffect(() => {
     setValue(name, value);
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [name, value, setValue]);
 
   const isHiddenValue = !forcedValueDescription && !statement?.title;
 


### PR DESCRIPTION
When we're using computed properties in a force field value, that can change as it depends on other fields, we weren't setting the correct value into the form

In the loom showcase the problem in main and in this PR
https://www.loom.com/share/929e31718e604e62a99f932f5001649c

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a React `useEffect` dependency array so forced values update when inputs change; minimal surface area and no security-sensitive logic.
> 
> **Overview**
> Ensures `ForcedValueField` re-applies its forced form value whenever `name` or `value` changes by updating the `useEffect` dependency array (and removing the exhaustive-deps suppression). This makes the field follow JSON-schema-driven updates instead of only setting the value once on mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f884a9b8024294c427e4ffc5c4bd7c9bf6f5afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->