### PR TITLE
fix: datepicker dropdown navigation + JSF logging + build heap

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "audit": "npm audit --audit-level=high",
-    "build": "NODE_ENV=production tsup",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' NODE_ENV=production tsup",
     "ci": "npm run build && npm run check-format && npm run check-exports && npm run lint && npm run type-check && npm run test",
     "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm --exclude-entrypoints index.css styles.css --profile node16",
     "check-format": "oxfmt --check",

--- a/src/common/createHeadlessForm.tsx
+++ b/src/common/createHeadlessForm.tsx
@@ -25,7 +25,16 @@ export const createHeadlessForm = (
 ): JSONSchemaFormResultWithFieldsets => {
   if (options && options.jsfModify) {
     const { required, allOf, ...modifyConfig } = options.jsfModify;
-    const { schema } = modify(jsfSchema, modifyConfig);
+    // muteLogging: true suppresses the generic library log; we surface the
+    // actual warnings ourselves when present so they're actionable.
+    const { schema, warnings } = modify(jsfSchema, {
+      ...modifyConfig,
+      muteLogging: true,
+    } as Parameters<typeof modify>[1]);
+    if (warnings && warnings.length > 0) {
+      // eslint-disable-next-line no-console
+      console.warn('jsfModify warnings:', warnings);
+    }
     jsfSchema = schema;
 
     if (required) {

--- a/src/components/form/fields/default/DatePickerFieldDefault.tsx
+++ b/src/components/form/fields/default/DatePickerFieldDefault.tsx
@@ -29,6 +29,10 @@ export function DatePickerFieldDefault({
   const maxDateValue = maxDate ? new Date(maxDate) : undefined;
   const [open, setOpen] = useState(false);
 
+  const currentYear = new Date().getFullYear();
+  const fromYear = minDateValue ? minDateValue.getFullYear() : 1900;
+  const toYear = maxDateValue ? maxDateValue.getFullYear() : currentYear + 10;
+
   return (
     <FormItem
       data-field={name}
@@ -62,6 +66,9 @@ export function DatePickerFieldDefault({
         >
           <Calendar
             mode='single'
+            captionLayout='dropdown'
+            fromYear={fromYear}
+            toYear={toYear}
             className='RemoteFlows__DatepickerField__Calendar'
             selected={field.value ? new Date(field.value) : undefined}
             onDayClick={(day) => {
@@ -69,7 +76,11 @@ export function DatePickerFieldDefault({
               field.onChange(formattedDate);
               setOpen(false);
             }}
-            defaultMonth={minDateValue}
+            defaultMonth={
+              field.value
+                ? new Date(field.value)
+                : (maxDateValue ?? minDateValue)
+            }
             disabled={(date: Date) => {
               if (minDateValue && date < minDateValue) return true;
               if (maxDateValue && date > maxDateValue) return true;

--- a/src/components/form/fields/default/DatePickerFieldDefault.tsx
+++ b/src/components/form/fields/default/DatePickerFieldDefault.tsx
@@ -31,7 +31,10 @@ export function DatePickerFieldDefault({
 
   const currentYear = new Date().getFullYear();
   const fromYear = minDateValue ? minDateValue.getFullYear() : 1900;
-  const toYear = maxDateValue ? maxDateValue.getFullYear() : currentYear + 10;
+  const toYear = Math.max(
+    fromYear,
+    maxDateValue ? maxDateValue.getFullYear() : currentYear + 10,
+  );
 
   return (
     <FormItem

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -225,4 +225,40 @@
     height: 0.875rem;
     width: 0.875rem;
   }
+
+  /* Caption dropdown layout (captionLayout="dropdown") — month/year selects */
+  .rdp-caption_dropdowns {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .rdp-dropdown {
+    appearance: none;
+    -webkit-appearance: none;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.15rem 1.5rem 0.15rem 0.5rem;
+    cursor: pointer;
+    color: var(--color-foreground);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2371717a' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.35rem center;
+  }
+
+  .rdp-dropdown:focus {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 1px;
+  }
+
+  .rdp-dropdown_month {
+    min-width: 5rem;
+  }
+
+  .rdp-dropdown_year {
+    min-width: 4rem;
+  }
 }


### PR DESCRIPTION
## Summary

Standalone infrastructure improvements, no new flows.

- **JSF**: pass `muteLogging: true` to `modify()` to suppress generic library noise; forward any returned warnings to `console.warn` so they remain actionable.
- **Build**: raise Node heap to 8192 MB for production `tsup` builds to prevent OOM on larger bundles.
- **DatePicker**: add `captionLayout="dropdown"` with year range derived from `min`/`max` date
  constraints. The arrow-only navigation is impractical for fields like date of birth where
  the valid range spans decades — a dropdown lets users jump directly to the right year.
  Also fix `defaultMonth` to follow the current field value rather than always jumping to `minDate`.
  Add CSS for the unstyled month/year select elements that the dropdown mode relies on.
## Test plan

- [x] Open a date field (e.g. in ContractAmendment or CreateCompany) — calendar header should show month/year dropdowns instead of prev/next arrows
- [x] Verify selecting a year/month from the dropdowns jumps the calendar correctly
- [x] Verify a pre-filled date field opens the calendar on the correct month (not on `minDate`)
- [x] Run `npm run ci` — should pass cleanly


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX, logging, and build tooling changes with no auth, security, or data-path modifications.
> 
> **Overview**
> **Date picker** fields now use month/year **dropdown** navigation instead of arrow-only paging, with `fromYear`/`toYear` derived from `minDate`/`maxDate` (or sensible defaults). Opening the calendar uses the **current value’s month** when set, otherwise `maxDate` or `minDate`—fixing the prior behavior that always opened on `minDate`. **Global CSS** styles the react-day-picker dropdown selects used by that layout.
> 
> **Headless form** setup passes **`muteLogging: true`** into `modify()` and logs returned **`jsfModify warnings`** via `console.warn` so schema issues stay visible without library noise.
> 
> **Production `build`** sets **`NODE_OPTIONS='--max-old-space-size=8192'`** (matching dev) to reduce OOM risk during `tsup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5376b5e3df3334f3e2ed2393cb53237d6cc93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->