### PR TITLE
fix(contractor-subscriptions) - rely on secure properties && add fallbacks

### DIFF
--- a/src/common/api/fixtures/contractors-subscriptions.ts
+++ b/src/common/api/fixtures/contractors-subscriptions.ts
@@ -8,6 +8,7 @@ export const mockContractorSubscriptionResponse = {
         name: 'Monthly Contractor of Record Subscription',
         identifier: 'urn:remotecom:resource:product:contractor:aor:monthly',
         short_name: 'COR',
+        description: 'Engage and pay contractors compliantly',
       },
       currency: {
         code: 'USD',
@@ -25,6 +26,7 @@ export const mockContractorSubscriptionResponse = {
         name: 'Monthly Contractor Plus Subscription',
         identifier: 'urn:remotecom:resource:product:contractor:plus:monthly',
         short_name: 'CM+',
+        description: 'Engage and pay contractors with indemnity coverage',
       },
       currency: {
         code: 'USD',
@@ -43,6 +45,8 @@ export const mockContractorSubscriptionResponse = {
         identifier:
           'urn:remotecom:resource:product:contractor:standard:monthly',
         short_name: 'CM',
+        description:
+          'Remote reduces liability by directly engaging the contractor',
       },
       currency: {
         code: 'USD',

--- a/src/common/api/fixtures/contractors-subscriptions.ts
+++ b/src/common/api/fixtures/contractors-subscriptions.ts
@@ -8,7 +8,8 @@ export const mockContractorSubscriptionResponse = {
         name: 'Monthly Contractor of Record Subscription',
         identifier: 'urn:remotecom:resource:product:contractor:aor:monthly',
         short_name: 'COR',
-        description: 'Engage and pay contractors compliantly',
+        description:
+          'Remote reduces liability by directly engaging the contractor',
       },
       currency: {
         code: 'USD',
@@ -45,8 +46,7 @@ export const mockContractorSubscriptionResponse = {
         identifier:
           'urn:remotecom:resource:product:contractor:standard:monthly',
         short_name: 'CM',
-        description:
-          'Remote reduces liability by directly engaging the contractor',
+        description: 'Engage and pay contractors with indemnity coverage',
       },
       currency: {
         code: 'USD',

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -37,6 +37,7 @@ import {
   contractorStandardProductIdentifier,
   corProductIdentifier,
   eorProductIdentifier,
+  FEATURES_BY_IDENTIFIER,
   IR35_FILE_SUBTYPE,
   ProductType,
 } from '@/src/flows/ContractorOnboarding/constants';
@@ -445,7 +446,7 @@ export const useContractorSubscriptionSchemaField = (
     : false;
 
   const corSubscription = contractorSubscriptions?.find(
-    (subscription) => subscription.product.short_name === 'COR',
+    (subscription) => subscription.product.identifier === corProductIdentifier,
   );
 
   const isEligibilityQuestionnaireBlocked =
@@ -500,7 +501,20 @@ export const useContractorSubscriptionSchemaField = (
       const label = title;
       const value = product.identifier ?? '';
       const description = product.description ?? '';
-      const features = product.features ?? [];
+
+      if (!product.description) {
+        console.error(
+          `[Data Integrity] Missing description for product: ${product.identifier}`,
+          { product },
+        );
+      }
+
+      const features =
+        product.features ??
+        FEATURES_BY_IDENTIFIER[
+          product.identifier as keyof typeof FEATURES_BY_IDENTIFIER
+        ] ??
+        [];
       const meta = {
         features,
         price: {

--- a/src/flows/ContractorOnboarding/constants.ts
+++ b/src/flows/ContractorOnboarding/constants.ts
@@ -159,3 +159,27 @@ export const pricingPlanDetails = {
     contractPillText: 'Contract between Remote and employee',
   },
 };
+
+export const FEATURES_BY_IDENTIFIER: Record<string, string[]> = {
+  [contractorStandardProductIdentifier]: [
+    'Contract between you and contractor',
+    'Localized contract templates',
+    'AI-powered features to reduce misclassification risks',
+    'Experts on hand to identify misclassification risks',
+    'Only pay for active contractors',
+    'Work with contractors in 200+ countries and jurisdictions',
+  ],
+  [contractorPlusProductIdentifier]: [
+    'Contract between you and contractor',
+    'Access to all Contractor Management features',
+    '$100K indemnity coverage for penalties',
+    '4X monetary coverage than our competitors  in case of penalties',
+  ],
+  [corProductIdentifier]: [
+    'Contract between Remote and the contractor',
+    'Our most comprehensive option for compliance and flexibility',
+    'Locally compliant agreements',
+    'Localized contract templates',
+    'Indemnity coverage for losses related to Remote’s administration and contractor payments',
+  ],
+};

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -302,7 +302,8 @@ export const useContractorOnboarding = ({
   const hasEligibilityQuestionnaireSubmitted = useMemo(() => {
     return Boolean(
       contractorSubscriptions?.find(
-        (subscription) => subscription.product.short_name === 'COR',
+        (subscription) =>
+          subscription.product.identifier === corProductIdentifier,
       )?.eligibility_questionnaire?.submitted_at,
     );
   }, [contractorSubscriptions]);
@@ -325,7 +326,8 @@ export const useContractorOnboarding = ({
 
   const eligibilityAnswers = useMemo(() => {
     return contractorSubscriptions?.find(
-      (subscription) => subscription.product.short_name === 'COR',
+      (subscription) =>
+        subscription.product.identifier === corProductIdentifier,
     )?.eligibility_questionnaire?.responses;
   }, [contractorSubscriptions]);
 


### PR DESCRIPTION
We got reports that some properties dissapear on the database, I am changing how we rely on short_name and start relying on the identifier instead

And I am doing a fallback for features and logging when description is set that can give us a clue in the future

I want to write in the future a captureException helper which emits the event to Mezmo and Honeycomb and set alerts on slack so I know when error happens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect which subscription is treated as COR and what users see on pricing plans; identifier-based matching is safer than short_name but wrong fallbacks could misrepresent product features during onboarding.
> 
> **Overview**
> Hardens contractor subscription handling when API product fields are missing or unstable by matching **COR** subscriptions on `product.identifier` instead of `short_name`, including eligibility questionnaire and blocking logic in onboarding hooks.
> 
> Pricing plan options now **fall back** to client-side `FEATURES_BY_IDENTIFIER` when `product.features` is absent, and log a `[Data Integrity]` **console.error** when `product.description` is missing. Static feature copy for standard, plus, and COR tiers lives in `constants.ts`, and subscription mocks gain sample descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897fb6835b90686782e3ef297f3c6b5e8409b4d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->