### PR TITLE
fix(contract-details) - fix state to avoid having the AI endpoint response getting resubmitted

### DIFF
--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -723,6 +723,7 @@ export const useContractorOnboarding = ({
       ...hardcodedValues,
       ...onboardingInitialValues,
       ...employmentContractDetails,
+      ...stepState.values?.contract_details,
     };
 
     return getInitialValues(stepFields.contract_details, initialValues);
@@ -731,6 +732,7 @@ export const useContractorOnboarding = ({
     employmentContractDetails,
     onboardingInitialValues,
     employmentBasicInformation,
+    stepState.values?.contract_details,
   ]);
 
   const contractPreviewInitialValues = useMemo(() => {
@@ -1071,10 +1073,18 @@ export const useContractorOnboarding = ({
         return;
       }
       case 'contract_details': {
+        const {
+          services_and_deliverables_ai_warning:
+            _servicesAndDeliverablesAiWarning,
+          services_and_deliverables_error_skippable:
+            _servicesAndDeliverablesErrorSkippable,
+          ...contractDetailsData
+        } = parsedValues;
+
         const shouldSkipAiChecks =
           fieldValues.services_and_deliverables_error_skippable === true;
         const payload: CreateContractDocument = {
-          contract_document: parsedValues,
+          contract_document: contractDetailsData,
           skip_ai_checks: shouldSkipAiChecks,
         };
 

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -723,7 +723,6 @@ export const useContractorOnboarding = ({
       ...hardcodedValues,
       ...onboardingInitialValues,
       ...employmentContractDetails,
-      ...stepState.values?.contract_details,
     };
 
     return getInitialValues(stepFields.contract_details, initialValues);
@@ -732,7 +731,6 @@ export const useContractorOnboarding = ({
     employmentContractDetails,
     onboardingInitialValues,
     employmentBasicInformation,
-    stepState.values?.contract_details,
   ]);
 
   const contractPreviewInitialValues = useMemo(() => {

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -771,24 +771,23 @@ describe('ContractorOnboardingFlow', () => {
     nextButton.click();
 
     await waitFor(() => {
-      expect(postContractDocumentSpy).toHaveBeenCalledTimes(2);
+      expect(postContractDocumentSpy).toHaveBeenCalledTimes(3);
 
-      const secondPayload = postContractDocumentSpy.mock.calls[1][0];
+      const thirdPayload = postContractDocumentSpy.mock.calls[2][0];
 
-      expect(secondPayload.contract_document).not.toHaveProperty(
+      expect(thirdPayload.contract_document).not.toHaveProperty(
         'services_and_deliverables_ai_warning',
       );
-      expect(secondPayload.contract_document).not.toHaveProperty(
+      expect(thirdPayload.contract_document).not.toHaveProperty(
         'services_and_deliverables_error_skippable',
       );
 
-      // Real fields should still be there
-      expect(secondPayload.contract_document).toHaveProperty(
+      expect(thirdPayload.contract_document).toHaveProperty(
         'services_and_deliverables',
       );
 
-      // skip_ai_checks flag should work correctly
-      expect(secondPayload.skip_ai_checks).toBe(true);
+      // skip_ai_checks flag should work correctly (still true from previous error)
+      expect(thirdPayload.skip_ai_checks).toBe(true);
     });
   });
 

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -686,6 +686,112 @@ describe('ContractorOnboardingFlow', () => {
     });
   });
 
+  it('should exclude AI warning fields from payload even after navigation', async () => {
+    const postContractDocumentSpy = vi.fn();
+
+    server.use(
+      http.post(
+        '*/v1/contractors/employments/*/contract-documents',
+        async ({ request }) => {
+          const requestBody = await request.json();
+          postContractDocumentSpy(requestBody);
+
+          if (postContractDocumentSpy.mock.calls.length === 1) {
+            return HttpResponse.json(
+              {
+                error: {
+                  errors: {
+                    services_and_deliverables: {
+                      error: ['Possible misclassification risk'],
+                      source: 'REMOTE_AI',
+                      skippable: true,
+                    },
+                  },
+                },
+              },
+              { status: 422 },
+            );
+          }
+
+          return HttpResponse.json(mockContractDocumentCreatedResponse);
+        },
+      ),
+    );
+
+    mockRender.mockImplementation(
+      createMockRenderImplementation(MultiStepFormWithoutCountry),
+    );
+
+    render(
+      <ContractorOnboardingFlow
+        {...defaultProps}
+        countryCode='PRT'
+        skipSteps={['select_country']}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+    await fillBasicInformation();
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+    await fillContractorSubscription();
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+    await fillContractDetails();
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Details/i);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Possible misclassification risk/i),
+      ).toBeInTheDocument();
+    });
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+    await screen.findByText(/Step: Contract Preview/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    const previousButton = screen.getByText(/Back/i);
+    previousButton.click();
+    await screen.findByText(/Step: Contract Details/i);
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await waitFor(() => {
+      expect(postContractDocumentSpy).toHaveBeenCalledTimes(2);
+
+      const secondPayload = postContractDocumentSpy.mock.calls[1][0];
+
+      expect(secondPayload.contract_document).not.toHaveProperty(
+        'services_and_deliverables_ai_warning',
+      );
+      expect(secondPayload.contract_document).not.toHaveProperty(
+        'services_and_deliverables_error_skippable',
+      );
+
+      // Real fields should still be there
+      expect(secondPayload.contract_document).toHaveProperty(
+        'services_and_deliverables',
+      );
+
+      // skip_ai_checks flag should work correctly
+      expect(secondPayload.skip_ai_checks).toBe(true);
+    });
+  });
+
   it('should sign contract document when submitting contract preview', async () => {
     const signContractDocumentSpy = vi.fn();
 


### PR DESCRIPTION
Doing a quick fix to solve the issue at hand, we remove some hidden values from getting sent actually the problem is in the architecture we have some state not synced correctly when dealing with the forms

the hidden bugs are for the architecture, I'll explain them in a loom, we'll need to fix them someday

The loom is long as I am talking what are bugs in the architecture, we don't have a clear SSOT for the values state

https://www.loom.com/share/a38fcfaa0cf04ee4b6c690bc6ad375e3?focus_title=1&muted=1&from_recorder=1


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted payload shaping on contract document creation with test coverage; no auth or broad architectural changes.
> 
> **Overview**
> **Contract details** submissions no longer send client-only AI state on `POST` contract-documents: `services_and_deliverables_ai_warning` and `services_and_deliverables_error_skippable` are stripped from `contract_document` while **`skip_ai_checks`** still comes from `fieldValues` when the user may proceed after a skippable Remote AI error.
> 
> A regression test walks the flow through a skippable AI 422, forward to preview, **back** to contract details, and a third submit—asserting those two keys are absent from `contract_document` but `skip_ai_checks` stays `true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148959d7e3911ea42cdb8df852b7196f4dbf28ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->