### PR TITLE
fix(preonboarding) - fix sandbox bug when request fails

### DIFF
--- a/src/flows/Onboarding/components/PreOnboardingRequirements.tsx
+++ b/src/flows/Onboarding/components/PreOnboardingRequirements.tsx
@@ -12,18 +12,27 @@ export const usePreOnboardingRequirements = ({
   employmentId,
 }: {
   employmentId: string;
+  options?: Parameters<typeof useGetPreOnboardingRequirements>[1];
 }) => {
+  const { onboardingBag } = useOnboardingContext();
   const [documentIds, setDocumentIds] = useState<Record<string, string>>({});
   const [activeRequirementSlug, setActiveRequirementSlug] = useState<
     string | undefined
   >();
+
+  const isPreOnboardingRequirementsEnabled = Boolean(
+    onboardingBag.options?.features?.includes('pre_onboarding_requirements') &&
+    !!employmentId,
+  );
 
   const {
     data: requirements,
     isLoading: isLoadingRequirements,
     refetch: refetchRequirements,
   } = useGetPreOnboardingRequirements(employmentId, {
-    queryOptions: { enabled: !!employmentId },
+    queryOptions: {
+      enabled: isPreOnboardingRequirementsEnabled,
+    },
   });
 
   const activeDocumentId = activeRequirementSlug

--- a/src/flows/Onboarding/components/__tests__/PreOnboardingRequirements.test.tsx
+++ b/src/flows/Onboarding/components/__tests__/PreOnboardingRequirements.test.tsx
@@ -31,6 +31,9 @@ const mockOnboardingBag = {
       index: 4,
     },
   },
+  options: {
+    features: ['pre_onboarding_requirements'],
+  },
 };
 
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -326,38 +326,26 @@ export const useOnboarding = ({
       isOnboardingReservesEnabled,
     );
 
-  const {
-    data: requirements,
-    isLoading: isLoadingPreOnboardingRequirements,
-    isError: isErrorPreOnboardingRequirements,
-  } = useGetPreOnboardingRequirements(internalEmploymentId as string, {
-    queryOptions: { enabled: !!internalEmploymentId },
-  });
+  const { data: requirements, isLoading: isLoadingPreOnboardingRequirements } =
+    useGetPreOnboardingRequirements(internalEmploymentId as string, {
+      queryOptions: { enabled: !!internalEmploymentId },
+    });
 
   const arePreOnboardingRequirementsFulfilled = useMemo(() => {
     // While loading, block the invite
     if (isLoadingPreOnboardingRequirements) {
       return false;
     }
-    // If error or no requirements, allow invite (don't block the flow)
-    if (
-      isErrorPreOnboardingRequirements ||
-      !requirements ||
-      requirements.length === 0
-    ) {
+    // If no requirements data at all, allow invite (don't block the flow)
+    if (!requirements || requirements.length === 0) {
       return true;
     }
 
-    // Check if all requirements are finished
-    return (
-      requirements?.every((requirement) => requirement.status === 'finished') ??
-      false
+    // Check if all requirements are finished (even if there's an error, check cached data)
+    return requirements.every(
+      (requirement) => requirement.status === 'finished',
     );
-  }, [
-    requirements,
-    isLoadingPreOnboardingRequirements,
-    isErrorPreOnboardingRequirements,
-  ]);
+  }, [requirements, isLoadingPreOnboardingRequirements]);
 
   const {
     selectCountryForm,

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -326,12 +326,15 @@ export const useOnboarding = ({
       isOnboardingReservesEnabled,
     );
 
+  const isPreOnboardingRequirementsEnabled = Boolean(
+    options?.features?.includes('pre_onboarding_requirements') &&
+    !!internalEmploymentId,
+  );
+
   const { data: requirements, isLoading: isLoadingPreOnboardingRequirements } =
     useGetPreOnboardingRequirements(internalEmploymentId as string, {
       queryOptions: {
-        enabled:
-          !!internalEmploymentId &&
-          options?.features?.includes('pre_onboarding_requirements'),
+        enabled: isPreOnboardingRequirementsEnabled,
       },
     });
 
@@ -1038,6 +1041,13 @@ export const useOnboarding = ({
      * Employment id passed useful to be used between components
      */
     employmentId: internalEmploymentId,
+
+    /**
+     * Onboarding flow options (feature flags)
+     */
+    options: {
+      features: options?.features,
+    },
 
     /**
      * Credit risk status of the company, useful to know what to to show in the review step

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -335,14 +335,20 @@ export const useOnboarding = ({
   });
 
   const arePreOnboardingRequirementsFulfilled = useMemo(() => {
-    if (
-      !requirements ||
-      isLoadingPreOnboardingRequirements ||
-      isErrorPreOnboardingRequirements
-    ) {
+    // While loading, block the invite
+    if (isLoadingPreOnboardingRequirements) {
       return false;
     }
-    if (requirements?.length === 0) return true;
+    // If error or no requirements, allow invite (don't block the flow)
+    if (
+      isErrorPreOnboardingRequirements ||
+      !requirements ||
+      requirements.length === 0
+    ) {
+      return true;
+    }
+
+    // Check if all requirements are finished
     return (
       requirements?.every((requirement) => requirement.status === 'finished') ??
       false

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -328,7 +328,11 @@ export const useOnboarding = ({
 
   const { data: requirements, isLoading: isLoadingPreOnboardingRequirements } =
     useGetPreOnboardingRequirements(internalEmploymentId as string, {
-      queryOptions: { enabled: !!internalEmploymentId },
+      queryOptions: {
+        enabled:
+          !!internalEmploymentId &&
+          options?.features?.includes('pre_onboarding_requirements'),
+      },
     });
 
   const arePreOnboardingRequirementsFulfilled = useMemo(() => {

--- a/src/flows/Onboarding/tests/OnboardingInvite.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingInvite.test.tsx
@@ -1209,6 +1209,10 @@ describe('OnboardingInvite', () => {
 
   describe('pre-onboarding requirements', () => {
     it('should disable button when pre-onboarding requirements are not finished', async () => {
+      defaultProps.options = {
+        features: ['pre_onboarding_requirements'],
+      };
+
       server.use(
         http.get(
           '*/v1/onboarding/employments/:employmentId/pre-onboarding-document-requirements',
@@ -1226,6 +1230,10 @@ describe('OnboardingInvite', () => {
     });
 
     it('should enable button when all pre-onboarding requirements are finished', async () => {
+      defaultProps.options = {
+        features: ['pre_onboarding_requirements'],
+      };
+
       server.use(
         http.get(
           '*/v1/onboarding/employments/:employmentId/pre-onboarding-document-requirements',
@@ -1266,6 +1274,10 @@ describe('OnboardingInvite', () => {
     });
 
     it('should disable button when at least one requirement is not finished', async () => {
+      defaultProps.options = {
+        features: ['pre_onboarding_requirements'],
+      };
+
       server.use(
         http.get(
           '*/v1/onboarding/employments/:employmentId/pre-onboarding-document-requirements',

--- a/src/flows/Onboarding/types.ts
+++ b/src/flows/Onboarding/types.ts
@@ -62,7 +62,8 @@ export type OnboardingRenderProps = {
 type OnboardingFeatures =
   | 'onboarding_reserves'
   | 'dynamic_steps'
-  | 'ea_preview';
+  | 'ea_preview'
+  | 'pre_onboarding_requirements';
 
 /**
  * JSON schema version configuration for a specific country


### PR DESCRIPTION
First cause was endpoint removed in the API

Second bug when API failed the business logic failed

Third if we had put the feature flag first wouldn't have happened, two would have still be there, not a bad thing to find it


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when invite is allowed relative to pre-onboarding API failures and feature flags, which affects review-step onboarding behavior in production when the flag is enabled.
> 
> **Overview**
> Pre-onboarding document requirements are now behind the **`pre_onboarding_requirements`** onboarding feature flag, so environments without the API (e.g. sandbox) no longer hit the requirements endpoint unless the flag is on.
> 
> **Invite gating** was adjusted: loading still disables invite; missing or empty requirements no longer block invite; API errors no longer force invite to stay disabled (cached requirement data is still evaluated when present). The same flag gates fetches in **`usePreOnboardingRequirements`**, and **`useOnboarding`** exposes **`options.features`** on the onboarding bag for components/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4268f6c528c0c4df54eb943d21c266b684d97d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->