### PR TITLE
feat(employment-agreements) - Add employment agreement content

### DIFF
--- a/.sizelimit.json
+++ b/.sizelimit.json
@@ -1,6 +1,6 @@
 {
   "limits": {
-    "total": 600000,
+    "total": 650000,
     "totalGzip": 250000,
     "css": 150000,
     "cssGzip": 25000,

--- a/example/src/EmploymentAgreementInfoModal.tsx
+++ b/example/src/EmploymentAgreementInfoModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@remoteoss/remote-flows/internals';
+import { EmploymentAgreementInfoContent } from '@remoteoss/remote-flows';
+
+interface EmploymentAgreementInfoModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const EmploymentAgreementInfoModal: React.FC<
+  EmploymentAgreementInfoModalProps
+> = ({ open, onOpenChange }) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-2xl max-h-[80vh] overflow-y-auto'>
+        <DialogHeader>
+          <DialogTitle>Employment agreement preview</DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-4 text-sm text-gray-700'>
+          <EmploymentAgreementInfoContent />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -21,6 +21,7 @@ import {
   FullScreenDialogContent,
   Button,
 } from '@remoteoss/remote-flows/internals';
+import { EmploymentAgreementInfoModal } from './EmploymentAgreementInfoModal';
 import { ReviewOnboardingStep } from './ReviewOnboardingStep';
 import { OnboardingAlertStatuses } from './OnboardingAlertStatuses';
 import { RemoteFlows } from './RemoteFlows';
@@ -107,6 +108,7 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
   });
   const [showPreviewModal, setShowPreviewModal] = useState(false);
   const [isPdfLoading, setIsPdfLoading] = useState(true);
+  const [showInfoModal, setShowInfoModal] = useState(false);
 
   switch (onboardingBag.stepState.currentStep.name) {
     case 'select_country':
@@ -345,8 +347,35 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
                   </h2>
                 </div>
 
-                {/* Download Button */}
-                <div className='mr-4'>
+                {/* Right side buttons */}
+                <div className='flex items-center gap-2'>
+                  {/* About this preview button */}
+                  <Button
+                    onClick={() => setShowInfoModal(true)}
+                    variant='ghost'
+                    size='sm'
+                    className='text-blue-600 hover:text-blue-700'
+                  >
+                    <svg
+                      xmlns='http://www.w3.org/2000/svg'
+                      width='16'
+                      height='16'
+                      viewBox='0 0 24 24'
+                      fill='none'
+                      stroke='currentColor'
+                      strokeWidth='2'
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      className='mr-1'
+                    >
+                      <circle cx='12' cy='12' r='10' />
+                      <path d='M12 16v-4' />
+                      <path d='M12 8h.01' />
+                    </svg>
+                    About this preview
+                  </Button>
+
+                  {/* Download Button */}
                   <Button
                     onClick={handleDownload}
                     disabled={!pdfContent}
@@ -396,6 +425,13 @@ const MultiStepForm = ({ components, onboardingBag }: MultiStepFormProps) => {
               </div>
             </FullScreenDialogContent>
           </FullScreenDialog>
+
+          {/* Info Modal */}
+          <EmploymentAgreementInfoModal
+            open={showInfoModal}
+            onOpenChange={setShowInfoModal}
+          />
+
           <div className='buttons-container'>
             <BackButton
               className='back-button'
@@ -560,7 +596,7 @@ const OnboardingWithProps = ({
       employmentId={employmentId}
       externalId={externalId}
       options={{
-        features: ['onboarding_reserves', 'dynamic_steps' /* 'ea_preview' */],
+        features: ['onboarding_reserves', 'dynamic_steps', 'ea_preview'],
         jsonSchemaVersion: {
           employment_basic_information: 3,
         },

--- a/src/components/shared/zendesk-drawer/utils.ts
+++ b/src/components/shared/zendesk-drawer/utils.ts
@@ -7,10 +7,16 @@ export const zendeskArticles = {
   disclaimerCostCalculator: 4668194326797,
   /**
    * Guide for engaging contractors
-   * Access: private (Need Remote account to access)
+   * Access: Private (Need Remote account to access)
    * https://support.remote.com/hc/en-us/articles/43161434169613
    */
   engagingContractors: 43161434169613,
+  /**
+   * Employment Agreements
+   * Access: Public (Need Remote account to access)
+   * https://support.remote.com/hc/en-us/articles/39266991211149
+   */
+  employmentAgreements: 39266991211149,
   /**
    * Employee Onboarding Timeline
    * Access: Private (Need Remote account to access)

--- a/src/flows/Onboarding/components/EmploymentAgreementInfoContent.tsx
+++ b/src/flows/Onboarding/components/EmploymentAgreementInfoContent.tsx
@@ -115,7 +115,7 @@ export const EmploymentAgreementInfoContent = () => {
           target='_blank'
           rel='noopener noreferrer'
         >
-          Employee Onboarding Timeline ↗
+          Agreement Engagement Guide ↗
         </a>{' '}
         to understand what can (and can't) be modified.
       </p>

--- a/src/flows/Onboarding/components/EmploymentAgreementInfoContent.tsx
+++ b/src/flows/Onboarding/components/EmploymentAgreementInfoContent.tsx
@@ -1,5 +1,7 @@
-import { zendeskArticles } from '@/src/components/shared/zendesk-drawer/utils';
-import { ZendeskTriggerButton } from '@/src/components/shared/zendesk-drawer/ZendeskTriggerButton';
+import {
+  buildZendeskURL,
+  zendeskArticles,
+} from '@/src/components/shared/zendesk-drawer/utils';
 import { cn } from '@/src/internals';
 
 export const EmploymentAgreementInfoContent = () => {
@@ -107,14 +109,14 @@ export const EmploymentAgreementInfoContent = () => {
         )}
       >
         For guidance, see our{' '}
-        <ZendeskTriggerButton
-          className={cn(
-            'RemoteFlows__EmploymentAgreementInfoContent__ZendeskTriggerButton',
-          )}
-          zendeskId={zendeskArticles.employmentAgreements}
+        <a
+          className={cn('RemoteFlows__EmploymentAgreementInfoContent__Link')}
+          href={buildZendeskURL(zendeskArticles.employmentAgreements)}
+          target='_blank'
+          rel='noopener noreferrer'
         >
           Employee Onboarding Timeline ↗
-        </ZendeskTriggerButton>{' '}
+        </a>{' '}
         to understand what can (and can't) be modified.
       </p>
     </>

--- a/src/flows/Onboarding/components/EmploymentAgreementInfoContent.tsx
+++ b/src/flows/Onboarding/components/EmploymentAgreementInfoContent.tsx
@@ -1,0 +1,122 @@
+import { zendeskArticles } from '@/src/components/shared/zendesk-drawer/utils';
+import { ZendeskTriggerButton } from '@/src/components/shared/zendesk-drawer/ZendeskTriggerButton';
+import { cn } from '@/src/internals';
+
+export const EmploymentAgreementInfoContent = () => {
+  return (
+    <>
+      <div
+        className={cn('RemoteFlows__EmploymentAgreementInfoContent__InfoBox')}
+      >
+        <p
+          className={cn(
+            'RemoteFlows__EmploymentAgreementInfoContent__InfoBoxText',
+          )}
+        >
+          You are previewing a draft version of our employment agreement
+          template for this specific hire in this specific country, based on the
+          selections you made on the previous screens.
+        </p>
+      </div>
+
+      <p
+        className={cn(
+          'RemoteFlows__EmploymentAgreementInfoContent__Description',
+        )}
+      >
+        Remote's agreements are drafted by local employment and labor law
+        experts to ensure compliance, balance, and efficiency.
+      </p>
+
+      <div>
+        <p
+          className={cn(
+            'RemoteFlows__EmploymentAgreementInfoContent__WarningTitle',
+          )}
+        >
+          We strongly discourage customizations or redlining.
+        </p>
+        <p
+          className={cn(
+            'RemoteFlows__EmploymentAgreementInfoContent__Description',
+          )}
+        >
+          Modifying agreements can:
+        </p>
+        <ul
+          className={cn(
+            'RemoteFlows__EmploymentAgreementInfoContent__List list-disc list-inside',
+          )}
+        >
+          <li
+            className={cn(
+              'RemoteFlows__EmploymentAgreementInfoContent__ListItem',
+            )}
+          >
+            Create compliance risks
+          </li>
+          <li
+            className={cn(
+              'RemoteFlows__EmploymentAgreementInfoContent__ListItem',
+            )}
+          >
+            Jeopardize enforceability
+          </li>
+          <li
+            className={cn(
+              'RemoteFlows__EmploymentAgreementInfoContent__ListItem',
+            )}
+          >
+            Increase the risk of misemployment
+          </li>
+        </ul>
+      </div>
+
+      <p
+        className={cn(
+          'RemoteFlows__EmploymentAgreementInfoContent__Description',
+        )}
+      >
+        If you have questions or believe a change is necessary, please do not
+        invite the employee. Instead, save this invitation as a draft and
+        contact your Account Executive or Customer Success Manager at Remote.
+      </p>
+
+      <p
+        className={cn(
+          'RemoteFlows__EmploymentAgreementInfoContent__Description',
+        )}
+      >
+        If neither is available, please reach out to{' '}
+        <a
+          href='mailto:help@remote.com'
+          className={cn('RemoteFlows__EmploymentAgreementInfoContent__Link')}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          help@remote.com ↗
+        </a>
+        . Our Legal team will review and, where possible, align your needs with
+        local compliance requirements, before inviting the employee, ensuring a
+        smooth onboarding process.
+      </p>
+
+      <p
+        className={cn(
+          'RemoteFlows__EmploymentAgreementInfoContent__Description',
+        )}
+      >
+        For guidance, see our{' '}
+        <ZendeskTriggerButton
+          className={cn(
+            'RemoteFlows__EmploymentAgreementInfoContent__ZendeskTriggerButton',
+          )}
+          zendeskId={zendeskArticles.employmentAgreements}
+        >
+          Employee Onboarding Timeline ↗
+        </ZendeskTriggerButton>{' '}
+        to understand what can (and can't) be modified.
+      </p>
+    </>
+  );
+};

--- a/src/flows/Onboarding/components/__tests__/EmploymentAgreementInfoContent.test.tsx
+++ b/src/flows/Onboarding/components/__tests__/EmploymentAgreementInfoContent.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { EmploymentAgreementInfoContent } from '../EmploymentAgreementInfoContent';
+
+describe('EmploymentAgreementInfoContent', () => {
+  it('should render without crashing', () => {
+    render(<EmploymentAgreementInfoContent />);
+
+    // Just check some key text is present
+    expect(
+      screen.getByText(/previewing a draft version/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/strongly discourage customizations/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/help@remote.com/i)).toBeInTheDocument();
+  });
+});

--- a/src/flows/Onboarding/components/__tests__/EmploymentAgreementInfoContent.test.tsx
+++ b/src/flows/Onboarding/components/__tests__/EmploymentAgreementInfoContent.test.tsx
@@ -6,9 +6,7 @@ describe('EmploymentAgreementInfoContent', () => {
     render(<EmploymentAgreementInfoContent />);
 
     // Just check some key text is present
-    expect(
-      screen.getByText(/previewing a draft version/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/previewing a draft version/i)).toBeInTheDocument();
     expect(
       screen.getByText(/strongly discourage customizations/i),
     ).toBeInTheDocument();

--- a/src/flows/Onboarding/index.ts
+++ b/src/flows/Onboarding/index.ts
@@ -1,4 +1,5 @@
 export { OnboardingFlow } from './OnboardingFlow';
+export { EmploymentAgreementInfoContent } from './components/EmploymentAgreementInfoContent';
 export type { OnboardingInviteProps } from './components/OnboardingInvite';
 export type { PreOnboardingRequirementsBag } from './components/PreOnboardingRequirements';
 export type {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,10 @@ export type {
   AcknowledgeInformationProps,
 } from '@/src/flows/Termination';
 
-export { OnboardingFlow } from '@/src/flows/Onboarding';
+export {
+  OnboardingFlow,
+  EmploymentAgreementInfoContent,
+} from '@/src/flows/Onboarding';
 
 export type {
   OnboardingInviteProps,


### PR DESCRIPTION
Add employment agreement modal to the example, we put the content into a component like we did for others for preferences of the partner that if we change the component the SSOT is on the SDK

<img width="2067" height="914" alt="image" src="https://github.com/user-attachments/assets/31a84a0c-c842-40a6-acc4-3b2cdd9842a3" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Informational UI and a new public export; no auth, data, or onboarding flow logic changes beyond enabling the example feature flag.
> 
> **Overview**
> Adds **`EmploymentAgreementInfoContent`** to the SDK as the single source of truth for copy shown when users learn about the employment agreement preview (draft disclaimer, anti-redlining guidance, **help@remote.com**, and a Zendesk **Agreement Engagement Guide** link via new **`zendeskArticles.employmentAgreements`**). The component is re-exported from the package entry points.
> 
> The **example** onboarding app enables the **`ea_preview`** feature, adds an **About this preview** control on the full-screen EA preview header, and opens a dialog that renders the exported content through **`EmploymentAgreementInfoModal`**. Bundle **size limit** total is raised slightly to accommodate the new code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0319f226ea1ad5768fc408f803dae0701e1f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->