### PR TITLE
1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - add dummy logic to show the preview employment step (#1073) [#1073](https://github.com/remoteoss/remote-flows/pull/1073)
 - preview the pdf and download it (#1085) [#1085](https://github.com/remoteoss/remote-flows/pull/1085)
 
-
 #### Fixes
 
 - rely on secure properties && add fallbacks (#1086) [#1086](https://github.com/remoteoss/remote-flows/pull/1086)
@@ -18,7 +17,6 @@
 
 - update dependency vite to v8.0.16 [security] (#1083) [#1083](https://github.com/remoteoss/remote-flows/pull/1083)
 - update dependency dompurify to v3.4.9 [security] (#1084) [#1084](https://github.com/remoteoss/remote-flows/pull/1084)
-
 
 ## 1.38.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,21 @@
 
 ### Minor Changes
 
-- update dependency vite to v8.0.16 [security] (#1083) [#1083](https://github.com/remoteoss/remote-flows/pull/1083)
-- update dependency dompurify to v3.4.9 [security] (#1084) [#1084](https://github.com/remoteoss/remote-flows/pull/1084)
+#### Features
+
 - add dummy logic to show the preview employment step (#1073) [#1073](https://github.com/remoteoss/remote-flows/pull/1073)
 - preview the pdf and download it (#1085) [#1085](https://github.com/remoteoss/remote-flows/pull/1085)
+
+
+#### Fixes
+
 - rely on secure properties && add fallbacks (#1086) [#1086](https://github.com/remoteoss/remote-flows/pull/1086)
+
+#### Chores
+
+- update dependency vite to v8.0.16 [security] (#1083) [#1083](https://github.com/remoteoss/remote-flows/pull/1083)
+- update dependency dompurify to v3.4.9 [security] (#1084) [#1084](https://github.com/remoteoss/remote-flows/pull/1084)
+
 
 ## 1.38.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @remoteoss/remote-flows
 
+## 1.39.0
+
+### Minor Changes
+
+- update dependency vite to v8.0.16 [security] (#1083) [#1083](https://github.com/remoteoss/remote-flows/pull/1083)
+- update dependency dompurify to v3.4.9 [security] (#1084) [#1084](https://github.com/remoteoss/remote-flows/pull/1084)
+- add dummy logic to show the preview employment step (#1073) [#1073](https://github.com/remoteoss/remote-flows/pull/1073)
+- preview the pdf and download it (#1085) [#1085](https://github.com/remoteoss/remote-flows/pull/1085)
+- rely on secure properties && add fallbacks (#1086) [#1086](https://github.com/remoteoss/remote-flows/pull/1086)
+
 ## 1.38.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "dependencies": {
         "@hookform/resolvers": "5.2.2",
         "@radix-ui/react-checkbox": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.39.0

### Minor Changes

#### Features

- add dummy logic to show the preview employment step (#1073) [#1073](https://github.com/remoteoss/remote-flows/pull/1073)
- preview the pdf and download it (#1085) [#1085](https://github.com/remoteoss/remote-flows/pull/1085)


#### Fixes

- rely on secure properties && add fallbacks (#1086) [#1086](https://github.com/remoteoss/remote-flows/pull/1086)

#### Chores

- update dependency vite to v8.0.16 [security] (#1083) [#1083](https://github.com/remoteoss/remote-flows/pull/1083)
- update dependency dompurify to v3.4.9 [security] (#1084) [#1084](https://github.com/remoteoss/remote-flows/pull/1084)



---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog updates; functional changes are documented from prior merges, not introduced in this diff.
> 
> **Overview**
> **Release 1.39.0** — bumps `@remoteoss/remote-flows` from **1.38.0** to **1.39.0** in `package.json` and `package-lock.json`, and adds the **1.39.0** section to `CHANGELOG.md`.
> 
> The changelog records what ships in this minor release (already merged via linked PRs): **employment preview step** placeholder logic (#1073), **PDF preview and download** (#1085), a fix to **use secure properties with fallbacks** (#1086), and **security dependency bumps** for `vite` (#1083) and `dompurify` (#1084).
> 
> There is **no application source change** in this diff—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c909d4f19c6ae3de832f854af4e0d58644c6903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->