### PR TITLE
docs(onboarding) - add demo tel implementation

### DIFF
--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -5,6 +5,7 @@ import type {
   FieldSetToggleComponentProps,
   FileComponentProps,
   PDFPreviewComponentProps,
+  TelFieldComponentProps,
 } from '@remoteoss/remote-flows';
 import { FileUploader } from '@remoteoss/remote-flows/internals';
 //import { ZendeskDialog } from './ZendeskDialog';
@@ -331,6 +332,78 @@ const PDFPreview = ({ base64Data }: PDFPreviewComponentProps) => {
   );
 };
 
+const TelField = ({ field, fieldData, fieldState }: TelFieldComponentProps) => {
+  const {
+    label,
+    description,
+    options,
+    onChangeCountryCode,
+    onChangePhoneNumber,
+    currentCountry,
+    nationalPhoneNumber,
+  } = fieldData;
+
+  const selectedCountryCode = currentCountry
+    ? `${currentCountry.name}-${currentCountry.dialCode}`
+    : '';
+
+  return (
+    <div className='input-container'>
+      {label && <label htmlFor={field.name}>{label}</label>}
+
+      <div className='flex gap-2'>
+        {/* Country Code Select */}
+        <div className='w-[180px]'>
+          <select
+            value={selectedCountryCode}
+            onChange={(e) => {
+              const country = options?.find(
+                (opt) =>
+                  `${opt.label}-${opt.meta?.countryCode}` === e.target.value,
+              );
+              if (country && onChangeCountryCode) {
+                onChangeCountryCode({
+                  name: country.label,
+                  dialCode: country.meta?.countryCode || '',
+                  pattern: country.pattern || '',
+                });
+              }
+            }}
+            className='w-full select'
+          >
+            <option value=''>Select country code</option>
+            {options?.map((option, index) => (
+              <option
+                key={`${option.label}-${option.meta?.countryCode}-${index}`}
+                value={`${option.label}-${option.meta?.countryCode}`}
+              >
+                {option.label} +{option.meta?.countryCode}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Phone Number Input */}
+        <div className='flex-1'>
+          <input
+            {...field}
+            type='tel'
+            className='input'
+            value={nationalPhoneNumber || ''}
+            onChange={onChangePhoneNumber}
+            placeholder="Employee's phone number"
+          />
+        </div>
+      </div>
+
+      {renderDescription(description, fieldData.transformHtml)}
+      {fieldState.error && (
+        <p className='error-message'>{fieldState.error.message}</p>
+      )}
+    </div>
+  );
+};
+
 export const components: Components = {
   button: Button,
   text: Input,
@@ -343,5 +416,6 @@ export const components: Components = {
   file: FileUploadField,
   date: DatePickerInput,
   pdfViewer: PDFPreview,
+  tel: TelField,
   //zendeskDrawer: ZendeskDialog,
 };

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -29,6 +29,7 @@ import { transformHtmlToComponents } from './utils/transformHtml';
 import { sanitizeHtml } from '@remoteoss/remote-flows/internals';
 import { downloadFile } from './utils';
 import './css/main.css';
+import { components } from './Components';
 
 const BenefitsAboutSection = ({
   description,
@@ -552,6 +553,7 @@ const OnboardingWithProps = ({
   <RemoteFlows
     proxy={{ url: window.location.origin }}
     transformHtmlToComponents={transformHtmlToComponents}
+    components={components}
   >
     <OnboardingFlow
       companyId={companyId}

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -29,7 +29,6 @@ import { transformHtmlToComponents } from './utils/transformHtml';
 import { sanitizeHtml } from '@remoteoss/remote-flows/internals';
 import { downloadFile } from './utils';
 import './css/main.css';
-import { components } from './Components';
 
 const BenefitsAboutSection = ({
   description,
@@ -553,7 +552,6 @@ const OnboardingWithProps = ({
   <RemoteFlows
     proxy={{ url: window.location.origin }}
     transformHtmlToComponents={transformHtmlToComponents}
-    components={components}
   >
     <OnboardingFlow
       companyId={companyId}


### PR DESCRIPTION
I am writing docs for external partners, decide to wrote a little demo so they know how to interact with the code

<img width="981" height="139" alt="image" src="https://github.com/user-attachments/assets/e78898c6-f5ca-4ef2-9b65-0aeef45015b5" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only UI demo with no production or security impact.
> 
> **Overview**
> Adds a **reference `tel` field implementation** to the example app’s custom `components` map so external partners can see how to render phone fields from `@remoteoss/remote-flows`.
> 
> The new `TelField` uses `TelFieldComponentProps`: a country-code `<select>` driven by `options` and `onChangeCountryCode`, plus a `type="tel"` input bound to `nationalPhoneNumber` / `onChangePhoneNumber`, with the same label, description, and error handling pattern as other demo fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f658108fcfd31a58827517015af756badb0aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->