### PR TITLE
fix(e2e) - fix onboarding tests

### DIFF
--- a/example/e2e/helpers/onboarding.ts
+++ b/example/e2e/helpers/onboarding.ts
@@ -98,6 +98,8 @@ interface fillOnboardingStep3SpainFormOptions {
   available_pto?: string;
   role_description?: string;
   experience_level?: string;
+  role_is_onsite?: string;
+  role_requires_license?: string;
   work_address_is_home_address?: string;
   annual_gross_salary?: string;
   annual_bonus_ack?: boolean;
@@ -163,6 +165,16 @@ export async function fillOnboardingStep3SpainForm(
       type: 'radio',
       value: options.experience_level,
       name: 'experience_level',
+    },
+    {
+      type: 'radio',
+      value: options.role_is_onsite,
+      name: 'role_is_onsite',
+    },
+    {
+      type: 'radio',
+      value: options.role_requires_license,
+      name: 'role_requires_license',
     },
     {
       type: 'radio',

--- a/example/e2e/onboard-basic-employee.spec.ts
+++ b/example/e2e/onboard-basic-employee.spec.ts
@@ -72,6 +72,8 @@ test.describe('Onboard basic employee', () => {
       has_social_security_number: 'yes',
       work_equipment: '200',
       compensation_expenses_ack: true,
+      role_is_onsite: 'yes',
+      role_requires_license: 'no',
     });
 
     stepTitle = page.getByTestId('onboarding-step-title');


### PR DESCRIPTION
Fix onboarding tests they were broken as I enabled a flag in sandbox

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes to Playwright helpers and a spec; no production application logic.
> 
> **Overview**
> Updates Playwright onboarding coverage so Spain **Contract Details** (step 3) fills two new required radio fields: `role_is_onsite` and `role_requires_license`.
> 
> The shared `fillOnboardingStep3SpainForm` helper gains optional options and `fillForm` entries for both fields. The basic employee e2e spec passes `role_is_onsite: 'yes'` and `role_requires_license: 'no'` when completing that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0a67f76e2a00105739350d0d4e6803a477302b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->