### PR TITLE
chore(deps) - remove unused types

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -24,7 +24,6 @@
       },
       "devDependencies": {
         "@playwright/test": "1.59.1",
-        "@types/dompurify": "3.2.0",
         "@types/node": "24.12.4",
         "@types/react-dom": "19.2.3",
         "@types/react-syntax-highlighter": "15.5.13",
@@ -64,8 +63,8 @@
         "lodash.omit": "4.18.0",
         "lodash.omitby": "4.6.0",
         "lucide-react": "1.16.0",
-        "postcss": "8.5.10",
-        "react-day-picker": "8.10.1",
+        "postcss": "8.5.14",
+        "react-day-picker": "8.10.2",
         "react-flagpack": "2.0.6",
         "react-hook-form": "7.73.1",
         "tailwind-merge": "3.5.0",
@@ -618,9 +617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,9 +634,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,9 +651,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -678,9 +668,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -698,9 +685,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,9 +702,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -816,17 +797,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
       }
     },
     "node_modules/@types/hast": {

--- a/example/package.json
+++ b/example/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",
-    "@types/dompurify": "3.2.0",
     "@types/node": "24.12.4",
     "@types/react-dom": "19.2.3",
     "@types/react-syntax-highlighter": "15.5.13",


### PR DESCRIPTION
The package manager is saying is not needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only cleanup in the example package with no logic or security behavior changes.
> 
> **Overview**
> Removes the deprecated **`@types/dompurify`** dev dependency from the **example** app because **`dompurify`** already ships its own TypeScript definitions; runtime usage (e.g. in `transformHtml`) is unchanged.
> 
> The **`package-lock.json`** refresh drops the stub types package and includes minor transitive version bumps (e.g. **`postcss`**, **`react-day-picker`**) plus lockfile metadata cleanup for optional **`@rolldown`** Linux bindings—no application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4a1b9bef6c39b9527825958daefcea416bcaaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->