### PR TITLE
chore(deps) - update kit to latest

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -46,7 +46,7 @@
         "@radix-ui/react-scroll-area": "1.2.10",
         "@radix-ui/react-select": "2.2.6",
         "@radix-ui/react-tabs": "1.1.13",
-        "@remoteoss/remote-json-schema-form-kit": "0.0.12",
+        "@remoteoss/remote-json-schema-form-kit": "0.0.14",
         "@tailwindcss/cli": "4.2.4",
         "@tailwindcss/postcss": "4.2.4",
         "@tanstack/react-query": "5.100.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@radix-ui/react-scroll-area": "1.2.10",
         "@radix-ui/react-select": "2.2.6",
         "@radix-ui/react-tabs": "1.1.13",
-        "@remoteoss/remote-json-schema-form-kit": "0.0.12",
+        "@remoteoss/remote-json-schema-form-kit": "0.0.14",
         "@tailwindcss/cli": "4.2.4",
         "@tailwindcss/postcss": "4.2.4",
         "@tanstack/react-query": "5.100.9",
@@ -3424,9 +3424,9 @@
       "license": "MIT"
     },
     "node_modules/@remoteoss/json-schema-form": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@remoteoss/json-schema-form/-/json-schema-form-1.2.11.tgz",
-      "integrity": "sha512-LShJp6jxVoZPn/zI35ReJykznaUXydO3GdlUtDCVS9mzA4xdf9ElDl6NHP83SSNMsAT/EPrLd8yYoX8vxsS8hw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@remoteoss/json-schema-form/-/json-schema-form-1.2.12.tgz",
+      "integrity": "sha512-aJiN8/RWFZcVeUFHVg2p7RgGsvQg30ZmVyRBDoj7n84yJN7BgP/tUmFKDOXICls/YMn4bHOoDlxVjo6LTkPMgg==",
       "license": "MIT",
       "dependencies": {
         "json-logic-js": "^2.0.5"
@@ -3468,12 +3468,12 @@
       }
     },
     "node_modules/@remoteoss/remote-json-schema-form-kit": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@remoteoss/remote-json-schema-form-kit/-/remote-json-schema-form-kit-0.0.12.tgz",
-      "integrity": "sha512-FTBjriXwN2gqAmSWmEe7LltCnKLjeXNmQgU6yl+we+Ux7odJyKGzdUAc0Vj8uqgaCiN+S9h++KeCAL/ZCwCpeA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@remoteoss/remote-json-schema-form-kit/-/remote-json-schema-form-kit-0.0.14.tgz",
+      "integrity": "sha512-igYw4sbPH28FGq+5eAM3h6wDOA6gCx0NH1vLysE8ZgOhuUN2g5bepLoAoyU2609sj1s3FX5qDFBTEoip7E+WTg==",
       "license": "MIT",
       "dependencies": {
-        "@remoteoss/json-schema-form": "^1.2.11",
+        "@remoteoss/json-schema-form": "^1.2.12",
         "@remoteoss/json-schema-form-v0-deprecated": "npm:@remoteoss/json-schema-form@0.12.3-beta.0",
         "date-fns": "^4.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@radix-ui/react-scroll-area": "1.2.10",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-tabs": "1.1.13",
-    "@remoteoss/remote-json-schema-form-kit": "0.0.12",
+    "@remoteoss/remote-json-schema-form-kit": "0.0.14",
     "@tailwindcss/cli": "4.2.4",
     "@tailwindcss/postcss": "4.2.4",
     "@tanstack/react-query": "5.100.9",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> No local logic changes; risk is limited to upstream form-kit behavior in flows that use JSON Schema forms.
> 
> **Overview**
> Bumps **`@remoteoss/remote-json-schema-form-kit`** from **0.0.12** to **0.0.14** in the root `package.json` and refreshes **`package-lock.json`** and **`example/package-lock.json`**. The lockfiles also pull in **`@remoteoss/json-schema-form` 1.2.12** as the kit’s dependency (from 1.2.11). There are **no changes to `src/`** or other application code—only version pins and lockfile integrity hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aad10a956d19d911b1ef2dc66c94f3800713549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->