### PR TITLE
chore: Bump JSF kit package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@radix-ui/react-scroll-area": "1.2.10",
         "@radix-ui/react-select": "2.2.6",
         "@radix-ui/react-tabs": "1.1.13",
-        "@remoteoss/remote-json-schema-form-kit": "0.0.11",
+        "@remoteoss/remote-json-schema-form-kit": "0.0.12",
         "@tailwindcss/cli": "4.2.4",
         "@tailwindcss/postcss": "4.2.4",
         "@tanstack/react-query": "5.100.9",
@@ -3468,9 +3468,9 @@
       }
     },
     "node_modules/@remoteoss/remote-json-schema-form-kit": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@remoteoss/remote-json-schema-form-kit/-/remote-json-schema-form-kit-0.0.11.tgz",
-      "integrity": "sha512-OvAmJFIFmVsHYBQUY2elqG1CX7PLdMMCcja1FQW4h12C3ht5bU7IFX1cIvzYY0gr1YO+lh7Oc2rWsIE6fLEXlQ==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@remoteoss/remote-json-schema-form-kit/-/remote-json-schema-form-kit-0.0.12.tgz",
+      "integrity": "sha512-FTBjriXwN2gqAmSWmEe7LltCnKLjeXNmQgU6yl+we+Ux7odJyKGzdUAc0Vj8uqgaCiN+S9h++KeCAL/ZCwCpeA==",
       "license": "MIT",
       "dependencies": {
         "@remoteoss/json-schema-form": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@radix-ui/react-scroll-area": "1.2.10",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-tabs": "1.1.13",
-    "@remoteoss/remote-json-schema-form-kit": "0.0.11",
+    "@remoteoss/remote-json-schema-form-kit": "0.0.12",
     "@tailwindcss/cli": "4.2.4",
     "@tailwindcss/postcss": "4.2.4",
     "@tanstack/react-query": "5.100.9",


### PR DESCRIPTION
Bumps [remote-json-schema-form-kit](https://www.npmjs.com/package/@remoteoss/remote-json-schema-form-kit) to v0.0.12 which adds new `compute_work_hours` json logic operator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main risk is behavioral differences in JSON schema form rendering/logic evaluation introduced by the upstream library update.
> 
> **Overview**
> Updates the `@remoteoss/remote-json-schema-form-kit` dependency to `0.0.12` in `package.json` and refreshes `package-lock.json` to the new resolved tarball/integrity.
> 
> No application/source code changes are included; behavior changes (e.g., new/updated JSON logic operators) come solely from the upstream package bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453671af67b74cb7558c81d41b3cc3778bff7ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->