### PR TITLE
Release/1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### Minor Changes
 
-- add standalone cost calculator Vercel deployment
-- GP SDK foundation — shared hooks and flow scaffolding (PBYR-4043)
-- apply oxfmt formatting
-- handle array-wrapped AI validation error from backend
-- fix mismatched checkout SHA version comment in cost-calculator jobs
-- fix mismatched checkout SHA version comment in pr cost-calculator job
+#### Refactors
+- Change default title when using Cost Calculator stand alone https://github.com/remoteoss/remote-flows/pull/1081
+
+#### Fixes
+- handle array-wrapped AI validation error from backend https://github.com/remoteoss/remote-flows/pull/1079
+
+#### CI
+- add standalone cost calculator Vercel deployment (ADP) https://github.com/remoteoss/remote-flows/pull/1075
 
 ## 1.37.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @remoteoss/remote-flows
 
+## 1.38.0
+
+### Minor Changes
+
+- add standalone cost calculator Vercel deployment
+- GP SDK foundation — shared hooks and flow scaffolding (PBYR-4043)
+- apply oxfmt formatting
+- handle array-wrapped AI validation error from backend
+- fix mismatched checkout SHA version comment in cost-calculator jobs
+- fix mismatched checkout SHA version comment in pr cost-calculator job
+
 ## 1.37.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@
 ### Minor Changes
 
 #### Refactors
+
 - Change default title when using Cost Calculator stand alone https://github.com/remoteoss/remote-flows/pull/1081
 
 #### Fixes
+
 - handle array-wrapped AI validation error from backend https://github.com/remoteoss/remote-flows/pull/1079
 
 #### CI
+
 - add standalone cost calculator Vercel deployment (ADP) https://github.com/remoteoss/remote-flows/pull/1075
 
 ## 1.37.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
### Minor Changes

#### Refactors
- Change default title when using Cost Calculator stand alone https://github.com/remoteoss/remote-flows/pull/1081

#### Fixes
- handle array-wrapped AI validation error from backend https://github.com/remoteoss/remote-flows/pull/1079

#### CI
- add standalone cost calculator Vercel deployment (ADP) https://github.com/remoteoss/remote-flows/pull/1075
