### PR TITLE
chore(e2e) - setup nightly e2e

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -10,6 +10,8 @@ jobs:
   e2e-tests-production:
     name: E2E Tests (Production)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +62,7 @@ jobs:
       issues: write
     steps:
       - name: Create Issue
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
@@ -70,6 +72,6 @@ jobs:
               title: `Nightly E2E Tests Failed - ${new Date().toISOString().split('T')[0]}`,
               body: `## Nightly E2E Test Failure\n\n**Workflow Run:** ${runUrl}\n\n**Date:** ${new Date().toISOString()}\n\nPlease review the Playwright reports in the workflow artifacts.`,
               labels: ['e2e-failure', 'automated'],
-              assignees: ['gabrielseco', 'jordividaller', 'cammellos'] 
+              assignees: ['gabrielseco', 'jordividaller', 'cammellos']
             });
             console.log(`Created issue #${issue.data.number}`);

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +39,7 @@ jobs:
         run: npx playwright install ${{ matrix.browser }} --with-deps
 
       - name: Run Playwright tests
+        id: playwright-tests
         env:
           BASE_URL: https://remote-flows.vercel.app
           VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
@@ -69,9 +71,8 @@ jobs:
             const issue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Nightly E2E Tests Failed - ${new Date().toISOString().split('T')[0]}`,
-              body: `## Nightly E2E Test Failure\n\n**Workflow Run:** ${runUrl}\n\n**Date:** ${new Date().toISOString()}\n\nPlease review the Playwright reports in the workflow artifacts.`,
-              labels: ['e2e-failure', 'automated'],
+              title: `Nightly E2E Workflow Failed - ${new Date().toISOString().split('T')[0]}`,
+              body: `## Nightly E2E Workflow Failure\n\n**Workflow Run:** ${runUrl}\n\n**Date:** ${new Date().toISOString()}\n\n**Note:** This could be a test failure or an infrastructure issue (npm install, browser setup, etc.). Please review the workflow logs and Playwright reports in the artifacts.`,
               assignees: ['gabrielseco', 'jordividaller', 'cammellos']
             });
             console.log(`Created issue #${issue.data.number}`);

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,75 @@
+name: E2E Nightly
+
+on:
+  schedule:
+    # Run at 2 AM UTC every day
+    - cron: '0 2 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  e2e-tests-production:
+    name: E2E Tests (Production)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24.15.0'
+
+      - name: Install main package dependencies
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Install example/ dependencies
+        working-directory: ./example
+        run: npm ci --include=optional --ignore-scripts
+
+      - name: Install Playwright browsers
+        working-directory: ./example
+        run: npx playwright install ${{ matrix.browser }} --with-deps
+
+      - name: Run Playwright tests
+        env:
+          BASE_URL: https://remote-flows.vercel.app
+          VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
+          DEBUG: pw:api
+        working-directory: ./example
+        run: npx playwright test --project=${{ matrix.browser }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: example/playwright-report/
+          retention-days: 30
+
+  create-issue-on-failure:
+    name: Create Issue on Failure
+    runs-on: ubuntu-latest
+    needs: e2e-tests-production
+    if: failure()
+    permissions:
+      issues: write
+    steps:
+      - name: Create Issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly E2E Tests Failed - ${new Date().toISOString().split('T')[0]}`,
+              body: `## Nightly E2E Test Failure\n\n**Workflow Run:** ${runUrl}\n\n**Date:** ${new Date().toISOString()}\n\nPlease review the Playwright reports in the workflow artifacts.`,
+              labels: ['e2e-failure', 'automated'],
+              assignees: ['gabrielseco', 'jordividaller', 'cammellos'] 
+            });
+            console.log(`Created issue #${issue.data.number}`);


### PR DESCRIPTION
Run e2e at 2.00 UTC and create issues to devs if something goes wrong

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change; it reuses existing Playwright setup and secrets without modifying application or deployment logic.
> 
> **Overview**
> Adds a **scheduled GitHub Actions workflow** that runs the existing `example/` Playwright suite against **production** (`https://remote-flows.vercel.app`) every night at 2:00 UTC, with **manual `workflow_dispatch`** as well.
> 
> Unlike PR/main CI (Chromium + preview URL), this job uses a **browser matrix** (Chromium, Firefox, WebKit), reuses the same install/test env (`BASE_URL`, `VERCEL_BYPASS_TOKEN`), and uploads **per-browser** HTML reports. A follow-up job **opens a GitHub issue** (assigned to the listed maintainers) when the nightly run fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604857d267d8a9a956aaa28f9eac809da244150f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->