### PR TITLE
chore: prepare release v1.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 ### Patch Changes
 
+#### Fixes
+
+- fix state to avoid having the AI endpoint response getting resubmitted (#1066) [#1066](https://github.com/remoteoss/remote-flows/pull/1066)
+- fix error when selecting regions or sub-regions [#1065]https://github.com/remoteoss/remote-flows/pull/1065
+
+#### Chores
+
 - update CHANGELOG.md (#1063) [#1063](https://github.com/remoteoss/remote-flows/pull/1063)
-- fix state to avoid having the AI endpoint response getting resubmitted (#1066) [#1066](https://github.com/remoteoss/remote-flows/pull/1066)
-- fix state to avoid having the AI endpoint response getting resubmitted (#1066) [#1066](https://github.com/remoteoss/remote-flows/pull/1066)
+- fix onboarding e2e tests with new JSON schema [#1067]https://github.com/remoteoss/remote-flows/pull/1067
 
 ## 1.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @remoteoss/remote-flows
 
+## 1.36.1
+
+### Patch Changes
+
+- update CHANGELOG.md (#1063) [#1063](https://github.com/remoteoss/remote-flows/pull/1063)
+- fix state to avoid having the AI endpoint response getting resubmitted (#1066) [#1066](https://github.com/remoteoss/remote-flows/pull/1066)
+- fix state to avoid having the AI endpoint response getting resubmitted (#1066) [#1066](https://github.com/remoteoss/remote-flows/pull/1066)
+
 ## 1.36.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.36.1

### Patch Changes

#### Fixes

- fix state to avoid having the AI endpoint response getting resubmitted (#1066) [#1066](https://github.com/remoteoss/remote-flows/pull/1066)
- fix error when selecting regions or sub-regions [#1065]https://github.com/remoteoss/remote-flows/pull/1065

#### Chores

- update CHANGELOG.md (#1063) [#1063](https://github.com/remoteoss/remote-flows/pull/1063)
- fix onboarding e2e tests with new JSON schema [#1067]https://github.com/remoteoss/remote-flows/pull/1067


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version + changelog); no runtime code changes in this diff.
> 
> **Overview**
> **Release v1.36.1** bumps `@remoteoss/remote-flows` from **1.36.0** to **1.36.1** and adds a **1.36.1** section to `CHANGELOG.md`.
> 
> The changelog documents patch-level work already merged elsewhere: preventing **duplicate AI endpoint submissions** via state handling, fixing **region / sub-region selection** errors, and updating **onboarding e2e** tests for a new JSON schema. This PR does not change application source—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b419c2aeaf8c8fcfab3511c861c3f29e3770358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->