### PR TITLE
1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 - add pre onboarding requirements block (#1064) [#1064](https://github.com/remoteoss/remote-flows/pull/1064)
 
-#### Fixes
+#### Fixes
 
 - handle empty pricing plans (#1069) [#1069](https://github.com/remoteoss/remote-flows/pull/1069)
 
-#### Refactors
+#### Refactors
 
 - migrate to v2 engagement agreement endpoints (#1070) [#1070](https://github.com/remoteoss/remote-flows/pull/1070)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @remoteoss/remote-flows
 
+## 1.37.0
+
+### Minor Changes
+
+- migrate to v2 engagement agreement endpoints (#1070) [#1070](https://github.com/remoteoss/remote-flows/pull/1070)
+- handle empty pricing plans (#1069) [#1069](https://github.com/remoteoss/remote-flows/pull/1069)
+- add pre onboarding requirements block (#1064) [#1064](https://github.com/remoteoss/remote-flows/pull/1064)
+
 ## 1.36.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@
 
 ### Minor Changes
 
-- migrate to v2 engagement agreement endpoints (#1070) [#1070](https://github.com/remoteoss/remote-flows/pull/1070)
-- handle empty pricing plans (#1069) [#1069](https://github.com/remoteoss/remote-flows/pull/1069)
+#### Features
+
 - add pre onboarding requirements block (#1064) [#1064](https://github.com/remoteoss/remote-flows/pull/1064)
+
+#### Fixes
+
+- handle empty pricing plans (#1069) [#1069](https://github.com/remoteoss/remote-flows/pull/1069)
+
+#### Refactors
+
+- migrate to v2 engagement agreement endpoints (#1070) [#1070](https://github.com/remoteoss/remote-flows/pull/1070)
 
 ## 1.36.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.36.0",
+      "version": "1.37.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.36.1",
+  "version": "1.37.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.37.0

### Minor Changes


#### Features

- add pre onboarding requirements block (#1064) [#1064](https://github.com/remoteoss/remote-flows/pull/1064)

#### Fixes

- handle empty pricing plans (#1069) [#1069](https://github.com/remoteoss/remote-flows/pull/1069)

#### Refactors

- migrate to v2 engagement agreement endpoints (#1070) [#1070](https://github.com/remoteoss/remote-flows/pull/1070)

---

This release was automatically generated from conventional commits.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor release bundles onboarding document signing, pricing edge cases, and API path changes for engagement agreement data; integration regressions are possible though the PR diff is low-risk metadata only.
> 
> **Overview**
> **Release 1.37.0** — bumps `@remoteoss/remote-flows` from **1.36.1** to **1.37.0** in `package.json` / `package-lock.json` and documents the minor release in `CHANGELOG.md`. The diff is packaging-only; the shipped behavior comes from the merged changes listed there.
> 
> **Pre-onboarding requirements** adds a **`PreOnboardingRequirements`** block on employer onboarding (requirements list, document preview/signing via `PreOnboardingRequirementsBag`).
> 
> **Pricing** fixes handling when the API returns **no pricing plans** (contractor onboarding plan selection).
> 
> **Engagement agreement** refactors Germany (and related) flows to use **`/v2/employments/{id}/engagement-agreement-details`** instead of the previous v1 employment endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd5bc71f88af81516db8a79e94c4fccfc69f704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->