### PR TITLE
docs(onboarding): update schema versions

### DIFF
--- a/src/components/JsonSchemaComparison/schemaVersions.ts
+++ b/src/components/JsonSchemaComparison/schemaVersions.ts
@@ -12,7 +12,7 @@ export const BASIC_INFO_VERSIONS: VersionOption[] = [
 
 // AI generated from tiger
 // Last updated: 2026-06-29
-const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
+export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   ALB: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },

--- a/src/components/JsonSchemaComparison/schemaVersions.ts
+++ b/src/components/JsonSchemaComparison/schemaVersions.ts
@@ -11,46 +11,67 @@ export const BASIC_INFO_VERSIONS: VersionOption[] = [
 ];
 
 // AI generated from tiger
-export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
-  ALB: [{ value: 1, label: 'v1' }],
+// Last updated: 2026-06-29
+const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
+  ALB: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   ARE: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
   ],
-  ARG: [{ value: 1, label: 'v1' }],
+  ARG: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   ARM: [{ value: 1, label: 'v1' }],
-  AUS: [{ value: 1, label: 'v1' }],
-  AUT: [
+  AUS: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
   ],
+  AUT: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
+    { value: 5, label: 'v5' },
+    { value: 6, label: 'v6' },
+  ],
   BEL: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   BGD: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   BGR: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   BIH: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   BLR: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
   ],
   BOL: [{ value: 1, label: 'v1' }],
-  BRA: [{ value: 1, label: 'v1' }],
+  BRA: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   CAN: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
@@ -58,27 +79,53 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   CHE: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
-  CHL: [{ value: 1, label: 'v1' }],
-  CHN: [
+  CHL: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
   ],
-  COL: [{ value: 1, label: 'v1' }],
-  CRI: [{ value: 1, label: 'v1' }],
-  CYP: [{ value: 1, label: 'v1' }],
+  CHN: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
+    { value: 5, label: 'v5' },
+  ],
+  COL: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  CRI: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+  ],
+  CYP: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   CZE: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   DEU: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
-  DNK: [{ value: 1, label: 'v1' }],
-  DOM: [{ value: 1, label: 'v1' }],
+  DNK: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  DOM: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   ECU: [{ value: 1, label: 'v1' }],
   EGY: [
     { value: 1, label: 'v1' },
@@ -87,21 +134,39 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   ESP: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
-  EST: [{ value: 1, label: 'v1' }],
-  FIN: [{ value: 1, label: 'v1' }],
+  EST: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  FIN: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   FRA: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
   ],
-  //FRA_SAS: [{ value: 1, label: 'v1' }],
+  FRA_SAS: [{ value: 1, label: 'v1' }],
   GBR: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
-  GEO: [{ value: 1, label: 'v1' }],
-  GRC: [{ value: 1, label: 'v1' }],
-  GTM: [{ value: 1, label: 'v1' }],
+  GEO: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  GRC: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  GTM: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+  ],
   HKG: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
@@ -110,21 +175,30 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   HRV: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   HUN: [{ value: 1, label: 'v1' }],
   IDN: [{ value: 1, label: 'v1' }],
   IND: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   IRL: [{ value: 1, label: 'v1' }],
   ISL: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
   ],
-  ISR: [{ value: 1, label: 'v1' }],
-  ITA: [{ value: 1, label: 'v1' }],
-  //ITA_APL: [{ value: 1, label: 'v1' }],
+  ISR: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+  ],
+  ITA: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  ITA_APL: [{ value: 1, label: 'v1' }],
   JAM: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
@@ -136,6 +210,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   KEN: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   KGZ: [{ value: 1, label: 'v1' }],
   KHM: [{ value: 1, label: 'v1' }],
@@ -143,6 +218,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   LBN: [
     { value: 1, label: 'v1' },
@@ -152,24 +228,37 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
-  LTU: [{ value: 1, label: 'v1' }],
+  LTU: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   LUX: [{ value: 1, label: 'v1' }],
   LVA: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
-  MAR: [{ value: 1, label: 'v1' }],
-  MDA: [{ value: 1, label: 'v1' }],
+  MAR: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  MDA: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   MEX: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   MKD: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   MLT: [{ value: 1, label: 'v1' }],
   MNG: [{ value: 1, label: 'v1' }],
@@ -186,31 +275,53 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 2, label: 'v2' },
   ],
   NIC: [{ value: 1, label: 'v1' }],
-  NLD: [{ value: 1, label: 'v1' }],
+  NLD: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   NOR: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   NZL: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   PAK: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
   ],
-  PAN: [{ value: 1, label: 'v1' }],
+  PAN: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   PER: [{ value: 1, label: 'v1' }],
   PHL: [{ value: 1, label: 'v1' }],
-  POL: [{ value: 1, label: 'v1' }],
-  PRI: [{ value: 1, label: 'v1' }],
+  POL: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  PRI: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   PRT: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
-  PRY: [{ value: 1, label: 'v1' }],
-  ROU: [{ value: 1, label: 'v1' }],
+  PRY: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  ROU: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   SAU: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
@@ -224,16 +335,22 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
-  SVK: [{ value: 1, label: 'v1' }],
+  SVK: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   SVN: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   SWE: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   THA: [
     { value: 1, label: 'v1' },
@@ -244,15 +361,30 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
   ],
-  TUR: [{ value: 1, label: 'v1' }],
-  TWN: [{ value: 1, label: 'v1' }],
+  TUR: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
+  ],
+  TWN: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   UGA: [{ value: 1, label: 'v1' }],
   UKR: [{ value: 1, label: 'v1' }],
-  URY: [{ value: 1, label: 'v1' }],
-  USA: [{ value: 1, label: 'v1' }],
+  URY: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
+  USA: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   VNM: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   XKX: [{ value: 1, label: 'v1' }],
   ZAF: [{ value: 1, label: 'v1' }],


### PR DESCRIPTION
Update the generated schema versions, that we haven't done that in a while

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wrong version counts could mis-route schema fetches or comparisons for affected countries; GBR onboarding now defaults to v3 instead of v2.
> 
> **Overview**
> Refreshes **`COUNTRY_CONTRACT_VERSIONS`** in `schemaVersions.ts` to match backend (tiger) contract-detail schema snapshots: many countries gain additional selectable versions (v2–v6 where applicable), previously commented **`FRA_SAS`** and **`ITA_APL`** entries are enabled, and a **Last updated: 2026-06-29** note is added.
> 
> In **`Onboarding.tsx`**, the United Kingdom (**GBR**) default **`contract_details`** schema version is raised from **2** to **3**, aligning onboarding with the new GBR v3 mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc6969efe3953ad9ddc273b32223a931c0a7f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->