### PR TITLE
fix(contractor-onboarding): handle array-wrapped AI validation error from backend

### DIFF
--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -979,8 +979,13 @@ export const useContractorOnboarding = ({
       return null;
     }
 
-    const servicesAndDeliverablesError = error.normalizedErrors
-      .services_and_deliverables as
+    const rawError = error.normalizedErrors.services_and_deliverables;
+
+    // The backend's normalize_errors wraps non-list values in an array,
+    // so the AI validation error object arrives as a single-element array.
+    const servicesAndDeliverablesError = (
+      Array.isArray(rawError) ? rawError[0] : rawError
+    ) as
       | {
           error: string[];
           source: string;

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -699,15 +699,16 @@ describe('ContractorOnboardingFlow', () => {
           if (postContractDocumentSpy.mock.calls.length === 1) {
             return HttpResponse.json(
               {
-                error: {
-                  errors: {
-                    services_and_deliverables: {
+                errors: {
+                  services_and_deliverables: [
+                    {
                       error: ['Possible misclassification risk'],
                       source: 'REMOTE_AI',
                       skippable: true,
                     },
-                  },
+                  ],
                 },
+                message: 'Unprocessable Entity',
               },
               { status: 422 },
             );
@@ -2923,17 +2924,18 @@ describe('ContractorOnboardingFlow', () => {
         http.post('*/v1/contractors/employments/*/contract-documents', () => {
           return HttpResponse.json(
             {
-              error: {
-                errors: {
-                  services_and_deliverables: {
+              errors: {
+                services_and_deliverables: [
+                  {
                     error: [
                       "The description of the services and deliverables is not clear or detailed enough to determine compliance with Remote's hiring criteria. It lacks any contextual clues or keywords related to the non-compliant categories.",
                     ],
                     source: 'REMOTE_AI',
                     skippable: false,
                   },
-                },
+                ],
               },
+              message: 'Unprocessable Entity',
             },
             { status: 422 },
           );
@@ -3022,17 +3024,18 @@ describe('ContractorOnboardingFlow', () => {
         http.post('*/v1/contractors/employments/*/contract-documents', () => {
           return HttpResponse.json(
             {
-              error: {
-                errors: {
-                  services_and_deliverables: {
+              errors: {
+                services_and_deliverables: [
+                  {
                     error: [
                       "The description of the services and deliverables is not clear or detailed enough to determine compliance with Remote's hiring criteria.",
                     ],
                     source: 'REMOTE_AI',
                     skippable: true,
                   },
-                },
+                ],
               },
+              message: 'Unprocessable Entity',
             },
             { status: 422 },
           );
@@ -3103,17 +3106,18 @@ describe('ContractorOnboardingFlow', () => {
         http.post('*/v1/contractors/employments/*/contract-documents', () => {
           return HttpResponse.json(
             {
-              error: {
-                errors: {
-                  services_and_deliverables: {
+              errors: {
+                services_and_deliverables: [
+                  {
                     error: [
                       "The description of the services and deliverables is not clear or detailed enough to determine compliance with Remote's hiring criteria.",
                     ],
                     source: 'REMOTE_AI',
                     skippable: true,
                   },
-                },
+                ],
               },
+              message: 'Unprocessable Entity',
             },
             { status: 422 },
           );
@@ -3393,20 +3397,23 @@ describe('ContractorOnboardingFlow', () => {
       const employmentId = generateUniqueEmploymentId();
 
       // Mock the contract document creation to fail with production-format AI error
-      // Production format: { errors: { ... } } instead of { error: { errors: { ... } } }
+      // Production format: errors.services_and_deliverables is an array (normalize_errors wraps non-list values)
       server.use(
         http.post('*/v1/contractors/employments/*/contract-documents', () => {
           return HttpResponse.json(
             {
               errors: {
-                services_and_deliverables: {
-                  error: [
-                    "The text is non-compliant because it includes language that implies weekly progress reviews, which can be interpreted as a form of day-to-day supervision or control over the Contractor's work.",
-                  ],
-                  source: 'REMOTE_AI',
-                  skippable: true,
-                },
+                services_and_deliverables: [
+                  {
+                    error: [
+                      "The text is non-compliant because it includes language that implies weekly progress reviews, which can be interpreted as a form of day-to-day supervision or control over the Contractor's work.",
+                    ],
+                    source: 'REMOTE_AI',
+                    skippable: true,
+                  },
+                ],
               },
+              message: 'Unprocessable Entity',
             },
             { status: 422 },
           );

--- a/src/lib/__tests__/mutations.test.ts
+++ b/src/lib/__tests__/mutations.test.ts
@@ -1,11 +1,94 @@
 import {
   ErrorResponse,
+  extractFieldErrors,
   mutationToPromise,
   normalizeFieldErrors,
   FieldError,
   isMutationError,
 } from '@/src/lib/mutations';
 import { $TSFixMe, Meta, NestedMeta } from '@/src/types/remoteFlows';
+
+describe('extractFieldErrors', () => {
+  it('should extract messages from a plain array of strings', () => {
+    expect(
+      extractFieldErrors({
+        errors: {
+          name: ['is required', 'is too short'],
+        },
+      }),
+    ).toEqual<FieldError[]>([
+      { field: 'name', messages: ['is required', 'is too short'] },
+    ]);
+  });
+
+  it('should extract messages from a nested object of arrays', () => {
+    expect(
+      extractFieldErrors({
+        errors: {
+          basic_information: {
+            name: ['is required'],
+          },
+        },
+      }),
+    ).toEqual<FieldError[]>([{ field: 'name', messages: ['is required'] }]);
+  });
+
+  it('should extract inner error messages when the value is an array-wrapped AI validation object', () => {
+    // The backend's normalize_errors wraps non-list values in an array, so the
+    // AI validation error arrives as a single-element array of objects.
+    expect(
+      extractFieldErrors({
+        errors: {
+          services_and_deliverables: [
+            {
+              error: ['Possible misclassification risk'],
+              source: 'REMOTE_AI',
+              skippable: true,
+            },
+          ],
+        },
+      }),
+    ).toEqual<FieldError[]>([
+      {
+        field: 'services_and_deliverables',
+        messages: ['Possible misclassification risk'],
+      },
+    ]);
+  });
+
+  it('should not produce "[object Object]" for array-wrapped object errors', () => {
+    const result = extractFieldErrors({
+      errors: {
+        services_and_deliverables: [
+          {
+            error: ['Possible misclassification risk'],
+            source: 'REMOTE_AI',
+            skippable: false,
+          },
+        ],
+      },
+    });
+
+    expect(result[0].messages).not.toContain('[object Object]');
+  });
+
+  it('should handle the nested error.error wrapper structure', () => {
+    expect(
+      extractFieldErrors({
+        error: {
+          errors: {
+            name: ['is required'],
+          },
+        },
+      }),
+    ).toEqual<FieldError[]>([{ field: 'name', messages: ['is required'] }]);
+  });
+
+  it('should return an empty array when there are no errors', () => {
+    expect(extractFieldErrors({})).toEqual([]);
+    expect(extractFieldErrors({ errors: null })).toEqual([]);
+  });
+});
 
 describe('normalizeFieldErrors', () => {
   it('should return empty array when no errors', () => {

--- a/src/lib/__tests__/mutations.test.ts
+++ b/src/lib/__tests__/mutations.test.ts
@@ -33,9 +33,11 @@ describe('extractFieldErrors', () => {
     ).toEqual<FieldError[]>([{ field: 'name', messages: ['is required'] }]);
   });
 
-  it('should extract inner error messages when the value is an array-wrapped AI validation object', () => {
+  it('should skip array-wrapped structured objects (e.g. AI validation) instead of emitting inline field errors', () => {
     // The backend's normalize_errors wraps non-list values in an array, so the
-    // AI validation error arrives as a single-element array of objects.
+    // AI validation error arrives as a single-element array of objects. These
+    // are surfaced via the field statement/skip flow, not as inline errors, so
+    // extractFieldErrors should not produce a field error for them.
     expect(
       extractFieldErrors({
         errors: {
@@ -48,12 +50,7 @@ describe('extractFieldErrors', () => {
           ],
         },
       }),
-    ).toEqual<FieldError[]>([
-      {
-        field: 'services_and_deliverables',
-        messages: ['Possible misclassification risk'],
-      },
-    ]);
+    ).toEqual<FieldError[]>([]);
   });
 
   it('should not produce "[object Object]" for array-wrapped object errors', () => {
@@ -69,7 +66,18 @@ describe('extractFieldErrors', () => {
       },
     });
 
-    expect(result[0].messages).not.toContain('[object Object]');
+    const allMessages = result.flatMap((fieldError) => fieldError.messages);
+    expect(allMessages).not.toContain('[object Object]');
+  });
+
+  it('should keep primitive messages while skipping object entries in a mixed array', () => {
+    expect(
+      extractFieldErrors({
+        errors: {
+          name: ['is required', { source: 'REMOTE_AI', error: ['ignored'] }],
+        },
+      }),
+    ).toEqual<FieldError[]>([{ field: 'name', messages: ['is required'] }]);
   });
 
   it('should handle the nested error.error wrapper structure', () => {

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -84,7 +84,15 @@ export function extractFieldErrors(error: $TSFixMe): FieldError[] {
     if (Array.isArray(value)) {
       fieldErrors.push({
         field: key,
-        messages: value.map((msg: $TSFixMe) => String(msg)),
+        // The backend's normalize_errors wraps non-list values in an array, so
+        // a field error can arrive as an array of objects (e.g. AI validation:
+        // [{ error: string[], source, skippable }]) rather than plain strings.
+        // Extract the inner `error` messages instead of stringifying the object.
+        messages: value.flatMap((msg: $TSFixMe) =>
+          msg && typeof msg === 'object' && Array.isArray(msg.error)
+            ? msg.error.map((m: $TSFixMe) => String(m))
+            : [String(msg)],
+        ),
       });
       return;
     }

--- a/src/lib/mutations.ts
+++ b/src/lib/mutations.ts
@@ -82,18 +82,18 @@ export function extractFieldErrors(error: $TSFixMe): FieldError[] {
 
   Object.entries(errors.errors).forEach(([key, value]) => {
     if (Array.isArray(value)) {
-      fieldErrors.push({
-        field: key,
-        // The backend's normalize_errors wraps non-list values in an array, so
-        // a field error can arrive as an array of objects (e.g. AI validation:
-        // [{ error: string[], source, skippable }]) rather than plain strings.
-        // Extract the inner `error` messages instead of stringifying the object.
-        messages: value.flatMap((msg: $TSFixMe) =>
-          msg && typeof msg === 'object' && Array.isArray(msg.error)
-            ? msg.error.map((m: $TSFixMe) => String(m))
-            : [String(msg)],
-        ),
-      });
+      // The backend's normalize_errors wraps non-list values in an array, so a
+      // field error can arrive as an array of structured objects (e.g. the
+      // REMOTE_AI validation error: [{ error, source, skippable }]). Those are
+      // surfaced to the user through the field's statement/skip flow, not as a
+      // plain inline message, so we skip object entries here to avoid rendering
+      // "[object Object]". Only primitive messages are kept.
+      const messages = value
+        .filter((msg: $TSFixMe) => msg === null || typeof msg !== 'object')
+        .map((msg: $TSFixMe) => String(msg));
+      if (messages.length > 0) {
+        fieldErrors.push({ field: key, messages });
+      }
       return;
     }
     if (value && typeof value === 'object') {


### PR DESCRIPTION
## Problem

When a consumer tries to create a contract document and the backend returns an AI validation error with `skippable: true`, clicking submit again returns the same error — `skip_ai_checks` is never sent as `true`.

## Root cause

The backend's `EORWeb.ErrorView.normalize_errors/1` wraps any non-list value in an array:

```elixir
Map.new(errors, fn {k, v} -> {k, if(is_list(v), do: v, else: [v])} end)
```

So the AI validation error object `{source: "REMOTE_AI", error: [...], skippable: true}` arrives to the SDK as `services_and_deliverables: [{source: "REMOTE_AI", ...}]`.

`extractAiValidationError` was reading `normalizedErrors.services_and_deliverables` as a plain object and checking `.source` on it — but `.source` on an array is `undefined`, so the function returned `null`. The catch block never called `setFieldValues` with `services_and_deliverables_error_skippable: true`, so on the second submit `shouldSkipAiChecks` remained `false`.

## Fix

`extractAiValidationError` now unwraps the array before checking `source`:

```ts
const servicesAndDeliverablesError = (
  Array.isArray(rawError) ? rawError[0] : rawError
) as { error: string[]; source: string; skippable: boolean } | undefined;
```

All 5 test mocks that simulated the AI error were also updated to use the actual backend response format (array-wrapped, `errors` at top level). The existing "production format" test was also using an object instead of an array — now corrected.