### PR TITLE
fix(multiselect): error when selecting a region

### DIFF
--- a/src/components/form/fields/tests/CountryField.test.tsx
+++ b/src/components/form/fields/tests/CountryField.test.tsx
@@ -253,4 +253,96 @@ describe('CountryField Component', () => {
       screen.queryByTestId('context-country-field'),
     ).not.toBeInTheDocument();
   });
+
+  it('selecting a region group selects every country inside the group', async () => {
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      options: [
+        { value: 'US', label: 'United States' },
+        { value: 'CA', label: 'Canada' },
+        { value: 'FR', label: 'France' },
+      ],
+      $meta: {
+        regions: {
+          'North America': ['US', 'CA'],
+        },
+        subregions: {},
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('combobox'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('option', { name: 'North America' }));
+    });
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith(['US', 'CA']);
+    });
+
+    expect(
+      screen.getByRole('button', { name: /remove United States/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /remove Canada/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /remove France/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clicking the same region group three times does not duplicate values', async () => {
+    renderWithFormContext({
+      ...defaultProps,
+      onChange: mockOnChange,
+      options: [
+        { value: 'US', label: 'United States' },
+        { value: 'CA', label: 'Canada' },
+      ],
+      $meta: {
+        regions: {
+          'North America': ['US', 'CA'],
+        },
+        subregions: {},
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('combobox'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    const groupOption = screen.getByRole('option', { name: 'North America' });
+
+    await act(async () => {
+      fireEvent.click(groupOption);
+    });
+    await act(async () => {
+      fireEvent.click(groupOption);
+    });
+    await act(async () => {
+      fireEvent.click(groupOption);
+    });
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith(['US', 'CA']);
+    });
+
+    expect(
+      screen.getAllByRole('button', { name: /remove United States/i }),
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByRole('button', { name: /remove Canada/i }),
+    ).toHaveLength(1);
+  });
 });

--- a/src/components/form/fields/tests/CountryField.test.tsx
+++ b/src/components/form/fields/tests/CountryField.test.tsx
@@ -271,20 +271,18 @@ describe('CountryField Component', () => {
       },
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('combobox'));
-    });
+    const select = screen.getByRole('combobox');
+    fireEvent.click(select);
 
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('option', { name: 'North America' }));
-    });
+    const option = screen.getByRole('option', { name: 'North America' });
+    fireEvent.click(option);
 
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenLastCalledWith(['US', 'CA']);
+      expect(mockOnChange).toHaveBeenCalledWith(['US', 'CA']);
     });
 
     expect(
@@ -314,28 +312,27 @@ describe('CountryField Component', () => {
       },
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('combobox'));
-    });
+    const select = screen.getByRole('combobox');
+    fireEvent.click(select);
 
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
 
-    const groupOption = screen.getByRole('option', { name: 'North America' });
+    const option = screen.getByRole('option', { name: 'North America' });
 
     await act(async () => {
-      fireEvent.click(groupOption);
+      fireEvent.click(option);
     });
     await act(async () => {
-      fireEvent.click(groupOption);
+      fireEvent.click(option);
     });
     await act(async () => {
-      fireEvent.click(groupOption);
+      fireEvent.click(option);
     });
 
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenLastCalledWith(['US', 'CA']);
+      expect(mockOnChange).toHaveBeenCalledWith(['US', 'CA']);
     });
 
     expect(

--- a/src/components/form/fields/tests/CountryField.test.tsx
+++ b/src/components/form/fields/tests/CountryField.test.tsx
@@ -321,15 +321,10 @@ describe('CountryField Component', () => {
 
     const option = screen.getByRole('option', { name: 'North America' });
 
-    await act(async () => {
-      fireEvent.click(option);
-    });
-    await act(async () => {
-      fireEvent.click(option);
-    });
-    await act(async () => {
-      fireEvent.click(option);
-    });
+    fireEvent.click(option);
+    fireEvent.click(option);
+    fireEvent.click(option);
+    fireEvent.click(option);
 
     await waitFor(() => {
       expect(mockOnChange).toHaveBeenCalledWith(['US', 'CA']);

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -122,12 +122,27 @@ export function MultiSelect({
                         <CommandItem
                           key={option.label}
                           onSelect={() => {
+                            let options = [option];
+
+                            if (Array.isArray(option.value)) {
+                              options = option.value.map((country: string) => ({
+                                label: country,
+                                value: country,
+                              }));
+                            }
+
                             onChange(
                               isSelected
                                 ? selected.filter(
                                     (item) => item.value !== option.value,
                                   )
-                                : [...selected, option],
+                                : [...selected, ...options].filter(
+                                    (item, index, self) =>
+                                      index ===
+                                      self.findIndex(
+                                        (i) => i.value === item.value,
+                                      ),
+                                  ),
                             );
                           }}
                         >

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -125,10 +125,12 @@ export function MultiSelect({
                             let options = [option];
 
                             if (Array.isArray(option.value)) {
-                              options = option.value.map((country: string) => ({
-                                label: country,
-                                value: country,
-                              }));
+                              options = option.value.map(
+                                (itemValue: string) => ({
+                                  label: itemValue,
+                                  value: itemValue,
+                                }),
+                              );
                             }
 
                             onChange(

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1071,10 +1071,18 @@ export const useContractorOnboarding = ({
         return;
       }
       case 'contract_details': {
+        const {
+          services_and_deliverables_ai_warning:
+            _servicesAndDeliverablesAiWarning,
+          services_and_deliverables_error_skippable:
+            _servicesAndDeliverablesErrorSkippable,
+          ...contractDetailsData
+        } = parsedValues;
+
         const shouldSkipAiChecks =
           fieldValues.services_and_deliverables_error_skippable === true;
         const payload: CreateContractDocument = {
-          contract_document: parsedValues,
+          contract_document: contractDetailsData,
           skip_ai_checks: shouldSkipAiChecks,
         };
 

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -686,6 +686,111 @@ describe('ContractorOnboardingFlow', () => {
     });
   });
 
+  it('should exclude AI warning fields from payload even after navigation', async () => {
+    const postContractDocumentSpy = vi.fn();
+
+    server.use(
+      http.post(
+        '*/v1/contractors/employments/*/contract-documents',
+        async ({ request }) => {
+          const requestBody = await request.json();
+          postContractDocumentSpy(requestBody);
+
+          if (postContractDocumentSpy.mock.calls.length === 1) {
+            return HttpResponse.json(
+              {
+                error: {
+                  errors: {
+                    services_and_deliverables: {
+                      error: ['Possible misclassification risk'],
+                      source: 'REMOTE_AI',
+                      skippable: true,
+                    },
+                  },
+                },
+              },
+              { status: 422 },
+            );
+          }
+
+          return HttpResponse.json(mockContractDocumentCreatedResponse);
+        },
+      ),
+    );
+
+    mockRender.mockImplementation(
+      createMockRenderImplementation(MultiStepFormWithoutCountry),
+    );
+
+    render(
+      <ContractorOnboardingFlow
+        {...defaultProps}
+        countryCode='PRT'
+        skipSteps={['select_country']}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+    await fillBasicInformation();
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+    await fillContractorSubscription();
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+    await fillContractDetails();
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Possible misclassification risk/i),
+      ).toBeInTheDocument();
+    });
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+    await screen.findByText(/Step: Contract Preview/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    const previousButton = screen.getByText(/Back/i);
+    previousButton.click();
+    await screen.findByText(/Step: Contract Details/i);
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await waitFor(() => {
+      expect(postContractDocumentSpy).toHaveBeenCalledTimes(3);
+
+      const thirdPayload = postContractDocumentSpy.mock.calls[2][0];
+
+      expect(thirdPayload.contract_document).not.toHaveProperty(
+        'services_and_deliverables_ai_warning',
+      );
+      expect(thirdPayload.contract_document).not.toHaveProperty(
+        'services_and_deliverables_error_skippable',
+      );
+
+      expect(thirdPayload.contract_document).toHaveProperty(
+        'services_and_deliverables',
+      );
+
+      // skip_ai_checks flag should work correctly (still true from previous error)
+      expect(thirdPayload.skip_ai_checks).toBe(true);
+    });
+  });
+
   it('should sign contract document when submitting contract preview', async () => {
     const signContractDocumentSpy = vi.fn();
 


### PR DESCRIPTION
**Problem**

Error when selecting regions or sub-regions on CountryField
<img width="1137" height="328" alt="Capture d’écran 2026-05-18 à 12 02 47" src="https://github.com/user-attachments/assets/ad19d296-8527-489e-b531-d5ca735dae07" />

**Solution**

CountryField uses multiselect ui component which is not equiped to receive array values. 
I have updated the code to support it, copying "Dragon" behaviour : 

- When clicking on a group (Region or SubRegion for this example), it select all the options presents inside the group. 
- When clicking again, nothing happens.

To avoid doublons, I clean the list when onChange. 

Finally I added tests to verify this two behaviors. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI selection logic and omitting client-only form fields from an existing API call; covered by new unit and flow tests.
> 
> **Overview**
> Fixes **CountryField** region/subregion selection by teaching **`MultiSelect`** to accept options whose `value` is a **string array**: choosing a group expands to all member countries, merges into the selection with **deduplication**, and repeated clicks on an already-selected group do not add duplicates.
> 
> On **contractor onboarding**, the **contract details** submit path now **strips** UI-only fields (`services_and_deliverables_ai_warning`, `services_and_deliverables_error_skippable`) from the `contract_document` API payload while still using the skippable flag for `skip_ai_checks`. **Tests** cover region multi-select behavior and payload shape after AI errors and back navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6994012b93ab5513ba97fd6d26003c835564e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->