### PR TITLE
docs: add GBR contract details v3 upgrade docs

### DIFF
--- a/docs/schema-changes/eor/contract-details/countries/GBR.md
+++ b/docs/schema-changes/eor/contract-details/countries/GBR.md
@@ -4,11 +4,33 @@ Schema versions for employee onboarding in United Kingdom.
 
 ## Current Version
 
-**Contract Details:** v2 (Since SDK 1.23.0)
+**Contract Details:** v3 (Since SDK TBD, enforced July 1, 2026)
 
 ## Contract Details
 
-### v2 - Current (Since SDK 1.23.0, March 2026)
+### v3 - Current (Since SDK TBD, enforced July 1, 2026)
+
+**What changed:**
+
+- Removed `shift_pattern` field
+- Added `risks_acknowledgment` required field — acknowledgement of UK employment law risks
+- Added `work_schedule` as a required field
+
+**Migration:**
+
+```tsx
+<OnboardingFlow
+  options={{
+    jsonSchemaVersionByCountry: {
+      GBR: { contract_details: 3 },
+    },
+  }}
+/>
+```
+
+---
+
+### v2 (Since SDK 1.23.0, March 2026)
 
 **What changed:**
 

--- a/docs/schema-changes/eor/contract-details/countries/GBR.md
+++ b/docs/schema-changes/eor/contract-details/countries/GBR.md
@@ -4,11 +4,11 @@ Schema versions for employee onboarding in United Kingdom.
 
 ## Current Version
 
-**Contract Details:** v3 (Since SDK TBD, enforced July 1, 2026)
+**Contract Details:** v3
 
 ## Contract Details
 
-### v3 - Current (Since SDK TBD, enforced July 1, 2026)
+### v3 - Current
 
 **What changed:**
 
@@ -30,7 +30,7 @@ Schema versions for employee onboarding in United Kingdom.
 
 ---
 
-### v2 (Since SDK 1.23.0, March 2026)
+### v2
 
 **What changed:**
 
@@ -50,6 +50,6 @@ Schema versions for employee onboarding in United Kingdom.
 
 ---
 
-### v1 (SDK 1.0.0)
+### v1
 
 Initial version with basic contract details fields.


### PR DESCRIPTION
## Summary

- Documents the v3 GBR contract details schema (enforced July 1, 2026)
- Notes removed `shift_pattern` field and two new required fields: `risks_acknowledgment` and `work_schedule`
- Preserves v1/v2 history in the same file

## Test plan

- [ ] Review the rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)