### PR TITLE
Proposed changes to e2e helpers

### DIFF
--- a/example/e2e/helpers/general.ts
+++ b/example/e2e/helpers/general.ts
@@ -32,36 +32,45 @@ export type FillFormOptions = {
   type: inputType;
   value?: string;
   cssId?: string;
-  dataField?: string;
+  name?: string;
   testId?: string;
+  options?: { nativeSelect?: boolean };
 };
 
 export async function fillForm(page: Page, values: FillFormOptions[]) {
   for (const option of values) {
     switch (option.type) {
       case 'textField':
-        await fillTextField(page, option.value, option.cssId, option.dataField);
+        if (option.name) {
+          await fillTextField(page, option.name, option.value);
+        } else {
+          throw new Error('textField need name to be located');
+        }
         break;
       case 'select':
-        await fillSelect(page, option.value, option.cssId, option.dataField);
+        if (option.name) {
+          await fillSelect(page, option.value, option.name, option.options);
+        } else {
+          throw new Error('select need name to be located');
+        }
         break;
       case 'comboBox':
-        if (option.dataField) {
-          await fillComboBox(page, option.value, option.dataField);
+        if (option.name) {
+          await fillComboBox(page, option.value, option.name);
         } else {
           throw new Error('comboBox need dataFieldId to be located');
         }
         break;
       case 'radio':
-        if (option.dataField) {
-          await fillRadio(page, option.value, option.dataField);
+        if (option.name) {
+          await fillRadio(page, option.value, option.name);
         } else {
           throw new Error('radio need dataFieldId to be located');
         }
         break;
       case 'checkbox':
-        if (option.dataField) {
-          await fillCheckbox(page, option.value, option.dataField);
+        if (option.name) {
+          await fillCheckbox(page, option.value, option.name);
         } else {
           throw new Error('checkbox need dataFieldId to be located');
         }
@@ -81,35 +90,24 @@ export async function fillForm(page: Page, values: FillFormOptions[]) {
 
 export async function fillTextField(
   page: Page,
+  name: string,
   value: string = '',
-  cssId?: string,
-  dataField?: string,
 ) {
-  if (cssId) {
-    if (value) {
-      await page.fill(cssId, value);
-    }
-  }
-
-  if (dataField) {
-    await page
-      .locator(`[data-field="${dataField}"] :is(input, textarea)`)
-      .fill(value);
-  }
+  await page.locator(`[data-field="${name}"] :is(input, textarea)`).fill(value);
 }
 
 export async function fillSelect(
   page: Page,
   value: string = '',
-  cssId?: string,
-  dataField?: string,
+  name: string,
+  options: { nativeSelect?: boolean } = { nativeSelect: false },
 ) {
-  if (cssId) {
-    await page.selectOption(cssId, value);
-  }
-
-  if (dataField) {
-    const dropdown = page.locator(`[data-field="${dataField}"]`);
+  if (options.nativeSelect) {
+    const dropdown = page.locator(`[data-field="${name}"] select`);
+    await dropdown.waitFor({ state: 'visible' });
+    await dropdown.selectOption(value);
+  } else {
+    const dropdown = page.locator(`[data-field="${name}"]`);
     await dropdown.click();
     const option = page.getByRole('option', { name: value });
     await option.waitFor({ state: 'visible' });

--- a/example/e2e/helpers/general.ts
+++ b/example/e2e/helpers/general.ts
@@ -31,7 +31,6 @@ export type inputType =
 export type FillFormOptions = {
   type: inputType;
   value?: string;
-  cssId?: string;
   name?: string;
   testId?: string;
   options?: { nativeSelect?: boolean };
@@ -58,21 +57,21 @@ export async function fillForm(page: Page, values: FillFormOptions[]) {
         if (option.name) {
           await fillComboBox(page, option.value, option.name);
         } else {
-          throw new Error('comboBox need dataFieldId to be located');
+          throw new Error('comboBox need name to be located');
         }
         break;
       case 'radio':
         if (option.name) {
           await fillRadio(page, option.value, option.name);
         } else {
-          throw new Error('radio need dataFieldId to be located');
+          throw new Error('radio need name to be located');
         }
         break;
       case 'checkbox':
         if (option.name) {
           await fillCheckbox(page, option.value, option.name);
         } else {
-          throw new Error('checkbox need dataFieldId to be located');
+          throw new Error('checkbox need name to be located');
         }
         break;
       case 'datepicker':

--- a/example/e2e/helpers/onboarding.ts
+++ b/example/e2e/helpers/onboarding.ts
@@ -12,10 +12,15 @@ export async function fillOnboardingIntroductionForm(
   options: Partial<fillOnboardingIntroductionFormOptions>,
 ) {
   await fillForm(page, [
-    { type: 'textField', value: options.company_id, cssId: '#companyId' },
-    { type: 'select', value: 'employee', cssId: '#type' },
-    { type: 'textField', value: options.employment_id, cssId: '#employmentId' },
-    { type: 'textField', value: options.external_id, cssId: '#externalId' },
+    { type: 'textField', value: options.company_id, name: 'companyId' },
+    {
+      type: 'select',
+      value: 'employee',
+      name: 'type',
+      options: { nativeSelect: true },
+    },
+    { type: 'textField', value: options.employment_id, name: 'employmentId' },
+    { type: 'textField', value: options.external_id, name: 'externalId' },
   ]);
 
   await page.click('.onboarding-form-button');
@@ -31,7 +36,7 @@ export async function fillOnboardingStep1Form(
   options: Partial<fillOnboardingStep1FormOptions>,
 ) {
   await fillForm(page, [
-    { type: 'select', value: options.country_id, dataField: 'country' },
+    { type: 'select', value: options.country_id, name: 'country' },
   ]);
 
   await page.click('.submit-button');
@@ -54,19 +59,19 @@ export async function fillOnboardingStep2Form(
   options: Partial<fillOnboardingStep2FormOptions>,
 ) {
   await fillForm(page, [
-    { type: 'textField', value: options.fullname, dataField: 'name' },
-    { type: 'textField', value: options.personal_email, dataField: 'email' },
-    { type: 'textField', value: options.work_email, dataField: 'work_email' },
-    { type: 'textField', value: options.job_title, dataField: 'job_title' },
+    { type: 'textField', value: options.fullname, name: 'name' },
+    { type: 'textField', value: options.personal_email, name: 'email' },
+    { type: 'textField', value: options.work_email, name: 'work_email' },
+    { type: 'textField', value: options.job_title, name: 'job_title' },
     {
       type: 'comboBox',
       value: options.country_id,
-      dataField: 'tax_servicing_countries',
+      name: 'tax_servicing_countries',
     },
     {
       type: 'comboBox',
       value: options.tax_job_category,
-      dataField: 'tax_job_category',
+      name: 'tax_job_category',
     },
     {
       type: 'datepicker',
@@ -76,7 +81,7 @@ export async function fillOnboardingStep2Form(
     {
       type: 'radio',
       value: options.has_seniority_date,
-      dataField: 'has_seniority_date',
+      name: 'has_seniority_date',
     },
   ]);
 
@@ -117,112 +122,112 @@ export async function fillOnboardingStep3SpainForm(
     {
       type: 'radio',
       value: options.contract_duration_type,
-      dataField: 'contract_duration_type',
+      name: 'contract_duration_type',
     },
     {
       type: 'radio',
       value: options.work_schedule,
-      dataField: 'work_schedule',
+      name: 'work_schedule',
     },
     {
       type: 'textField',
       value: options.probation_length,
-      dataField: 'probation_length',
+      name: 'probation_length',
     },
     {
       type: 'checkbox',
       value: options.probation_length_ack ? 'yes' : '',
-      dataField: 'probation_length_ack',
+      name: 'probation_length_ack',
     },
     {
       type: 'radio',
       value: options.available_pto_type,
-      dataField: 'available_pto_type',
+      name: 'available_pto_type',
     },
     {
       type: 'radio',
       value: options.overtime_compensation_method,
-      dataField: 'overtime_compensation_method',
+      name: 'overtime_compensation_method',
     },
     {
       type: 'textField',
       value: options.available_pto,
-      dataField: 'available_pto',
+      name: 'available_pto',
     },
     {
       type: 'textField',
       value: options.role_description,
-      dataField: 'role_description',
+      name: 'role_description',
     },
     {
       type: 'radio',
       value: options.experience_level,
-      dataField: 'experience_level',
+      name: 'experience_level',
     },
     {
       type: 'radio',
       value: options.work_address_is_home_address,
-      dataField: 'work_address_is_home_address',
+      name: 'work_address_is_home_address',
     },
     {
       type: 'textField',
       value: options.annual_gross_salary,
-      dataField: 'annual_gross_salary',
+      name: 'annual_gross_salary',
     },
     {
       type: 'checkbox',
       value: options.annual_bonus_ack ? 'yes' : '',
-      dataField: 'annual_bonus_ack',
+      name: 'annual_bonus_ack',
     },
     {
       type: 'comboBox',
       value: options.salary_installments,
-      dataField: 'is_salary_prorated',
+      name: 'is_salary_prorated',
     },
     {
       type: 'textField',
       value: options.allowances,
-      dataField: 'allowances',
+      name: 'allowances',
     },
     {
       type: 'radio',
       value: options.has_signing_bonus,
-      dataField: 'has_signing_bonus',
+      name: 'has_signing_bonus',
     },
     {
       type: 'radio',
       value: options.has_bonus,
-      dataField: 'has_bonus',
+      name: 'has_bonus',
     },
     {
       type: 'radio',
       value: options.has_commissions,
-      dataField: 'has_commissions',
+      name: 'has_commissions',
     },
     {
       type: 'radio',
       value: options.equity_compensation,
-      dataField: 'equity_compensation.offer_equity_compensation',
+      name: 'equity_compensation.offer_equity_compensation',
     },
     {
       type: 'radio',
       value: options.non_compete_clause_apply,
-      dataField: 'non_compete_clause_apply',
+      name: 'non_compete_clause_apply',
     },
     {
       type: 'radio',
       value: options.has_social_security_number,
-      dataField: 'has_social_security_number',
+      name: 'has_social_security_number',
     },
     {
       type: 'textField',
       value: options.work_equipment,
-      dataField: 'work_equipment',
+      name: 'work_equipment',
     },
     {
       type: 'checkbox',
       value: options.compensation_expenses_ack ? 'yes' : '',
-      dataField: 'compensation_expenses_ack',
+      name: 'compensation_expenses_ack',
     },
   ]);
 
@@ -252,42 +257,42 @@ export async function fillOnboardingStep4SpainForm(
       {
         type: 'radio',
         value: options.life_insurance_type,
-        dataField: 'f90cb339-172d-4d24-9ee6-da2e2ccc954e.filter',
+        name: 'f90cb339-172d-4d24-9ee6-da2e2ccc954e.filter',
       },
       {
         type: 'radio',
         value: options.life_insurance,
-        dataField: 'f90cb339-172d-4d24-9ee6-da2e2ccc954e.value',
+        name: 'f90cb339-172d-4d24-9ee6-da2e2ccc954e.value',
       },
       {
         type: 'radio',
         value: options.health_insurance_coverage,
-        dataField: '88081a16-882a-42b8-8cd5-6abb30585e4e.filter',
+        name: '88081a16-882a-42b8-8cd5-6abb30585e4e.filter',
       },
       {
         type: 'radio',
         value: options.health_insurance,
-        dataField: '88081a16-882a-42b8-8cd5-6abb30585e4e.value',
+        name: '88081a16-882a-42b8-8cd5-6abb30585e4e.value',
       },
       {
         type: 'radio',
         value: options.retirement,
-        dataField: '57b4108b-74d4-4830-ad11-68a46679f88c.value',
+        name: '57b4108b-74d4-4830-ad11-68a46679f88c.value',
       },
       {
         type: 'radio',
         value: options.mental_health,
-        dataField: '4a2d0edb-ebd9-49af-ad79-7390deb7ee71.value',
+        name: '4a2d0edb-ebd9-49af-ad79-7390deb7ee71.value',
       },
       {
         type: 'radio',
         value: options.wellness,
-        dataField: '5ffc8e84-1304-4abb-91c2-4d43b1fece5d.value',
+        name: '5ffc8e84-1304-4abb-91c2-4d43b1fece5d.value',
       },
       {
         type: 'radio',
         value: options.business_travel,
-        dataField: '91dd5796-5ed7-449e-9a75-15c07c288970.value',
+        name: '91dd5796-5ed7-449e-9a75-15c07c288970.value',
       },
     ]);
   }

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -551,7 +551,7 @@ export const OnboardingForm = () => {
 
   return (
     <form onSubmit={handleSubmit} className='onboarding-form-container'>
-      <div className='onboarding-form-group'>
+      <div data-field='companyId' className='onboarding-form-group'>
         <label htmlFor='companyId' className='onboarding-form-label'>
           Company ID:
         </label>
@@ -567,7 +567,7 @@ export const OnboardingForm = () => {
           className='onboarding-form-input'
         />
       </div>
-      <div className='onboarding-form-group'>
+      <div data-field='type' className='onboarding-form-group'>
         <label htmlFor='type' className='onboarding-form-label'>
           Type:
         </label>
@@ -587,7 +587,7 @@ export const OnboardingForm = () => {
           <option value='contractor'>Contractor</option>
         </select>
       </div>
-      <div className='onboarding-form-group'>
+      <div data-field='employmentId' className='onboarding-form-group'>
         <label htmlFor='employmentId' className='onboarding-form-label'>
           Employment ID:
         </label>
@@ -602,7 +602,7 @@ export const OnboardingForm = () => {
           className='onboarding-form-input'
         />
       </div>
-      <div className='onboarding-form-group'>
+      <div data-field='externalId' className='onboarding-form-group'>
         <label htmlFor='externalId' className='onboarding-form-label'>
           External ID:
         </label>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core e2e form-filling helpers and selectors; tests may start failing if any form fields lack the expected `data-field` wrappers or if select behavior differs between native/custom dropdowns.
> 
> **Overview**
> Refactors the Playwright `fillForm` helpers to locate inputs consistently via a required `name` mapped to `[data-field="..."]`, removing prior `cssId`/`dataField` locator options and adding clearer errors when `name` is missing.
> 
> Adds `nativeSelect` support to `fillSelect` (using direct `<select>` selection vs role-based option clicking) and updates onboarding e2e helpers accordingly. The onboarding intro form UI is also updated to add `data-field` attributes around its inputs/select so the new locators work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd745405b4a374110bc7f6b503082a4c03a970b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->