### PR TITLE
docs(time-field) - add time demo

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -308,9 +308,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -328,9 +325,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -348,9 +342,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -368,9 +359,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -388,9 +376,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -408,9 +393,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -428,9 +410,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -448,9 +427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -641,9 +617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -661,9 +634,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -681,9 +651,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,9 +668,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,9 +685,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,9 +702,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -6,6 +6,7 @@ import type {
   FileComponentProps,
   PDFPreviewComponentProps,
   TelFieldComponentProps,
+  TimeFieldComponentProps,
 } from '@remoteoss/remote-flows';
 import { FileUploader } from '@remoteoss/remote-flows/internals';
 //import { ZendeskDialog } from './ZendeskDialog';
@@ -305,6 +306,7 @@ const DatePickerInput = ({
       <label htmlFor={field.name}>{fieldData.label}</label>
       <input
         type='date'
+        className='input'
         id={field.name}
         data-testid={`date-picker-input-${field.name}`}
         onChange={(e) => {
@@ -404,6 +406,34 @@ const TelField = ({ field, fieldData, fieldState }: TelFieldComponentProps) => {
   );
 };
 
+const TimeField = ({
+  field,
+  fieldData,
+  fieldState,
+}: TimeFieldComponentProps) => {
+  const hasError = !!fieldState.error;
+
+  return (
+    <div className='input-container'>
+      <label htmlFor={field.name}>{fieldData.label}</label>
+      <input
+        {...field}
+        type='time'
+        id={field.name}
+        className={`input ${hasError ? 'error' : ''}`}
+        value={field.value ?? ''}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          field.onChange(event);
+        }}
+      />
+      {renderDescription(fieldData.description, fieldData.transformHtml)}
+      {fieldState.error && (
+        <p className='error-message'>{fieldState.error.message}</p>
+      )}
+    </div>
+  );
+};
+
 export const components: Components = {
   button: Button,
   text: Input,
@@ -417,5 +447,6 @@ export const components: Components = {
   date: DatePickerInput,
   pdfViewer: PDFPreview,
   tel: TelField,
+  time: TimeField,
   //zendeskDrawer: ZendeskDialog,
 };

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -30,6 +30,7 @@ import { transformHtmlToComponents } from './utils/transformHtml';
 import { sanitizeHtml } from '@remoteoss/remote-flows/internals';
 import { downloadFile } from './utils';
 import './css/main.css';
+import { components } from './Components';
 
 const BenefitsAboutSection = ({
   description,
@@ -588,6 +589,7 @@ const OnboardingWithProps = ({
   <RemoteFlows
     proxy={{ url: window.location.origin }}
     transformHtmlToComponents={transformHtmlToComponents}
+    components={components}
   >
     <OnboardingFlow
       companyId={companyId}

--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -30,7 +30,6 @@ import { transformHtmlToComponents } from './utils/transformHtml';
 import { sanitizeHtml } from '@remoteoss/remote-flows/internals';
 import { downloadFile } from './utils';
 import './css/main.css';
-import { components } from './Components';
 
 const BenefitsAboutSection = ({
   description,
@@ -589,7 +588,6 @@ const OnboardingWithProps = ({
   <RemoteFlows
     proxy={{ url: window.location.origin }}
     transformHtmlToComponents={transformHtmlToComponents}
-    components={components}
   >
     <OnboardingFlow
       companyId={companyId}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1764,9 +1764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1784,9 +1781,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1804,9 +1798,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1824,9 +1815,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1844,9 +1832,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,9 +1849,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1884,9 +1866,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1883,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2111,9 +2087,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2131,9 +2104,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2151,9 +2121,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2171,9 +2138,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,9 +2155,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2211,9 +2172,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2231,9 +2189,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2251,9 +2206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
Add time to let partners know how to override this field

<img width="1636" height="1524" alt="image" src="https://github.com/user-attachments/assets/e12a9e36-c49d-4d11-95dd-d3a5d0394be8" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app and documentation-only UI changes with incidental lockfile metadata updates; no production library behavior changes in this diff.
> 
> **Overview**
> Adds a **sample `time` field override** in the example app so partners can see how to customize time inputs the same way as other field types.
> 
> The new `TimeField` uses a native `type="time"` input with label, description, and error styling, and is registered on the shared `components` map. **Onboarding** now passes that map into `RemoteFlows`, so the demo actually exercises custom components during the flow. The date picker demo also picks up the shared `input` class for consistent styling.
> 
> Lockfile-only edits remove `libc` metadata from several optional Linux native bindings (no application logic change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b482999b30cd227daf16aa9f56b75cd118c3b4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->