### PR TITLE
fix(contractor-onboarding) - handle empty pricing plans

### DIFF
--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -350,25 +350,27 @@ const useEorSubscription = (options?: { enabled?: boolean }) => {
     (plan) => plan.product.name === 'EOR Monthly',
   );
 
-  const eorSubscription = {
-    product: {
-      identifier: eorProductIdentifier,
-      short_name: 'EOR',
-    },
-    currency: eorPricingPlan?.price.currency,
-    price: {
-      amount: convertFromCents(eorPricingPlan?.price.amount ?? 0),
-    },
-    features: [
-      'Contract between Remote and employee',
-      'Remote manages onboarding, payroll, and compliance',
-      'Manages taxes, benefits, and time-off tracking',
-      'Handles contracts, transfers, and terminations',
-    ],
-    description: 'Enables hiring in countries without a local entity',
-    label: 'Employer of Record',
-    value: eorProductIdentifier,
-  };
+  const eorSubscription = eorPricingPlan
+    ? {
+        product: {
+          identifier: eorProductIdentifier,
+          short_name: 'EOR',
+        },
+        currency: eorPricingPlan.price.currency,
+        price: {
+          amount: convertFromCents(eorPricingPlan.price.amount),
+        },
+        features: [
+          'Contract between Remote and employee',
+          'Remote manages onboarding, payroll, and compliance',
+          'Manages taxes, benefits, and time-off tracking',
+          'Handles contracts, transfers, and terminations',
+        ],
+        description: 'Enables hiring in countries without a local entity',
+        label: 'Employer of Record',
+        value: eorProductIdentifier,
+      }
+    : null;
 
   return { eorSubscription, isLoading: isLoadingPricingPlans };
 };
@@ -384,7 +386,10 @@ const addEorToFieldOptions = (
   eorSubscription: ReturnType<typeof useEorSubscription>['eorSubscription'],
   excludeProducts?: ProductType[],
 ) => {
-  if (shouldIncludeProduct(eorProductIdentifier, excludeProducts)) {
+  if (
+    eorSubscription &&
+    shouldIncludeProduct(eorProductIdentifier, excludeProducts)
+  ) {
     fieldOptions.push({
       label: eorSubscription.label,
       value: eorSubscription.value,

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -462,7 +462,8 @@ export const useContractorSubscriptionSchemaField = (
     });
 
   const hasAvailableOptions =
-    filteredContractorSubscriptions.length > 0 || showEorSubscription;
+    filteredContractorSubscriptions.length > 0 ||
+    (showEorSubscription && eorSubscription !== null);
 
   const form = createHeadlessForm(
     selectContractorSubscriptionStepSchema.data.schema,

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -2656,6 +2656,62 @@ describe('ContractorOnboardingFlow', () => {
         expect(eorOption).toBeChecked();
       });
     });
+
+    it('should not show Employer of Record option when pricing plans is empty', async () => {
+      server.use(
+        http.get('*/v1/countries', () => {
+          return HttpResponse.json({
+            data: [
+              {
+                code: 'PRT',
+                name: 'Portugal',
+                eor_onboarding: true,
+              },
+            ],
+          });
+        }),
+        http.get(
+          '*/v1/contractors/employments/*/contractor-subscriptions',
+          () => {
+            return HttpResponse.json(mockCMOnlyResponse);
+          },
+        ),
+        http.get('*/v1/companies/*/pricing-plans', () => {
+          return HttpResponse.json({
+            data: {
+              pricing_plans: [],
+            },
+          });
+        }),
+      );
+
+      mockRender.mockImplementation(
+        createMockRenderImplementation(MultiStepFormWithoutCountry),
+      );
+
+      render(
+        <ContractorOnboardingFlow
+          {...defaultProps}
+          countryCode='PRT'
+          skipSteps={['select_country']}
+        />,
+        { wrapper: TestProviders },
+      );
+
+      await screen.findByText(/Step: Basic Information/i);
+      await fillBasicInformation();
+
+      const nextButton = screen.getByText(/Next Step/i);
+      nextButton.click();
+
+      await screen.findByText(/Step: Pricing Plan/i);
+      await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+      const eorOption = screen.queryByRole('radio', {
+        name: /Employer of Record/i,
+      });
+      expect(eorOption).not.toBeInTheDocument();
+    });
   });
 
   describe('COR Contract Preview Skip', () => {


### PR DESCRIPTION
The SDK could break if pricing-plans endpoints returns empty for a company. I fixed that

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to pricing-plan option building and form required-state; covered by a new integration test.
> 
> **Overview**
> Fixes contractor onboarding **Pricing Plan** when company **pricing plans** return no **EOR Monthly** plan: **Employer of Record** is no longer offered with placeholder pricing.
> 
> `useEorSubscription` now returns **`null`** instead of a synthetic EOR object when the plan is missing. EOR is only added to subscription options and counted toward **has available options** when that data exists. A test asserts EOR is hidden when `pricing_plans` is empty but EOR onboarding would otherwise apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702a12e3262ea23be92d917423a1c6c916b6edc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->