### PR TITLE
1.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @remoteoss/remote-flows
 
+## 1.40.1
+
+### Patch Changes
+
+- update dependency oxfmt to v0.54.0 (#1056) [#1056](https://github.com/remoteoss/remote-flows/pull/1056)
+- update dependency tsx to v4.22.4 (#1059) [#1059](https://github.com/remoteoss/remote-flows/pull/1059)
+- update dependency dompurify to v3.4.11 [security] (#1091) [#1091](https://github.com/remoteoss/remote-flows/pull/1091)
+- update oxlint monorepo to v1.69.0 (#1057) [#1057](https://github.com/remoteoss/remote-flows/pull/1057)
+- update react monorepo to v19.2.17 (#1093) [#1093](https://github.com/remoteoss/remote-flows/pull/1093)
+- update tanstack-query monorepo to v5.101.0 (#1053) [#1053](https://github.com/remoteoss/remote-flows/pull/1053)
+- update dependency @arethetypeswrong/cli to v0.18.3 (#1092) [#1092](https://github.com/remoteoss/remote-flows/pull/1092)
+- update vitest monorepo to v4.1.8 (#1052) [#1052](https://github.com/remoteoss/remote-flows/pull/1052)
+- update dependency @remoteoss/remote-json-schema-form-kit to v0.0.15 (#1094) [#1094](https://github.com/remoteoss/remote-flows/pull/1094)
+- update radix-ui-primitives monorepo (#1096) [#1096](https://github.com/remoteoss/remote-flows/pull/1096)
+- update dependency html-react-parser to v6.1.3 (#1095) [#1095](https://github.com/remoteoss/remote-flows/pull/1095)
+- update dependency @hookform/resolvers to v5.4.0 (#1097) [#1097](https://github.com/remoteoss/remote-flows/pull/1097)
+- update dependency axios to v1.17.0 (#1098) [#1098](https://github.com/remoteoss/remote-flows/pull/1098)
+- update dependency axios to v1.18.0 (#1102) [#1102](https://github.com/remoteoss/remote-flows/pull/1102)
+- add time demo (#1103) [#1103](https://github.com/remoteoss/remote-flows/pull/1103)
+- fix punctuation (#1104) [#1104](https://github.com/remoteoss/remote-flows/pull/1104)
+- update vitest monorepo to v4.1.9 (#1105) [#1105](https://github.com/remoteoss/remote-flows/pull/1105)
+- update dependency oxfmt to v0.55.0 (#1107) [#1107](https://github.com/remoteoss/remote-flows/pull/1107)
+- update playwright monorepo to v1.61.0 (#1106) [#1106](https://github.com/remoteoss/remote-flows/pull/1106)
+- update oxlint monorepo (#1109) [#1109](https://github.com/remoteoss/remote-flows/pull/1109)
+
 ## 1.40.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",
@@ -2087,9 +2087,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2107,9 +2104,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2127,9 +2121,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,9 +2138,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2167,9 +2155,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2187,9 +2172,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2207,9 +2189,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2227,9 +2206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.40.1

### Patch Changes

#### Fixes

- fix punctuation (#1104) [#1104](https://github.com/remoteoss/remote-flows/pull/1104)

#### Chores

- update dependency oxfmt to v0.54.0 (#1056) [#1056](https://github.com/remoteoss/remote-flows/pull/1056)
- update dependency tsx to v4.22.4 (#1059) [#1059](https://github.com/remoteoss/remote-flows/pull/1059)
- update dependency dompurify to v3.4.11 [security] (#1091) [#1091](https://github.com/remoteoss/remote-flows/pull/1091)
- update oxlint monorepo to v1.69.0 (#1057) [#1057](https://github.com/remoteoss/remote-flows/pull/1057)
- update react monorepo to v19.2.17 (#1093) [#1093](https://github.com/remoteoss/remote-flows/pull/1093)
- update tanstack-query monorepo to v5.101.0 (#1053) [#1053](https://github.com/remoteoss/remote-flows/pull/1053)
- update dependency @arethetypeswrong/cli to v0.18.3 (#1092) [#1092](https://github.com/remoteoss/remote-flows/pull/1092)
- update vitest monorepo to v4.1.8 (#1052) [#1052](https://github.com/remoteoss/remote-flows/pull/1052)
- update dependency @remoteoss/remote-json-schema-form-kit to v0.0.15 (#1094) [#1094](https://github.com/remoteoss/remote-flows/pull/1094)
- update radix-ui-primitives monorepo (#1096) [#1096](https://github.com/remoteoss/remote-flows/pull/1096)
- update dependency html-react-parser to v6.1.3 (#1095) [#1095](https://github.com/remoteoss/remote-flows/pull/1095)
- update dependency @hookform/resolvers to v5.4.0 (#1097) [#1097](https://github.com/remoteoss/remote-flows/pull/1097)
- update dependency axios to v1.17.0 (#1098) [#1098](https://github.com/remoteoss/remote-flows/pull/1098)
- update dependency axios to v1.18.0 (#1102) [#1102](https://github.com/remoteoss/remote-flows/pull/1102)
- add time demo (#1103) [#1103](https://github.com/remoteoss/remote-flows/pull/1103)
- update vitest monorepo to v4.1.9 (#1105) [#1105](https://github.com/remoteoss/remote-flows/pull/1105)
- update dependency oxfmt to v0.55.0 (#1107) [#1107](https://github.com/remoteoss/remote-flows/pull/1107)
- update playwright monorepo to v1.61.0 (#1106) [#1106](https://github.com/remoteoss/remote-flows/pull/1106)
- update oxlint monorepo (#1109) [#1109](https://github.com/remoteoss/remote-flows/pull/1109)


---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR is a version and changelog publish with lockfile refresh; runtime behavior changes are from already-merged patches, with moderate regression risk mainly from axios/React/dompurify bumps rather than new logic in this diff.
> 
> **Overview**
> **Release 1.40.1** bumps `@remoteoss/remote-flows` from **1.40.0** to **1.40.1** in `package.json`, `package-lock.json`, and a new **CHANGELOG** section listing patch-level work already merged on main.
> 
> The shipped notes include **dependency and toolchain updates** (React 19.2.17, TanStack Query 5.101.0, Radix, Vitest/Playwright, oxfmt/oxlint, **axios** 1.18.0, **dompurify** 3.4.11 security, form-kit **0.0.15**, and related bumps) plus small product/docs touches (**time demo**, **punctuation fix**). The visible diff is mostly version metadata and lockfile housekeeping (e.g. oxlint binding `libc` fields removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe73a81cfd7e5c99b68e744b4229edef089aa73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->