### PR TITLE
handle active status for onboarding flow

### DIFF
--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -863,6 +863,7 @@ describe('ContractorOnboardingFlow', () => {
     'created_awaiting_reserve',
     'created_reserve_paid',
     'initiated',
+    'active',
   ])(
     'should automatically navigate to review step when employment status is %s and display employment data',
     async (status) => {

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -160,12 +160,14 @@ export const reviewStepAllowedEmploymentStatus: Employment['status'][] = [
   'invited',
   'created_awaiting_reserve',
   'created_reserve_paid',
+  'active',
 ];
 
 export const disabledInviteButtonEmploymentStatus: Employment['status'][] = [
   'initiated',
   'created_awaiting_reserve',
   'invited',
+  'active',
 ];
 
 /**

--- a/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
+++ b/src/flows/Onboarding/tests/OnboardingFlow.test.tsx
@@ -1094,6 +1094,7 @@ describe('OnboardingFlow', () => {
     'created_awaiting_reserve',
     'created_reserve_paid',
     'initiated',
+    'active',
   ])(
     'should automatically navigate to review step when employment status is %s and display employment data',
     async (status) => {

--- a/src/flows/Onboarding/utils.ts
+++ b/src/flows/Onboarding/utils.ts
@@ -111,12 +111,14 @@ export const reviewStepAllowedEmploymentStatus: Employment['status'][] = [
   'invited',
   'created_awaiting_reserve',
   'created_reserve_paid',
+  'active',
 ];
 
 export const disabledInviteButtonEmploymentStatus: Employment['status'][] = [
   'initiated',
   'created_awaiting_reserve',
   'invited',
+  'active',
 ];
 
 export const DEFAULT_VERSION = 1;


### PR DESCRIPTION
Fixed an issue where the SDK onboarding flow incorrectly handled active employmentIDs, causing a UI/API state mismatch during detail updates. The flow now correctly redirects users straight to the review step.

https://www.loom.com/share/4ce907707c5e46af8875305f83441c0e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist changes in onboarding utils plus tests; behavior is limited to active employment IDs and aligns UI with existing read-only review patterns.
> 
> **Overview**
> Fixes SDK onboarding when an employment is already **`active`**: the flow no longer leaves users on editable steps that conflict with backend state.
> 
> **Employee and contractor onboarding** now include **`active`** in `reviewStepAllowedEmploymentStatus`, so loading an active `employmentId` **auto-opens the review step** (read-only), same as `invited`, `initiated`, etc.
> 
> **Contractor onboarding** also adds **`active`** to `disabledInviteButtonEmploymentStatus`, so the invite action stays disabled for already-active employments.
> 
> Tests cover auto-navigation to review when status is **`active`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7cf3206ef3c617d516c4c52f28cd993982bbc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->