### PR TITLE
feat(ea-preview) - preview the pdf and download it

### DIFF
--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -96,6 +96,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     BackButton,
     SelectCountryStep,
     EngagementAgreementDetailsStep,
+    PreviewEmploymentAgreementStep,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -293,6 +294,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
 
       return (
         <>
+          <PreviewEmploymentAgreementStep />
           <div className='space-y-4'>
             <Button
               onClick={() => {
@@ -306,7 +308,6 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               Preview employment agreement
             </Button>
           </div>
-
           <FullScreenDialog
             open={showPreviewModal}
             onOpenChange={(open: boolean) => {
@@ -395,7 +396,6 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               </div>
             </FullScreenDialogContent>
           </FullScreenDialog>
-
           <div className='buttons-container'>
             <BackButton
               className='back-button'

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -15,7 +15,12 @@ import {
   zendeskArticles,
 } from '@remoteoss/remote-flows';
 import React, { useState } from 'react';
-import { Card } from '@remoteoss/remote-flows/internals';
+import {
+  Card,
+  FullScreenDialog,
+  FullScreenDialogContent,
+  Button,
+} from '@remoteoss/remote-flows/internals';
 import { ReviewOnboardingStep } from './ReviewOnboardingStep';
 import { OnboardingAlertStatuses } from './OnboardingAlertStatuses';
 import { RemoteFlows } from './RemoteFlows';
@@ -90,7 +95,6 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     BackButton,
     SelectCountryStep,
     EngagementAgreementDetailsStep,
-    PreviewEmploymentAgreementStep,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -99,6 +103,8 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
     apiError: '',
     fieldErrors: [],
   });
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
+  const [isPdfLoading, setIsPdfLoading] = useState(true);
 
   switch (onboardingBag.stepState.currentStep.name) {
     case 'select_country':
@@ -270,9 +276,89 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
       );
     }
     case 'employment_agreement_preview': {
+      const pdfContent = onboardingBag.employmentAgreementPreview?.content;
+      const pdfUrl = pdfContent
+        ? `${pdfContent as unknown as string}#view=FitV&toolbar=0`
+        : undefined;
+
       return (
         <>
-          <PreviewEmploymentAgreementStep />
+          <div className='space-y-4'>
+            <Button
+              onClick={() => {
+                setShowPreviewModal(true);
+                setIsPdfLoading(true);
+              }}
+              className='w-full'
+              variant='outline'
+              disabled={!pdfContent}
+            >
+              Preview employment agreement'
+            </Button>
+          </div>
+
+          <FullScreenDialog
+            open={showPreviewModal}
+            onOpenChange={(open: boolean) => {
+              setShowPreviewModal(open);
+              if (!open) {
+                setIsPdfLoading(true);
+              }
+            }}
+          >
+            <FullScreenDialogContent>
+              {/* Header */}
+              <div className='flex items-center justify-between px-6 py-4 border-b bg-white'>
+                <div className='flex items-center gap-4'>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    onClick={() => setShowPreviewModal(false)}
+                  >
+                    <svg
+                      xmlns='http://www.w3.org/2000/svg'
+                      width='24'
+                      height='24'
+                      viewBox='0 0 24 24'
+                      fill='none'
+                      stroke='currentColor'
+                      strokeWidth='2'
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                    >
+                      <path d='M19 12H5M12 19l-7-7 7-7' />
+                    </svg>
+                  </Button>
+                  <h2 className='text-lg font-semibold'>
+                    Employment Agreement Preview
+                  </h2>
+                </div>
+              </div>
+
+              {/* Full screen PDF viewer */}
+              <div className='flex-1 relative bg-gray-50 overflow-hidden'>
+                {isPdfLoading && (
+                  <div className='absolute inset-0 flex items-center justify-center bg-white z-10'>
+                    <div className='text-center'>
+                      <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-2'></div>
+                      <p className='text-sm text-gray-600'>
+                        Loading document...
+                      </p>
+                    </div>
+                  </div>
+                )}
+                {pdfUrl && (
+                  <iframe
+                    src={pdfUrl}
+                    className='w-full h-full border-0'
+                    title='Employment Agreement Preview'
+                    onLoad={() => setIsPdfLoading(false)}
+                  />
+                )}
+              </div>
+            </FullScreenDialogContent>
+          </FullScreenDialog>
+
           <div className='buttons-container'>
             <BackButton
               className='back-button'
@@ -437,7 +523,7 @@ const OnboardingWithProps = ({
       employmentId={employmentId}
       externalId={externalId}
       options={{
-        features: ['onboarding_reserves', 'dynamic_steps'],
+        features: ['onboarding_reserves', 'dynamic_steps', 'ea_preview'],
         jsonSchemaVersion: {
           employment_basic_information: 3,
         },

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -560,7 +560,7 @@ const OnboardingWithProps = ({
       employmentId={employmentId}
       externalId={externalId}
       options={{
-        features: ['onboarding_reserves', 'dynamic_steps', 'ea_preview'],
+        features: ['onboarding_reserves', 'dynamic_steps' /* 'ea_preview' */],
         jsonSchemaVersion: {
           employment_basic_information: 3,
         },

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -27,6 +27,7 @@ import { RemoteFlows } from './RemoteFlows';
 import { AlertError } from './AlertError';
 import { transformHtmlToComponents } from './utils/transformHtml';
 import { sanitizeHtml } from '@remoteoss/remote-flows/internals';
+import { downloadFile } from './utils';
 import './css/main.css';
 
 const BenefitsAboutSection = ({
@@ -281,6 +282,15 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
         ? `${pdfContent as unknown as string}#view=FitV&toolbar=0`
         : undefined;
 
+      const handleDownload = () => {
+        if (pdfContent) {
+          downloadFile(
+            pdfContent as unknown as string,
+            'employment-agreement.pdf',
+          );
+        }
+      };
+
       return (
         <>
           <div className='space-y-4'>
@@ -293,7 +303,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               variant='outline'
               disabled={!pdfContent}
             >
-              Preview employment agreement'
+              Preview employment agreement
             </Button>
           </div>
 
@@ -332,6 +342,33 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
                   <h2 className='text-lg font-semibold'>
                     Employment Agreement Preview
                   </h2>
+                </div>
+
+                {/* Download Button */}
+                <div className='mr-4'>
+                  <Button
+                    onClick={handleDownload}
+                    disabled={!pdfContent}
+                    variant='outline'
+                  >
+                    <svg
+                      xmlns='http://www.w3.org/2000/svg'
+                      width='20'
+                      height='20'
+                      viewBox='0 0 24 24'
+                      fill='none'
+                      stroke='currentColor'
+                      strokeWidth='2'
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      className='mr-2'
+                    >
+                      <path d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' />
+                      <polyline points='7 10 12 15 17 10' />
+                      <line x1='12' y1='15' x2='12' y2='3' />
+                    </svg>
+                    Download
+                  </Button>
                 </div>
               </div>
 

--- a/src/flows/Onboarding/api.ts
+++ b/src/flows/Onboarding/api.ts
@@ -14,6 +14,7 @@ import {
   getV1CountriesCountryCodeForm,
   getV1EmploymentsEmploymentIdBenefitOffers,
   getV1EmploymentsEmploymentIdBenefitOffersSchema,
+  getV1EmploymentsEmploymentIdEmploymentAgreementPreview,
   getV2EmploymentsEmploymentIdEngagementAgreementDetails,
   patchV1EmploymentsEmploymentId2,
   postV1CurrencyConverterEffective,
@@ -687,5 +688,37 @@ export const useSignPreOnboardingDocument = () => {
           signature,
         },
       }),
+  });
+};
+
+/**
+ * Get employment agreement preview
+ */
+export const useEmploymentAgreementPreview = (
+  employmentId: string | undefined,
+  options?: { queryOptions?: { enabled?: boolean } },
+) => {
+  const { client } = useClient();
+
+  return useQuery({
+    queryKey: ['employment-agreement-preview', employmentId],
+    retry: false,
+    enabled: (options?.queryOptions?.enabled ?? true) && !!employmentId,
+    queryFn: async () => {
+      const response =
+        await getV1EmploymentsEmploymentIdEmploymentAgreementPreview({
+          client: client as Client,
+          path: {
+            employment_id: employmentId as string,
+          },
+        });
+
+      if (response.error || !response.data) {
+        throw new Error('Failed to fetch employment agreement preview');
+      }
+
+      return response;
+    },
+    select: (response) => response.data?.data.employment_agreement,
   });
 };

--- a/src/flows/Onboarding/components/PreviewEmploymentAgreementStep.tsx
+++ b/src/flows/Onboarding/components/PreviewEmploymentAgreementStep.tsx
@@ -8,7 +8,5 @@ export function PreviewEmploymentAgreementStep() {
     onboardingBag?.next();
   };
 
-  // this step in theory shouldn't be a form, not sure yet...
-
   return <OnboardingForm defaultValues={{}} onSubmit={handleSubmit} />;
 }

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -31,6 +31,7 @@ import {
   useCompany,
   useCountriesSchemaField,
   useCreateEmployment,
+  useEmploymentAgreementPreview,
   useEmploymentEngagementAgreementDetails,
   useEmploymentOnboardingReservesStatus,
   useEngagementAgreementDetailsSchema,
@@ -71,6 +72,7 @@ const getLoadingStates = ({
   isLoadingBasicInformationForm,
   isLoadingContractDetailsForm,
   isLoadingEngagementAgreementDetails,
+  isLoadingEmploymentAgreementPreview,
   isLoadingEmploymentEngagementAgreementDetails,
   isLoadingEmployment,
   isLoadingBenefitsOffersSchema,
@@ -93,6 +95,7 @@ const getLoadingStates = ({
   isLoadingBenefitOffers: boolean;
   isLoadingCompany: boolean;
   isLoadingCountries: boolean;
+  isLoadingEmploymentAgreementPreview: boolean;
   employmentStatus?: Employment['status'];
   employmentId?: string;
   currentStepName: string;
@@ -109,7 +112,8 @@ const getLoadingStates = ({
     isLoadingBenefitsOffersSchema ||
     isLoadingBenefitOffers ||
     isLoadingCompany ||
-    isLoadingCountries;
+    isLoadingCountries ||
+    isLoadingEmploymentAgreementPreview;
 
   const isEmploymentReadOnly =
     employmentStatus &&
@@ -370,6 +374,20 @@ export const useOnboarding = ({
   useEffect(() => {
     setIncludeEmploymentAgreementPreview(isEmploymentAgreementPreviewAvailable);
   }, [isEmploymentAgreementPreviewAvailable]);
+
+  const isEmploymentEnabled =
+    Boolean(internalEmploymentId) &&
+    useEAPreview &&
+    stepState.currentStep.name === 'employment_agreement_preview';
+
+  const {
+    data: employmentAgreementPreview,
+    isLoading: isLoadingEmploymentAgreementPreview,
+  } = useEmploymentAgreementPreview(internalEmploymentId, {
+    queryOptions: {
+      enabled: isEmploymentEnabled,
+    },
+  });
 
   const createEmploymentMutation = useCreateEmployment(options);
   const updateEmploymentMutation = useUpdateEmployment(
@@ -775,6 +793,7 @@ export const useOnboarding = ({
           isLoadingBenefitOffers,
           isLoadingCompany,
           isLoadingCountries,
+          isLoadingEmploymentAgreementPreview,
           employmentId,
           employmentStatus: employmentStatus,
           basicInformationFields: stepFields.basic_information,
@@ -792,6 +811,7 @@ export const useOnboarding = ({
         isLoadingBenefitOffers,
         isLoadingCompany,
         isLoadingCountries,
+        isLoadingEmploymentAgreementPreview,
         employmentId,
         employmentStatus,
         stepFields.basic_information,
@@ -1217,5 +1237,10 @@ export const useOnboarding = ({
           name: country?.name,
         }
       : null,
+
+    /**
+     * Employment agreement preview
+     */
+    employmentAgreementPreview,
   };
 };


### PR DESCRIPTION
I've ask externally to see what partners have in mind to implement on this step, you can take a look at the loom and see how it looks and what questions I asked

Basically we call a new endpoint to get the preview pdf, we don't have the need to call a different endpoint to download the pdf as it already there.

I think most of the code should be implemented on the example app as they only need the pdf and then they bring their own components to preview the viewer etc...

and I don't know what UI they're going to use, that's why I asked some questions to them

When they clarify, I can modify or keep this solution


https://www.loom.com/share/2f157c2a75cf450580c948f7ad1513ce

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only preview fetch and example/UI wiring; no changes to employment creation, signing, or auth flows.
> 
> **Overview**
> Adds **employment agreement preview** data to onboarding when the **`ea_preview`** feature flag is enabled: a new **`useEmploymentAgreementPreview`** query loads the agreement from the API only on the **`employment_agreement_preview`** step, and the result is exposed on **`onboardingBag.employmentAgreementPreview`** (with loading folded into existing step loading state).
> 
> The **example onboarding app** turns on **`ea_preview`** and implements a **full-screen dialog** to open the PDF in an iframe (with a loading state) and **download** it via the existing **`downloadFile`** helper. The preview step component is unchanged aside from removing a stale comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db783e1da46a6acb420e46bf69a2837dae63baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->