### PR TITLE
1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 - update dependency @playwright/test to v1.60.0 (#1055) [#1055](https://github.com/remoteoss/remote-flows/pull/1055)
 - update dependency @remoteoss/remote-json-schema-form-kit to v0.14.0 (#1060) [#1060](https://github.com/remoteoss/remote-flows/pull/1060)
 
-
 ## 1.35.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @remoteoss/remote-flows
 
+## 1.36.0
+
+### Minor Changes
+
+- order forn
+- update dependency vite to v8.0.13 (#1036) [#1036](https://github.com/remoteoss/remote-flows/pull/1036)
+- update dependency lucide-react to v1.16.0 (#983) [#983](https://github.com/remoteoss/remote-flows/pull/983)
+- update dependency @types/jsdom to v28.0.3 (#1047) [#1047](https://github.com/remoteoss/remote-flows/pull/1047)
+- update dependency dompurify to v3.4.5 (#1023) [#1023](https://github.com/remoteoss/remote-flows/pull/1023)
+- update dependency html-react-parser to v6.1.1 (#1029) [#1029](https://github.com/remoteoss/remote-flows/pull/1029)
+- update dependency react-day-picker to v8.10.2 (#1024) [#1024](https://github.com/remoteoss/remote-flows/pull/1024)
+- update dependency @types/node to v24.12.4 (#1048) [#1048](https://github.com/remoteoss/remote-flows/pull/1048)
+- update dependency postcss to v8.5.14 (#988) [#988](https://github.com/remoteoss/remote-flows/pull/988)
+- update dependency axios to v1.16.1 (#1054) [#1054](https://github.com/remoteoss/remote-flows/pull/1054)
+- update dependency @vitejs/plugin-react to v6.0.2 (#1050) [#1050](https://github.com/remoteoss/remote-flows/pull/1050)
+- update dependency msw to v2.14.6 (#1051) [#1051](https://github.com/remoteoss/remote-flows/pull/1051)
+- add time field input (#1046) [#1046](https://github.com/remoteoss/remote-flows/pull/1046)
+- update dependency @playwright/test to v1.60.0 (#1055) [#1055](https://github.com/remoteoss/remote-flows/pull/1055)
+
 ## 1.35.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Minor Changes
 
-- order forn
+#### Features
+
+- add time field input (#1046) [#1046](https://github.com/remoteoss/remote-flows/pull/1046)
+
+#### Chores
+
+- add e2e tests for onboarding (#1010) [#1010](https://github.com/remoteoss/remote-flows/pull/1010)
 - update dependency vite to v8.0.13 (#1036) [#1036](https://github.com/remoteoss/remote-flows/pull/1036)
 - update dependency lucide-react to v1.16.0 (#983) [#983](https://github.com/remoteoss/remote-flows/pull/983)
 - update dependency @types/jsdom to v28.0.3 (#1047) [#1047](https://github.com/remoteoss/remote-flows/pull/1047)
@@ -16,8 +22,9 @@
 - update dependency axios to v1.16.1 (#1054) [#1054](https://github.com/remoteoss/remote-flows/pull/1054)
 - update dependency @vitejs/plugin-react to v6.0.2 (#1050) [#1050](https://github.com/remoteoss/remote-flows/pull/1050)
 - update dependency msw to v2.14.6 (#1051) [#1051](https://github.com/remoteoss/remote-flows/pull/1051)
-- add time field input (#1046) [#1046](https://github.com/remoteoss/remote-flows/pull/1046)
 - update dependency @playwright/test to v1.60.0 (#1055) [#1055](https://github.com/remoteoss/remote-flows/pull/1055)
+- update dependency @remoteoss/remote-json-schema-form-kit to v0.14.0 (#1060) [#1060](https://github.com/remoteoss/remote-flows/pull/1060)
+
 
 ## 1.35.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.36.0

### Minor Changes

#### Features

- add time field input (#1046) [#1046](https://github.com/remoteoss/remote-flows/pull/1046)

#### Chores

- add e2e tests for onboarding (#1010) [#1010](https://github.com/remoteoss/remote-flows/pull/1010)
- update dependency vite to v8.0.13 (#1036) [#1036](https://github.com/remoteoss/remote-flows/pull/1036)
- update dependency lucide-react to v1.16.0 (#983) [#983](https://github.com/remoteoss/remote-flows/pull/983)
- update dependency @types/jsdom to v28.0.3 (#1047) [#1047](https://github.com/remoteoss/remote-flows/pull/1047)
- update dependency dompurify to v3.4.5 (#1023) [#1023](https://github.com/remoteoss/remote-flows/pull/1023)
- update dependency html-react-parser to v6.1.1 (#1029) [#1029](https://github.com/remoteoss/remote-flows/pull/1029)
- update dependency react-day-picker to v8.10.2 (#1024) [#1024](https://github.com/remoteoss/remote-flows/pull/1024)
- update dependency @types/node to v24.12.4 (#1048) [#1048](https://github.com/remoteoss/remote-flows/pull/1048)
- update dependency postcss to v8.5.14 (#988) [#988](https://github.com/remoteoss/remote-flows/pull/988)
- update dependency axios to v1.16.1 (#1054) [#1054](https://github.com/remoteoss/remote-flows/pull/1054)
- update dependency @vitejs/plugin-react to v6.0.2 (#1050) [#1050](https://github.com/remoteoss/remote-flows/pull/1050)
- update dependency msw to v2.14.6 (#1051) [#1051](https://github.com/remoteoss/remote-flows/pull/1051)
- update dependency @playwright/test to v1.60.0 (#1055) [#1055](https://github.com/remoteoss/remote-flows/pull/1055)
- update dependency @remoteoss/remote-json-schema-form-kit to v0.14.0 (#1060) [#1060](https://github.com/remoteoss/remote-flows/pull/1060)


---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version and changelog/lockfile metadata change in this PR; no application logic in the diff.
> 
> **Overview**
> Bumps **`@remoteoss/remote-flows`** from **1.35.0** to **1.36.0** in `package.json` and `package-lock.json`, and adds a **1.36.0** section to `CHANGELOG.md` that documents the release (not new implementation in this diff).
> 
> The changelog entry highlights **time field input** as the user-facing feature, plus onboarding e2e tests and a batch of dependency updates (e.g. Vite 8, Playwright, `remote-json-schema-form-kit`, axios, MSW). Consumers should treat this PR as a **publish/versioning** change; functional work landed in the linked PRs listed in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527dc2da3f6b7c27671c8e8be6138331458d6bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->