### PR TITLE
fix(prettifyFormValues) - strip html tags

### DIFF
--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -335,6 +335,48 @@ describe('utils lib', () => {
       });
     });
 
+    it('strips HTML from labels', () => {
+      const values = { phone: '1234567890', email: 'test@example.com' };
+      const fields: JSFFields = [
+        { name: 'phone', type: 'text', label: 'Employee&#39;s phone number' },
+        { name: 'email', type: 'text', label: '<strong>Work email</strong>' },
+      ];
+      expect(prettifyFormValues(values, fields)).toEqual({
+        phone: {
+          prettyValue: '1234567890',
+          label: "Employee's phone number",
+          inputType: 'text',
+        },
+        email: {
+          prettyValue: 'test@example.com',
+          label: 'Work email',
+          inputType: 'text',
+        },
+      });
+    });
+
+    it('strips HTML from prettyValue in radio/select fields', () => {
+      const values = { status: 'active' };
+      const fields: JSFFields = [
+        {
+          name: 'status',
+          type: 'select',
+          label: 'Status',
+          options: [
+            { value: 'active', label: '<strong>Active</strong>' },
+            { value: 'inactive', label: 'Employee&#39;s status' },
+          ],
+        },
+      ];
+      expect(prettifyFormValues(values, fields)).toEqual({
+        status: {
+          prettyValue: 'Active',
+          label: 'Status',
+          inputType: 'select',
+        },
+      });
+    });
+
     it('handles multiple fields of different types', () => {
       const values = {
         name: 'John',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -130,7 +130,7 @@ export const sanitizeHtmlWithImageErrorHandling = (html: string) => {
  * @param html - The HTML string to strip
  * @returns Plain text without HTML tags or entities
  */
-export const stripHtml = (html: string | undefined | unknown): string => {
+export const stripHtml = (html: string | undefined): string => {
   if (!html || typeof html !== 'string') return '';
 
   const parser = new DOMParser();
@@ -199,7 +199,7 @@ export function prettifyFormValues(
               key,
               {
                 prettyValue: stripHtml(option?.label),
-                label: stripHtml(field?.label),
+                label: stripHtml(field?.label as string),
                 inputType: field?.type,
               },
             ];
@@ -212,7 +212,7 @@ export function prettifyFormValues(
             key,
             {
               prettyValue: true,
-              label: stripHtml(field.label),
+              label: stripHtml(field.label as string),
               inputType: field?.type,
             },
           ];
@@ -223,7 +223,7 @@ export function prettifyFormValues(
             key,
             {
               prettyValue: value.join(),
-              label: stripHtml(field.label),
+              label: stripHtml(field.label as string),
               inputType: field?.type,
             },
           ];
@@ -241,7 +241,7 @@ export function prettifyFormValues(
           if (!prettiedFieldset.label && prettiedFieldset.value) {
             const prettyValue: Record<string, unknown> = {
               ...prettiedFieldset.value,
-              label: stripHtml(field.label),
+              label: stripHtml(field.label as string),
               inputType: field?.type,
             };
             return [key, prettyValue];
@@ -261,7 +261,7 @@ export function prettifyFormValues(
                 (typeof value === 'string' || typeof value === 'number')
                   ? convertFromCents(value)
                   : value,
-              label: stripHtml(field.label),
+              label: stripHtml(field.label as string),
               inputType: field?.type,
               currency: field?.currency,
             },
@@ -273,7 +273,7 @@ export function prettifyFormValues(
             key,
             {
               prettyValue: value,
-              label: stripHtml(field.label),
+              label: stripHtml(field.label as string),
               inputType: field?.type,
             },
           ];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -130,8 +130,16 @@ export const sanitizeHtmlWithImageErrorHandling = (html: string) => {
  * @param html - The HTML string to strip
  * @returns Plain text without HTML tags or entities
  */
-export const stripHtml = (html: string | undefined): string | undefined => {
-  if (html === undefined) return undefined;
+export const stripHtml = (
+  html: string | undefined | null,
+): string | undefined | null => {
+  if (html === null) {
+    return null;
+  }
+
+  if (html === undefined) {
+    return undefined;
+  }
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -130,8 +130,8 @@ export const sanitizeHtmlWithImageErrorHandling = (html: string) => {
  * @param html - The HTML string to strip
  * @returns Plain text without HTML tags or entities
  */
-export const stripHtml = (html: string | undefined): string => {
-  if (!html || typeof html !== 'string') return '';
+export const stripHtml = (html: string | undefined): string | undefined => {
+  if (html === undefined) return undefined;
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -133,12 +133,8 @@ export const sanitizeHtmlWithImageErrorHandling = (html: string) => {
 export const stripHtml = (
   html: string | undefined | null,
 ): string | undefined | null => {
-  if (html === null) {
-    return null;
-  }
-
-  if (html === undefined) {
-    return undefined;
+  if (html === null || html === undefined) {
+    return html;
   }
 
   const parser = new DOMParser();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -126,6 +126,20 @@ export const sanitizeHtmlWithImageErrorHandling = (html: string) => {
 };
 
 /**
+ * Strips HTML tags and decodes HTML entities from a string
+ * @param html - The HTML string to strip
+ * @returns Plain text without HTML tags or entities
+ */
+export const stripHtml = (html: string | undefined | unknown): string => {
+  if (!html || typeof html !== 'string') return '';
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  return doc.body.textContent || '';
+};
+
+/**
  * Ensures base64 data has the correct data URI prefix for PDF content
  * @param base64Data - The base64 data string
  * @returns The base64 data with proper data URI prefix
@@ -184,8 +198,8 @@ export function prettifyFormValues(
             return [
               key,
               {
-                prettyValue: option?.label,
-                label: field?.label,
+                prettyValue: stripHtml(option?.label),
+                label: stripHtml(field?.label),
                 inputType: field?.type,
               },
             ];
@@ -196,7 +210,11 @@ export function prettifyFormValues(
         if (field?.type === 'checkbox' && field?.const) {
           return [
             key,
-            { prettyValue: true, label: field.label, inputType: field?.type },
+            {
+              prettyValue: true,
+              label: stripHtml(field.label),
+              inputType: field?.type,
+            },
           ];
         }
 
@@ -205,7 +223,7 @@ export function prettifyFormValues(
             key,
             {
               prettyValue: value.join(),
-              label: field.label,
+              label: stripHtml(field.label),
               inputType: field?.type,
             },
           ];
@@ -223,7 +241,7 @@ export function prettifyFormValues(
           if (!prettiedFieldset.label && prettiedFieldset.value) {
             const prettyValue: Record<string, unknown> = {
               ...prettiedFieldset.value,
-              label: field.label,
+              label: stripHtml(field.label),
               inputType: field?.type,
             };
             return [key, prettyValue];
@@ -243,7 +261,7 @@ export function prettifyFormValues(
                 (typeof value === 'string' || typeof value === 'number')
                   ? convertFromCents(value)
                   : value,
-              label: field.label,
+              label: stripHtml(field.label),
               inputType: field?.type,
               currency: field?.currency,
             },
@@ -253,7 +271,11 @@ export function prettifyFormValues(
         if (field) {
           return [
             key,
-            { prettyValue: value, label: field.label, inputType: field?.type },
+            {
+              prettyValue: value,
+              label: stripHtml(field.label),
+              inputType: field?.type,
+            },
           ];
         }
       })


### PR DESCRIPTION
We strip html tags that can appear from the schema

## Before

<img width="876" height="314" alt="image" src="https://github.com/user-attachments/assets/c36c1eae-0169-4c29-b346-9ea0c76d7bc6" />

## Now

<img width="831" height="418" alt="image" src="https://github.com/user-attachments/assets/b14a302f-9433-4a2a-aa7c-7d9ad43a62c7" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes display formatting of schema-provided labels/options by stripping markup/entities, with tests added to lock in behavior.
> 
> **Overview**
> `prettifyFormValues` now strips HTML tags and decodes HTML entities from schema-provided field `label`s and `radio`/`select` option labels before returning them, preventing markup from leaking into review/summary UI.
> 
> Adds a new `stripHtml` helper (DOMParser-based) in `utils.ts` and extends `utils.test.ts` with coverage for HTML/entity stripping in both labels and option-derived `prettyValue`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de9b86f1e1272347e803a4ee7ea364195c38ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->