### PR TITLE
1.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Patch Changes
 
+#### Fixes
+
 - handle empty contractor subscriptions (#1016) [#1016](https://github.com/remoteoss/remote-flows/pull/1016)
-- regenerate openapi spec and fix imports (#1019) [#1019](https://github.com/remoteoss/remote-flows/pull/1019)
+- fix disabled button state in contract-preview (#1022) [#1022](https://github.com/remoteoss/remote-flows/pull/1022)
+
+#### Chores
+
 - update dependency oxlint to v1.63.0 (#999) [#999](https://github.com/remoteoss/remote-flows/pull/999)
 - update dependency filesize to v11.0.17 (#997) [#997](https://github.com/remoteoss/remote-flows/pull/997)
 - update dependency jsdom to v29.1.1 (#989) [#989](https://github.com/remoteoss/remote-flows/pull/989)
@@ -16,8 +21,9 @@
 - update dependency msw to v2.14.5 (#985) [#985](https://github.com/remoteoss/remote-flows/pull/985)
 - update dependency axios to v1.16.0 (#1027) [#1027](https://github.com/remoteoss/remote-flows/pull/1027)
 - update amondnet/vercel-action action to v42.3.0 (#1026) [#1026](https://github.com/remoteoss/remote-flows/pull/1026)
-- fix disabled button state (#1022) [#1022](https://github.com/remoteoss/remote-flows/pull/1022)
-- Add openapi-ts:local script for local API development (#1025) [#1025](https://github.com/remoteoss/remote-flows/pull/1025)
+- regenerate openapi spec and fix imports (#1019) [#1019](https://github.com/remoteoss/remote-flows/pull/1019)
+- add openapi-ts:local script for local API development (#1025) [#1025](https://github.com/remoteoss/remote-flows/pull/1025)
+
 
 ## 1.33.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @remoteoss/remote-flows
 
+## 1.33.2
+
+### Patch Changes
+
+- handle empty contractor subscriptions (#1016) [#1016](https://github.com/remoteoss/remote-flows/pull/1016)
+- regenerate openapi spec and fix imports (#1019) [#1019](https://github.com/remoteoss/remote-flows/pull/1019)
+- update dependency oxlint to v1.63.0 (#999) [#999](https://github.com/remoteoss/remote-flows/pull/999)
+- update dependency filesize to v11.0.17 (#997) [#997](https://github.com/remoteoss/remote-flows/pull/997)
+- update dependency jsdom to v29.1.1 (#989) [#989](https://github.com/remoteoss/remote-flows/pull/989)
+- update dependency @tanstack/react-query to v5.100.9 (#967) [#967](https://github.com/remoteoss/remote-flows/pull/967)
+- update dependency @types/node to v24.12.3 (#1020) [#1020](https://github.com/remoteoss/remote-flows/pull/1020)
+- update dependency oxfmt to v0.48.0 (#998) [#998](https://github.com/remoteoss/remote-flows/pull/998)
+- update dependency vite to v8.0.11 (#1021) [#1021](https://github.com/remoteoss/remote-flows/pull/1021)
+- update dependency msw to v2.14.5 (#985) [#985](https://github.com/remoteoss/remote-flows/pull/985)
+- update dependency axios to v1.16.0 (#1027) [#1027](https://github.com/remoteoss/remote-flows/pull/1027)
+- update amondnet/vercel-action action to v42.3.0 (#1026) [#1026](https://github.com/remoteoss/remote-flows/pull/1026)
+- fix disabled button state (#1022) [#1022](https://github.com/remoteoss/remote-flows/pull/1022)
+- Add openapi-ts:local script for local API development (#1025) [#1025](https://github.com/remoteoss/remote-flows/pull/1025)
+
 ## 1.33.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - regenerate openapi spec and fix imports (#1019) [#1019](https://github.com/remoteoss/remote-flows/pull/1019)
 - add openapi-ts:local script for local API development (#1025) [#1025](https://github.com/remoteoss/remote-flows/pull/1025)
 
-
 ## 1.33.1
 
 ### Patch Changes

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -36,7 +36,7 @@
     },
     "..": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.33.2

### Patch Changes

#### Fixes

- handle empty contractor subscriptions (#1016) [#1016](https://github.com/remoteoss/remote-flows/pull/1016)
- fix disabled button state in contract-preview (#1022) [#1022](https://github.com/remoteoss/remote-flows/pull/1022)

#### Chores

- update dependency oxlint to v1.63.0 (#999) [#999](https://github.com/remoteoss/remote-flows/pull/999)
- update dependency filesize to v11.0.17 (#997) [#997](https://github.com/remoteoss/remote-flows/pull/997)
- update dependency jsdom to v29.1.1 (#989) [#989](https://github.com/remoteoss/remote-flows/pull/989)
- update dependency @tanstack/react-query to v5.100.9 (#967) [#967](https://github.com/remoteoss/remote-flows/pull/967)
- update dependency @types/node to v24.12.3 (#1020) [#1020](https://github.com/remoteoss/remote-flows/pull/1020)
- update dependency oxfmt to v0.48.0 (#998) [#998](https://github.com/remoteoss/remote-flows/pull/998)
- update dependency vite to v8.0.11 (#1021) [#1021](https://github.com/remoteoss/remote-flows/pull/1021)
- update dependency msw to v2.14.5 (#985) [#985](https://github.com/remoteoss/remote-flows/pull/985)
- update dependency axios to v1.16.0 (#1027) [#1027](https://github.com/remoteoss/remote-flows/pull/1027)
- update amondnet/vercel-action action to v42.3.0 (#1026) [#1026](https://github.com/remoteoss/remote-flows/pull/1026)
- regenerate openapi spec and fix imports (#1019) [#1019](https://github.com/remoteoss/remote-flows/pull/1019)
- add openapi-ts:local script for local API development (#1025) [#1025](https://github.com/remoteoss/remote-flows/pull/1025)


---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only updates the package/version metadata and changelog; it does not modify runtime code paths.
> 
> **Overview**
> Bumps `@remoteoss/remote-flows` from `1.33.1` to `1.33.2` in `package.json` and lockfiles.
> 
> Updates `CHANGELOG.md` with the `1.33.2` release notes (two fixes and a set of dependency/tooling chores).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0676f16a500ad2a99ca706724578e19f6abfcf43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->