### PR TITLE
1.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @remoteoss/remote-flows
 
+## 1.41.1
+
+### Patch Changes
+
+- update actions/checkout action to v7 (#1113) [#1113](https://github.com/remoteoss/remote-flows/pull/1113)
+- fix sandbox bug when request fails (#1117) [#1117](https://github.com/remoteoss/remote-flows/pull/1117)
+
 ## 1.41.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Patch Changes
 
-- update actions/checkout action to v7 (#1113) [#1113](https://github.com/remoteoss/remote-flows/pull/1113)
+#### Fixes
+
 - fix sandbox bug when request fails (#1117) [#1117](https://github.com/remoteoss/remote-flows/pull/1117)
+
+#### Chores
+
+- update actions/checkout action to v7 (#1113) [#1113](https://github.com/remoteoss/remote-flows/pull/1113)
 
 ## 1.41.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.41.1

### Patch Changes

#### Fixes

- fix sandbox bug when request fails (#1117) [#1117](https://github.com/remoteoss/remote-flows/pull/1117)

#### Chores

- update actions/checkout action to v7 (#1113) [#1113](https://github.com/remoteoss/remote-flows/pull/1113)

---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch version and changelog/lockfile updates only in this PR; functional changes are small fixes documented from prior merges.
> 
> **Overview**
> **Patch release** that bumps `@remoteoss/remote-flows` from **1.41.0** to **1.41.1** in `package.json`, `package-lock.json`, and adds a **1.41.1** section to `CHANGELOG.md`.
> 
> The changelog records two changes already merged on main: a **fix for sandbox behavior when API requests fail** (#1117) and a **CI chore** bumping `actions/checkout` to v7 (#1113). This PR’s diff is release bookkeeping only—no additional application source changes appear in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b5daac5d51c37c6b9b20dcb25777773f8ba3db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->