### PR TITLE
1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @remoteoss/remote-flows
 
+## 1.35.0
+
+### Minor Changes
+
+- update remote-json-schema-form-kit to v0.0.12
+- add employer of record information (#1043) [#1043](https://github.com/remoteoss/remote-flows/pull/1043)
+- strip html tags (#1044) [#1044](https://github.com/remoteoss/remote-flows/pull/1044)
+- fix maxDate for contractor of record (#1042) [#1042](https://github.com/remoteoss/remote-flows/pull/1042)
+
 ## 1.34.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,21 @@
 
 ### Minor Changes
 
-- update remote-json-schema-form-kit to v0.0.12
-- add employer of record information (#1043) [#1043](https://github.com/remoteoss/remote-flows/pull/1043)
-- strip html tags (#1044) [#1044](https://github.com/remoteoss/remote-flows/pull/1044)
+#### Features
+
+- add employer of record information for pricingPlanDetails (#1043) [#1043](https://github.com/remoteoss/remote-flows/pull/1043)
+
+
+#### Fixes
+
+- strip html tags for meta.fields (#1044) [#1044](https://github.com/remoteoss/remote-flows/pull/1044)
 - fix maxDate for contractor of record (#1042) [#1042](https://github.com/remoteoss/remote-flows/pull/1042)
+
+
+#### Chores
+
+- update remote-json-schema-form-kit to v0.0.12
+
 
 ## 1.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,14 @@
 
 - add employer of record information for pricingPlanDetails (#1043) [#1043](https://github.com/remoteoss/remote-flows/pull/1043)
 
-
 #### Fixes
 
 - strip html tags for meta.fields (#1044) [#1044](https://github.com/remoteoss/remote-flows/pull/1044)
 - fix maxDate for contractor of record (#1042) [#1042](https://github.com/remoteoss/remote-flows/pull/1042)
 
-
 #### Chores
 
 - update remote-json-schema-form-kit to v0.0.12
-
 
 ## 1.34.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.34.0",
+      "version": "1.35.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.35.0

### Minor Changes

- update remote-json-schema-form-kit to v0.0.12 
- add employer of record information (#1043) [#1043](https://github.com/remoteoss/remote-flows/pull/1043)
- strip html tags (#1044) [#1044](https://github.com/remoteoss/remote-flows/pull/1044)
- fix maxDate for contractor of record (#1042) [#1042](https://github.com/remoteoss/remote-flows/pull/1042)

---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version and adds release notes, with no functional code changes included in the diff.
> 
> **Overview**
> **Release 1.35.0 metadata update.** Updates `package.json`/`package-lock.json` version from `1.34.0` to `1.35.0` and appends a `CHANGELOG.md` entry documenting the new feature/fix items and a dependency bump (`@remoteoss/remote-json-schema-form-kit` to `0.0.12`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e82f00b746d443c091fa20382aa137d16e2f791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->