### PR TITLE
feat(pricing-modals) - add employer of record information

### DIFF
--- a/example/src/components/PricingPlanModals.tsx
+++ b/example/src/components/PricingPlanModals.tsx
@@ -14,6 +14,7 @@ import {
   contractorStandardProductIdentifier,
   contractorPlusProductIdentifier,
   pricingPlanDetails,
+  eorProductIdentifier,
 } from '@remoteoss/remote-flows';
 import { useState } from 'react';
 import { CheckIcon, ChevronRight } from 'lucide-react';
@@ -74,6 +75,7 @@ export const PricingPlanOptionsModal = () => {
     contractorStandardProductIdentifier,
     contractorPlusProductIdentifier,
     corProductIdentifier,
+    eorProductIdentifier,
   ];
 
   return (

--- a/src/flows/ContractorOnboarding/constants.ts
+++ b/src/flows/ContractorOnboarding/constants.ts
@@ -148,4 +148,15 @@ export const pricingPlanDetails = {
     ],
     contractPillText: 'Contract between Remote and contractor',
   },
+  [eorProductIdentifier]: {
+    title: 'Employer of Record',
+    subtitle: 'Remote engages the employee on your behalf',
+    listItems: [
+      'Contract between Remote and employee',
+      'Remote manages onboarding, payroll, and compliance',
+      'Manages taxes, benefits, and time-off tracking',
+      'Handles contracts, transfers, and terminations',
+    ],
+    contractPillText: 'Contract between Remote and employee',
+  },
 };

--- a/src/flows/ContractorOnboarding/constants.ts
+++ b/src/flows/ContractorOnboarding/constants.ts
@@ -152,7 +152,6 @@ export const pricingPlanDetails = {
     title: 'Employer of Record',
     subtitle: 'Remote engages the employee on your behalf',
     listItems: [
-      'Contract between Remote and employee',
       'Remote manages onboarding, payroll, and compliance',
       'Manages taxes, benefits, and time-off tracking',
       'Handles contracts, transfers, and terminations',


### PR DESCRIPTION
Add employer of record information for the pricing card modal

<img width="629" height="921" alt="image" src="https://github.com/user-attachments/assets/57a7954d-9427-4ae4-9460-eab0d822e3f0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/content expansion: introduces a new plan identifier into an existing modal list and adds its corresponding static `pricingPlanDetails` entry.
> 
> **Overview**
> **Adds Employer of Record (EOR) to pricing plan modals.** The pricing plan options modal now includes `eorProductIdentifier` alongside existing contractor/COR plans.
> 
> **Adds EOR copy to plan details.** `pricingPlanDetails` gains a new entry for EOR (title/subtitle/bullets/contract pill) so the modal can render the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6e2b00ee6ed91a533e7f18a8b06d6b5871e38c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->