### PR TITLE
fix(contractor-onboarding) - fix maxDate for contractor of record

### DIFF
--- a/src/common/dates.ts
+++ b/src/common/dates.ts
@@ -10,6 +10,22 @@ export function getYearMonthDate(date: Date) {
   };
 }
 
+/**
+ * Parses a date-only string (YYYY-MM-DD) as local time, avoiding timezone issues.
+ *
+ * Using `new Date('2025-01-15')` parses as UTC midnight, which becomes the previous
+ * day in UTC-negative timezones (Americas). This function parses the date components
+ * directly to create a Date at local midnight, ensuring the same calendar day
+ * regardless of timezone.
+ *
+ * Use this for date-only strings from forms, API responses, or anywhere you need
+ * calendar dates without time/timezone considerations.
+ *
+ * @example
+ * // In New York (UTC-5):
+ * new Date('2025-01-15')      // → 2025-01-14T19:00:00 (previous day!)
+ * parseLocalDate('2025-01-15') // → 2025-01-15T00:00:00 (correct day)
+ */
 export const parseLocalDate = (dateString: string) => {
   const [year, month, day] = dateString.split('-').map(Number);
   return new Date(year, month - 1, day);

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -96,6 +96,7 @@ export function FieldSetField({
     ({ name: fieldName }) => `${name}.${fieldName}`,
   );
   const watchedValues = watch(fieldNames);
+  const allFormValues = watch(); // Watch entire form for calculateDynamicProperties
   const prevValuesRef = useRef<string[]>(watchedValues);
   const triggerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -223,7 +224,7 @@ export function FieldSetField({
               if (field.calculateDynamicProperties) {
                 field = {
                   ...field,
-                  ...(field.calculateDynamicProperties(watchedValues, field) ||
+                  ...(field.calculateDynamicProperties(allFormValues, field) ||
                     {}),
                 };
               }

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -33,15 +33,7 @@ type FieldWithoutOptions = FieldBase & {
   options?: never;
 };
 
-type FieldWithCalculateDynamicProperties = FieldBase & {
-  calculateDynamicProperties: (formValues: FieldValues) => {
-    [key: string]: unknown;
-  };
-};
-type Field =
-  | FieldWithOptions
-  | FieldWithoutOptions
-  | FieldWithCalculateDynamicProperties;
+type Field = FieldWithOptions | FieldWithoutOptions;
 
 type FieldSetFeatures = {
   toggle?: {

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -1,4 +1,4 @@
-import { FieldValues, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { Fragment, useEffect, useRef } from 'react';
 import omit from 'lodash.omit';
 import { baseFields } from '@/src/components/form/fields/baseFields';

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { FieldValues, useFormContext } from 'react-hook-form';
 import { Fragment, useEffect, useRef } from 'react';
 import omit from 'lodash.omit';
 import { baseFields } from '@/src/components/form/fields/baseFields';
@@ -33,7 +33,15 @@ type FieldWithoutOptions = FieldBase & {
   options?: never;
 };
 
-type Field = FieldWithOptions | FieldWithoutOptions;
+type FieldWithCalculateDynamicProperties = FieldBase & {
+  calculateDynamicProperties: (formValues: FieldValues) => {
+    [key: string]: unknown;
+  };
+};
+type Field =
+  | FieldWithOptions
+  | FieldWithoutOptions
+  | FieldWithCalculateDynamicProperties;
 
 type FieldSetFeatures = {
   toggle?: {
@@ -95,8 +103,11 @@ export function FieldSetField({
   const fieldNames = fields.map(
     ({ name: fieldName }) => `${name}.${fieldName}`,
   );
+  const fieldsetNeedsAllFormValues = fields.some(
+    (field: $TSFixMe) => field.calculateDynamicProperties,
+  );
   const watchedValues = watch(fieldNames);
-  const allFormValues = watch();
+  const allFormValues = fieldsetNeedsAllFormValues ? watch() : watchedValues;
   const prevValuesRef = useRef<string[]>(watchedValues);
   const triggerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/components/form/fields/FieldSetField.tsx
+++ b/src/components/form/fields/FieldSetField.tsx
@@ -96,7 +96,7 @@ export function FieldSetField({
     ({ name: fieldName }) => `${name}.${fieldName}`,
   );
   const watchedValues = watch(fieldNames);
-  const allFormValues = watch(); // Watch entire form for calculateDynamicProperties
+  const allFormValues = watch();
   const prevValuesRef = useRef<string[]>(watchedValues);
   const triggerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/flows/ContractorOnboarding/jsfModify.tsx
+++ b/src/flows/ContractorOnboarding/jsfModify.tsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { addMonths, format } from 'date-fns';
 import { FieldValues } from 'react-hook-form';
 import { ChangeEvent } from 'react';
 
@@ -124,6 +124,25 @@ export const buildContractDetailsJsfModify = (
               ? format(new Date(), 'yyyy-MM-dd')
               : undefined,
             ...statement,
+          },
+        },
+        'service_duration.expiration_date': {
+          'x-jsf-presentation': {
+            calculateDynamicProperties: (formValues: FieldValues) => {
+              const maxDate =
+                isContractorOfRecord &&
+                formValues.service_duration?.provisional_start_date
+                  ? addMonths(
+                      new Date(
+                        formValues.service_duration.provisional_start_date,
+                      ),
+                      12,
+                    )
+                  : undefined;
+              return {
+                maxDate: maxDate ? format(maxDate, 'yyyy-MM-dd') : undefined,
+              };
+            },
           },
         },
         services_and_deliverables: {

--- a/src/flows/ContractorOnboarding/jsfModify.tsx
+++ b/src/flows/ContractorOnboarding/jsfModify.tsx
@@ -2,6 +2,7 @@ import { addMonths, format } from 'date-fns';
 import { FieldValues } from 'react-hook-form';
 import { ChangeEvent } from 'react';
 
+import { parseLocalDate } from '@/src/common/dates';
 import { createStatementProperty } from '@/src/components/form/jsf-utils/createFields';
 import { zendeskArticles } from '@/src/components/shared/zendesk-drawer/utils';
 import { ZendeskTriggerButton } from '@/src/components/shared/zendesk-drawer/ZendeskTriggerButton';
@@ -133,7 +134,7 @@ export const buildContractDetailsJsfModify = (
                 isContractorOfRecord &&
                 formValues.service_duration?.provisional_start_date
                   ? addMonths(
-                      new Date(
+                      parseLocalDate(
                         formValues.service_duration.provisional_start_date,
                       ),
                       12,

--- a/src/flows/ContractorOnboarding/jsfModify.tsx
+++ b/src/flows/ContractorOnboarding/jsfModify.tsx
@@ -1,4 +1,4 @@
-import { addMonths, format } from 'date-fns';
+import { addYears, format } from 'date-fns';
 import { FieldValues } from 'react-hook-form';
 import { ChangeEvent } from 'react';
 
@@ -133,11 +133,11 @@ export const buildContractDetailsJsfModify = (
               const maxDate =
                 isContractorOfRecord &&
                 formValues.service_duration?.provisional_start_date
-                  ? addMonths(
+                  ? addYears(
                       parseLocalDate(
                         formValues.service_duration.provisional_start_date,
                       ),
-                      12,
+                      1,
                     )
                   : undefined;
               return {

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -3309,4 +3309,149 @@ describe('ContractorOnboardingFlow', () => {
       expect(mockOnError).toHaveBeenCalled();
     });
   });
+
+  describe('COR Contract Duration MaxDate', () => {
+    it('should set maxDate to 12 months after provisional_start_date for COR', async () => {
+      const employmentId = generateUniqueEmploymentId();
+
+      server.use(
+        http.get(`*/v1/employments/${employmentId}`, () => {
+          return HttpResponse.json({
+            ...mockContractorEmploymentResponse,
+            data: {
+              ...mockContractorEmploymentResponse.data,
+              employment: {
+                ...mockContractorEmploymentResponse.data.employment,
+                id: employmentId,
+                contractor_type: 'cor',
+              },
+            },
+          });
+        }),
+      );
+
+      mockRender.mockImplementation(
+        createMockRenderImplementation(MultiStepFormWithoutCountry),
+      );
+
+      render(
+        <ContractorOnboardingFlow
+          employmentId={employmentId}
+          countryCode='PRT'
+          skipSteps={['select_country']}
+          {...defaultProps}
+        />,
+        { wrapper: TestProviders },
+      );
+
+      await screen.findByText(/Step: Basic Information/i);
+      await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+      await fillBasicInformation();
+
+      let nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Pricing Plan/i);
+      await fillContractorSubscription('Contractor of Record');
+
+      nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Eligibility Questionnaire/i);
+      await fillEligibilityQuestionnaire();
+
+      nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Contract Details/i);
+
+      // Fill the provisional start date
+      const startDate = '2025-01-15';
+      await fillDatePickerByTestId(
+        startDate,
+        'service_duration.provisional_start_date',
+      );
+
+      // Get the expiration date field
+      const expirationDateField = screen.getByTestId(
+        'service_duration.expiration_date',
+      );
+      expect(expirationDateField).toBeInTheDocument();
+
+      // Verify maxDate is set (12 months after start date = 2026-01-15)
+      await waitFor(() => {
+        expect(expirationDateField).toHaveAttribute('max', '2026-01-15');
+      });
+    });
+
+    it('should not set maxDate for non-COR contractor types', async () => {
+      const employmentId = generateUniqueEmploymentId();
+
+      server.use(
+        http.get(`*/v1/employments/${employmentId}`, () => {
+          return HttpResponse.json({
+            ...mockContractorEmploymentResponse,
+            data: {
+              ...mockContractorEmploymentResponse.data,
+              employment: {
+                ...mockContractorEmploymentResponse.data.employment,
+                id: employmentId,
+                contractor_type: 'cm',
+              },
+            },
+          });
+        }),
+      );
+
+      mockRender.mockImplementation(
+        createMockRenderImplementation(MultiStepFormWithoutCountry),
+      );
+
+      render(
+        <ContractorOnboardingFlow
+          employmentId={employmentId}
+          countryCode='PRT'
+          skipSteps={['select_country']}
+          {...defaultProps}
+        />,
+        { wrapper: TestProviders },
+      );
+
+      // Navigate to contract details step
+      await screen.findByText(/Step: Basic Information/i);
+      await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+      await fillBasicInformation();
+
+      let nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Pricing Plan/i);
+      await fillContractorSubscription('Contractor Management Plus');
+
+      nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Contract Details/i);
+
+      // Fill the provisional start date
+      const startDate = '2025-01-15';
+      await fillDatePickerByTestId(
+        startDate,
+        'service_duration.provisional_start_date',
+      );
+
+      // Get the expiration date field
+      const expirationDateField = screen.getByTestId(
+        'service_duration.expiration_date',
+      );
+      expect(expirationDateField).toBeInTheDocument();
+
+      // Verify maxDate is NOT set for non-COR types
+      await waitFor(() => {
+        expect(expirationDateField).not.toHaveAttribute('max');
+      });
+    });
+  });
 });

--- a/src/flows/Onboarding/tests/fixtures/basicInformation/v3-germany.ts
+++ b/src/flows/Onboarding/tests/fixtures/basicInformation/v3-germany.ts
@@ -5975,7 +5975,7 @@ export const basicInformationSchemaV3Germany = {
           blockedDates: [],
           inputType: 'date',
           meta: {
-            mot: 20,
+            mot: 0,
           },
           minDate: '2025-05-12',
           softBlockedDates: [],

--- a/src/tests/defaultComponents.tsx
+++ b/src/tests/defaultComponents.tsx
@@ -4,6 +4,12 @@ import { defaultComponents as defaultComponentsFromPackage } from '@/src/default
 export const defaultComponents = {
   ...defaultComponentsFromPackage,
   date: ({ field, fieldData, fieldState }: FieldComponentProps) => {
+    const maxDate = fieldData.maxDate
+      ? new Date(fieldData.maxDate).toISOString().split('T')[0]
+      : undefined;
+    const minDate = fieldData.minDate
+      ? new Date(fieldData.minDate).toISOString().split('T')[0]
+      : undefined;
     return (
       <div className='input-container'>
         <label htmlFor={field.name}>{fieldData.label}</label>
@@ -16,6 +22,8 @@ export const defaultComponents = {
           onChange={(e) => {
             field?.onChange?.(e.target.value);
           }}
+          {...(maxDate && { max: maxDate })}
+          {...(minDate && { min: minDate })}
         />
         {fieldData.description && (
           <p className='input-description'>{fieldData.description}</p>


### PR DESCRIPTION
Adds a maxDate to the service_duration.expirationDate when the product selected is contractor of record


https://www.loom.com/share/7d7c49eb8c9c445db4f7b8d2abb4c3e5



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes dynamic form behavior and date constraint computation, which could affect validation/UX across fieldsets if `calculateDynamicProperties` relies on different watched values. Scope is limited to onboarding form date fields and test utilities.
> 
> **Overview**
> **Contractor of Record contracts now cap the expiration date** by dynamically setting `service_duration.expiration_date` `maxDate` to 1 year after `service_duration.provisional_start_date` in `buildContractDetailsJsfModify`.
> 
> To prevent timezone off-by-one errors, date-only strings are now parsed via a new `parseLocalDate('YYYY-MM-DD')` helper, and `FieldSetField` passes full form values into `calculateDynamicProperties` when needed. Tests and the test `date` component were updated to assert/reflect `min`/`max` attributes, and onboarding fixtures tweak Germany MOT metadata (`mot: 20` → `0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3629d1cc821b05d3d29980124281abfbbd261341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->