### PR TITLE
feat(gp): GP SDK foundation — shared hooks and flow scaffolding

### DIFF
--- a/src/common/api/gpOnboarding.ts
+++ b/src/common/api/gpOnboarding.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getV1CompaniesCompanyIdLegalEntities,
+  getV1EmploymentsEmploymentIdOnboardingSteps,
+} from '@/src/client';
+import { Client } from '@/src/client/client';
+import { useClient } from '@/src/context';
+
+export const useGPOnboardingSteps = (employmentId: string | undefined) => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['gp-onboarding-steps', employmentId],
+    enabled: !!employmentId,
+    retry: false,
+    queryFn: async () => {
+      const response = await getV1EmploymentsEmploymentIdOnboardingSteps({
+        client: client as Client,
+        headers: { Authorization: `` },
+        path: { employment_id: employmentId as string },
+      });
+
+      if (response.error || !response.data) {
+        throw new Error('Failed to fetch onboarding steps');
+      }
+
+      return response.data;
+    },
+    select: (data) => data.data.steps,
+  });
+};
+
+export const useGPLegalEntities = (companyId: string | undefined) => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['gp-legal-entities', companyId],
+    enabled: !!companyId,
+    retry: false,
+    queryFn: async () => {
+      const response = await getV1CompaniesCompanyIdLegalEntities({
+        client: client as Client,
+        headers: { Authorization: `` },
+        path: { company_id: companyId as string },
+      });
+
+      if (response.error || !response.data) {
+        throw new Error('Failed to fetch legal entities');
+      }
+
+      return response.data;
+    },
+    select: (data) =>
+      (data.data?.legal_entities ?? []).filter(
+        (le) => le.global_payroll_enabled,
+      ),
+  });
+};

--- a/src/flows/PayrollAdminOnboarding/PayrollAdminOnboardingFlow.tsx
+++ b/src/flows/PayrollAdminOnboarding/PayrollAdminOnboardingFlow.tsx
@@ -1,0 +1,49 @@
+import { useId } from 'react';
+import { usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding/hooks';
+import { PayrollAdminOnboardingContext } from '@/src/flows/PayrollAdminOnboarding/context';
+import type { PayrollAdminOnboardingFlowProps } from '@/src/flows/PayrollAdminOnboarding/types';
+
+// Stable module-level references — prevents consumer subtrees from unmounting on parent re-renders.
+// Each will be replaced with a real implementation in PBYR-4044.
+const SelectCountryStep = () => null;
+const ContractDetailsStep = () => null;
+const AdministrativeDetailsStep = () => null;
+const InvitationStep = () => null;
+const SubmitButton = () => null;
+const BackButton = () => null;
+
+export const PayrollAdminOnboardingFlow = ({
+  companyId,
+  legalEntityId,
+  countryCode,
+  employmentId,
+  initialValues,
+  options,
+  render,
+}: PayrollAdminOnboardingFlowProps) => {
+  const formId = useId();
+  const adminBag = usePayrollAdminOnboarding({
+    companyId,
+    legalEntityId,
+    countryCode,
+    employmentId,
+    initialValues,
+    options,
+  });
+
+  return (
+    <PayrollAdminOnboardingContext.Provider value={{ formId, adminBag }}>
+      {render({
+        adminBag,
+        components: {
+          SelectCountryStep,
+          ContractDetailsStep,
+          AdministrativeDetailsStep,
+          InvitationStep,
+          SubmitButton,
+          BackButton,
+        },
+      })}
+    </PayrollAdminOnboardingContext.Provider>
+  );
+};

--- a/src/flows/PayrollAdminOnboarding/context.ts
+++ b/src/flows/PayrollAdminOnboarding/context.ts
@@ -1,0 +1,23 @@
+import type { usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding/hooks';
+import { createContext, useContext } from 'react';
+
+export const PayrollAdminOnboardingContext = createContext<{
+  formId: string | undefined;
+  adminBag: ReturnType<typeof usePayrollAdminOnboarding> | null;
+}>({
+  formId: undefined,
+  adminBag: null,
+});
+
+export const usePayrollAdminOnboardingContext = () => {
+  const context = useContext(PayrollAdminOnboardingContext);
+  if (!context.formId || !context.adminBag) {
+    throw new Error(
+      'usePayrollAdminOnboardingContext must be used within a PayrollAdminOnboardingFlow',
+    );
+  }
+  return context as {
+    formId: string;
+    adminBag: ReturnType<typeof usePayrollAdminOnboarding>;
+  };
+};

--- a/src/flows/PayrollAdminOnboarding/hooks.tsx
+++ b/src/flows/PayrollAdminOnboarding/hooks.tsx
@@ -1,0 +1,96 @@
+import { useState, useMemo, useCallback } from 'react';
+import { useGPOnboardingSteps } from '@/src/common/api/gpOnboarding';
+import { useStepState } from '@/src/flows/useStepState';
+import type { Step } from '@/src/flows/useStepState';
+import type { PayrollAdminOnboardingFlowProps } from '@/src/flows/PayrollAdminOnboarding/types';
+import { useErrorReporting } from '@/src/components/error-handling/useErrorReporting';
+
+export type AdminStepKey =
+  | 'select_country'
+  | 'contract_details'
+  | 'administrative_details'
+  | 'invite';
+
+const buildAdminSteps = (
+  skipCountry: boolean,
+): Record<AdminStepKey, Step<AdminStepKey>> => {
+  let index = 0;
+  return {
+    select_country: {
+      index: index++,
+      name: 'select_country',
+      visible: !skipCountry,
+    },
+    contract_details: { index: index++, name: 'contract_details' },
+    administrative_details: {
+      index: index++,
+      name: 'administrative_details',
+    },
+    invite: { index: index++, name: 'invite' },
+  };
+};
+
+export const usePayrollAdminOnboarding = ({
+  companyId,
+  legalEntityId,
+  countryCode: initialCountryCode,
+  employmentId: initialEmploymentId,
+  initialValues,
+  options,
+}: Omit<PayrollAdminOnboardingFlowProps, 'render'>) => {
+  const [internalEmploymentId, setInternalEmploymentId] = useState<
+    string | undefined
+  >(initialEmploymentId);
+
+  const [internalCountryCode, setInternalCountryCode] = useState<
+    string | undefined
+  >(initialCountryCode);
+
+  // Fix: derive from state, not from the prop, so setInternalCountryCode changes are reflected
+  const skipCountry = !!internalCountryCode;
+
+  // Fix: memoize to avoid allocating a new object on every render
+  const steps = useMemo(() => buildAdminSteps(skipCountry), [skipCountry]);
+
+  const { updateErrorContext } = useErrorReporting({ flow: 'payroll_admin_onboarding' });
+
+  const onStepChange = useCallback(
+    (step: Step<AdminStepKey>) => {
+      updateErrorContext({ step: step.name });
+    },
+    [updateErrorContext],
+  );
+
+  const { stepState, nextStep, previousStep, goToStep, setStepValues } =
+    useStepState<AdminStepKey>(steps, onStepChange);
+
+  const {
+    data: apiSteps,
+    isLoading: isLoadingSteps,
+    refetch: refetchSteps,
+  } = useGPOnboardingSteps(internalEmploymentId);
+
+  const isComplete =
+    apiSteps?.find((s) => s.type === 'completion')?.sub_steps?.[0]?.status ===
+    'completed';
+
+  return {
+    stepState,
+    isLoading: isLoadingSteps,
+    isComplete: isComplete ?? false,
+    companyId,
+    legalEntityId,
+    countryCode: internalCountryCode,
+    employmentId: internalEmploymentId,
+    initialValues,
+    options,
+    apiSteps,
+    setInternalEmploymentId,
+    setInternalCountryCode,
+    refetchSteps,
+    goToNextStep: nextStep,
+    goToPreviousStep: previousStep,
+    goToStep,
+    setStepValues,
+  };
+};

--- a/src/flows/PayrollAdminOnboarding/hooks.tsx
+++ b/src/flows/PayrollAdminOnboarding/hooks.tsx
@@ -52,7 +52,9 @@ export const usePayrollAdminOnboarding = ({
   // Fix: memoize to avoid allocating a new object on every render
   const steps = useMemo(() => buildAdminSteps(skipCountry), [skipCountry]);
 
-  const { updateErrorContext } = useErrorReporting({ flow: 'payroll_admin_onboarding' });
+  const { updateErrorContext } = useErrorReporting({
+    flow: 'payroll_admin_onboarding',
+  });
 
   const onStepChange = useCallback(
     (step: Step<AdminStepKey>) => {

--- a/src/flows/PayrollAdminOnboarding/index.ts
+++ b/src/flows/PayrollAdminOnboarding/index.ts
@@ -1,0 +1,6 @@
+export { PayrollAdminOnboardingFlow } from './PayrollAdminOnboardingFlow';
+export { usePayrollAdminOnboarding } from './hooks';
+export type {
+  PayrollAdminOnboardingFlowProps,
+  PayrollAdminOnboardingRenderProps,
+} from './types';

--- a/src/flows/PayrollAdminOnboarding/types.ts
+++ b/src/flows/PayrollAdminOnboarding/types.ts
@@ -1,0 +1,33 @@
+import { FlowOptions } from '@/src/flows/types';
+import { usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding/hooks';
+
+// Step component prop types are intentionally empty for this scaffold — PBYR-4044 will
+// replace these with typed props once each step component is implemented.
+type StepComponentType = React.ComponentType<Record<string, never>>;
+
+export type PayrollAdminOnboardingRenderProps = {
+  adminBag: ReturnType<typeof usePayrollAdminOnboarding>;
+  components: {
+    SelectCountryStep: StepComponentType;
+    ContractDetailsStep: StepComponentType;
+    AdministrativeDetailsStep: StepComponentType;
+    InvitationStep: StepComponentType;
+    SubmitButton: StepComponentType;
+    BackButton: StepComponentType;
+  };
+};
+
+export type PayrollAdminOnboardingFlowProps = {
+  /** UUID of the company. */
+  companyId: string;
+  /** UUID of the GP-enabled legal entity (required for GP employment creation). */
+  legalEntityId: string;
+  /** Optional. Pre-select country and skip country selection. */
+  countryCode?: string;
+  /** Optional. Resume an existing in-progress GP employment. */
+  employmentId?: string;
+  /** Optional. Pre-populate form fields. Server data overrides these. */
+  initialValues?: Record<string, unknown>;
+  options?: Omit<FlowOptions, 'jsfModify' | 'jsonSchemaVersion'>;
+  render: (props: PayrollAdminOnboardingRenderProps) => React.ReactNode;
+};

--- a/src/flows/PayrollEmployeeOnboarding/PayrollEmployeeOnboardingFlow.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/PayrollEmployeeOnboardingFlow.tsx
@@ -1,0 +1,41 @@
+import { useId } from 'react';
+import { usePayrollEmployeeOnboarding } from '@/src/flows/PayrollEmployeeOnboarding/hooks';
+import { PayrollEmployeeOnboardingContext } from '@/src/flows/PayrollEmployeeOnboarding/context';
+import type { PayrollEmployeeOnboardingFlowProps } from '@/src/flows/PayrollEmployeeOnboarding/types';
+
+// Stable module-level references — prevents consumer subtrees from unmounting on parent re-renders.
+// Each will be replaced with a real implementation in PBYR-4045.
+const PersonalDetailsStep = () => null;
+const HomeAddressStep = () => null;
+const BankAccountStep = () => null;
+const SubmitButton = () => null;
+const BackButton = () => null;
+
+export const PayrollEmployeeOnboardingFlow = ({
+  employmentId,
+  initialValues,
+  options,
+  render,
+}: PayrollEmployeeOnboardingFlowProps) => {
+  const formId = useId();
+  const employeeBag = usePayrollEmployeeOnboarding({
+    employmentId,
+    initialValues,
+    options,
+  });
+
+  return (
+    <PayrollEmployeeOnboardingContext.Provider value={{ formId, employeeBag }}>
+      {render({
+        employeeBag,
+        components: {
+          PersonalDetailsStep,
+          HomeAddressStep,
+          BankAccountStep,
+          SubmitButton,
+          BackButton,
+        },
+      })}
+    </PayrollEmployeeOnboardingContext.Provider>
+  );
+};

--- a/src/flows/PayrollEmployeeOnboarding/context.ts
+++ b/src/flows/PayrollEmployeeOnboarding/context.ts
@@ -1,0 +1,23 @@
+import type { usePayrollEmployeeOnboarding } from '@/src/flows/PayrollEmployeeOnboarding/hooks';
+import { createContext, useContext } from 'react';
+
+export const PayrollEmployeeOnboardingContext = createContext<{
+  formId: string | undefined;
+  employeeBag: ReturnType<typeof usePayrollEmployeeOnboarding> | null;
+}>({
+  formId: undefined,
+  employeeBag: null,
+});
+
+export const usePayrollEmployeeOnboardingContext = () => {
+  const context = useContext(PayrollEmployeeOnboardingContext);
+  if (!context.formId || !context.employeeBag) {
+    throw new Error(
+      'usePayrollEmployeeOnboardingContext must be used within a PayrollEmployeeOnboardingFlow',
+    );
+  }
+  return context as {
+    formId: string;
+    employeeBag: ReturnType<typeof usePayrollEmployeeOnboarding>;
+  };
+};

--- a/src/flows/PayrollEmployeeOnboarding/hooks.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/hooks.tsx
@@ -24,7 +24,9 @@ export const usePayrollEmployeeOnboarding = ({
   initialValues,
   options,
 }: Omit<PayrollEmployeeOnboardingFlowProps, 'render'>) => {
-  const { updateErrorContext } = useErrorReporting({ flow: 'payroll_employee_onboarding' });
+  const { updateErrorContext } = useErrorReporting({
+    flow: 'payroll_employee_onboarding',
+  });
 
   const onStepChange = useCallback(
     (step: Step<EmployeeStepKey>) => {
@@ -36,8 +38,11 @@ export const usePayrollEmployeeOnboarding = ({
   const { stepState, nextStep, previousStep, goToStep, setStepValues } =
     useStepState<EmployeeStepKey>(EMPLOYEE_STEPS, onStepChange);
 
-  const { data: apiSteps, isLoading, refetch: refetchSteps } =
-    useGPOnboardingSteps(employmentId);
+  const {
+    data: apiSteps,
+    isLoading,
+    refetch: refetchSteps,
+  } = useGPOnboardingSteps(employmentId);
 
   const selfOnboardingSubsteps = useMemo(() => {
     const selfOnboarding = apiSteps?.find((s) => s.type === 'self_onboarding');

--- a/src/flows/PayrollEmployeeOnboarding/hooks.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/hooks.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useCallback } from 'react';
+import { useGPOnboardingSteps } from '@/src/common/api/gpOnboarding';
+import { useStepState } from '@/src/flows/useStepState';
+import type { Step } from '@/src/flows/useStepState';
+import type { PayrollEmployeeOnboardingFlowProps } from '@/src/flows/PayrollEmployeeOnboarding/types';
+import { useErrorReporting } from '@/src/components/error-handling/useErrorReporting';
+
+export type EmployeeStepKey =
+  | 'personal_details'
+  | 'home_address'
+  | 'bank_account';
+
+// Steps are stable — visibility of bank_account is not derived from loaded data here.
+// Consumers check selfOnboardingSubsteps to determine whether the bank_account step
+// applies to the employment; the BankAccountStep component handles its own no-op case.
+const EMPLOYEE_STEPS: Record<EmployeeStepKey, Step<EmployeeStepKey>> = {
+  personal_details: { index: 0, name: 'personal_details' },
+  home_address: { index: 1, name: 'home_address' },
+  bank_account: { index: 2, name: 'bank_account' },
+};
+
+export const usePayrollEmployeeOnboarding = ({
+  employmentId,
+  initialValues,
+  options,
+}: Omit<PayrollEmployeeOnboardingFlowProps, 'render'>) => {
+  const { updateErrorContext } = useErrorReporting({ flow: 'payroll_employee_onboarding' });
+
+  const onStepChange = useCallback(
+    (step: Step<EmployeeStepKey>) => {
+      updateErrorContext({ step: step.name });
+    },
+    [updateErrorContext],
+  );
+
+  const { stepState, nextStep, previousStep, goToStep, setStepValues } =
+    useStepState<EmployeeStepKey>(EMPLOYEE_STEPS, onStepChange);
+
+  const { data: apiSteps, isLoading, refetch: refetchSteps } =
+    useGPOnboardingSteps(employmentId);
+
+  const selfOnboardingSubsteps = useMemo(() => {
+    const selfOnboarding = apiSteps?.find((s) => s.type === 'self_onboarding');
+    return selfOnboarding?.sub_steps ?? [];
+  }, [apiSteps]);
+
+  const isComplete =
+    apiSteps?.find((s) => s.type === 'completion')?.sub_steps?.[0]?.status ===
+    'completed';
+
+  return {
+    stepState,
+    isLoading,
+    isComplete: isComplete ?? false,
+    employmentId,
+    initialValues,
+    options,
+    apiSteps,
+    selfOnboardingSubsteps,
+    refetchSteps,
+    goToNextStep: nextStep,
+    goToPreviousStep: previousStep,
+    goToStep,
+    setStepValues,
+  };
+};

--- a/src/flows/PayrollEmployeeOnboarding/index.ts
+++ b/src/flows/PayrollEmployeeOnboarding/index.ts
@@ -1,0 +1,6 @@
+export { PayrollEmployeeOnboardingFlow } from './PayrollEmployeeOnboardingFlow';
+export { usePayrollEmployeeOnboarding } from './hooks';
+export type {
+  PayrollEmployeeOnboardingFlowProps,
+  PayrollEmployeeOnboardingRenderProps,
+} from './types';

--- a/src/flows/PayrollEmployeeOnboarding/types.ts
+++ b/src/flows/PayrollEmployeeOnboarding/types.ts
@@ -1,0 +1,27 @@
+import { FlowOptions } from '@/src/flows/types';
+import { usePayrollEmployeeOnboarding } from '@/src/flows/PayrollEmployeeOnboarding/hooks';
+
+// Step component prop types are intentionally empty for this scaffold — PBYR-4045 will
+// replace these with typed props once each step component is implemented.
+type StepComponentType = React.ComponentType<Record<string, never>>;
+
+export type PayrollEmployeeOnboardingRenderProps = {
+  employeeBag: ReturnType<typeof usePayrollEmployeeOnboarding>;
+  components: {
+    PersonalDetailsStep: StepComponentType;
+    HomeAddressStep: StepComponentType;
+    /** Check employeeBag.selfOnboardingSubsteps to determine if bank account is required. */
+    BankAccountStep: StepComponentType;
+    SubmitButton: StepComponentType;
+    BackButton: StepComponentType;
+  };
+};
+
+export type PayrollEmployeeOnboardingFlowProps = {
+  /** UUID of the employment, scoped to the employee token. */
+  employmentId: string;
+  /** Optional. Pre-populate form fields. */
+  initialValues?: Record<string, unknown>;
+  options?: Omit<FlowOptions, 'jsfModify' | 'jsonSchemaVersion'>;
+  render: (props: PayrollEmployeeOnboardingRenderProps) => React.ReactNode;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,13 +87,19 @@ export type {
 
 export type { ContractPreviewStatementProps } from '@/src/flows/ContractorOnboarding/components/ContractPreviewStatement';
 
-export { PayrollAdminOnboardingFlow, usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding';
+export {
+  PayrollAdminOnboardingFlow,
+  usePayrollAdminOnboarding,
+} from '@/src/flows/PayrollAdminOnboarding';
 export type {
   PayrollAdminOnboardingFlowProps,
   PayrollAdminOnboardingRenderProps,
 } from '@/src/flows/PayrollAdminOnboarding';
 
-export { PayrollEmployeeOnboardingFlow, usePayrollEmployeeOnboarding } from '@/src/flows/PayrollEmployeeOnboarding';
+export {
+  PayrollEmployeeOnboardingFlow,
+  usePayrollEmployeeOnboarding,
+} from '@/src/flows/PayrollEmployeeOnboarding';
 export type {
   PayrollEmployeeOnboardingFlowProps,
   PayrollEmployeeOnboardingRenderProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,20 @@ export type {
 
 export type { ContractPreviewStatementProps } from '@/src/flows/ContractorOnboarding/components/ContractPreviewStatement';
 
+export { PayrollAdminOnboardingFlow, usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding';
+export type {
+  PayrollAdminOnboardingFlowProps,
+  PayrollAdminOnboardingRenderProps,
+} from '@/src/flows/PayrollAdminOnboarding';
+
+export { PayrollEmployeeOnboardingFlow, usePayrollEmployeeOnboarding } from '@/src/flows/PayrollEmployeeOnboarding';
+export type {
+  PayrollEmployeeOnboardingFlowProps,
+  PayrollEmployeeOnboardingRenderProps,
+} from '@/src/flows/PayrollEmployeeOnboarding';
+
+export { useGPLegalEntities } from '@/src/common/api/gpOnboarding';
+
 export { CreateCompanyFlow } from '@/src/flows/CreateCompany';
 export type {
   CreateCompanyFlowProps,


### PR DESCRIPTION
## Summary

- Adds `useGPLegalEntities(companyId)` — public hook that fetches GP-enabled legal entities for a company
- Adds `useGPOnboardingSteps(employmentId)` — internal shared hook used by both GP flows
- Scaffolds `PayrollAdminOnboardingFlow` and `PayrollEmployeeOnboardingFlow` with types, context, hooks, and flow containers (step components are stubs; real implementations land in PBYR-4044 and PBYR-4045)
- Wires both flows into `src/index.tsx` and `package.json` exports map

Closes PBYR-4043 · Part of PBYR-3935

## Test plan

- [x] `npm run type-check` passes
- [x] `npm test -- --run` passes (781 tests)
- [x] `npm run build` produces `dist/flows/PayrollAdminOnboarding/` and `dist/flows/PayrollEmployeeOnboarding/`
- [x] Both flows and `useGPLegalEntities` are importable from `@remoteoss/remote-flows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)