### PR TITLE
Feat/onboard without contract

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -160,6 +160,7 @@ const MultiStepForm = ({
     ContractPreviewStep,
     ContractReviewButton,
     SaveDraftButton,
+    ContractOriginStep,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -402,6 +403,33 @@ const MultiStepForm = ({
                 will not be treating them as an employee.
               </p>
             )}
+          <div className='contractor-onboarding-buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Back
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Continue
+            </SubmitButton>
+          </div>
+        </div>
+      );
+
+    case 'contract_origin':
+      return (
+        <div className='contractor-onboarding-form-layout'>
+          <ContractOriginStep
+            onSuccess={() => console.log('contract origin set')}
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <AlertError errors={errors} />
           <div className='contractor-onboarding-buttons-container'>
             <BackButton
               className='back-button'

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -15,6 +15,7 @@ import {
   JSFCustomComponentProps,
   PricingPlanComponentProps,
   PricingPlanDataProps,
+  RadioGroupComponentProps,
   corProductIdentifier,
   eorProductIdentifier,
   $TSFixMe,
@@ -137,6 +138,67 @@ const Switcher = (props: JSFCustomComponentProps) => {
         ))}
       </TabsList>
     </Tabs>
+  );
+};
+
+// Consumer-side copy for each contract origin option. The SDK only ships the
+// option values; we decide here how each radio is labelled and described.
+const CONTRACT_ORIGIN_CONTENT: Record<
+  string,
+  { title: string; description: string }
+> = {
+  provided_by_remote: {
+    title: 'Contractor services agreement',
+    description:
+      'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
+  },
+  provided_by_customer: {
+    title: 'Continue without an agreement',
+    description: 'Use your own agreement outside Remote.',
+  },
+};
+
+const ContractOriginRadio = ({
+  field,
+  fieldData,
+  fieldState,
+}: RadioGroupComponentProps) => {
+  return (
+    <fieldset className='contract-origin-radio'>
+      {fieldData.options?.map((option) => {
+        const content = CONTRACT_ORIGIN_CONTENT[option.value] ?? {
+          title: option.label,
+          description: option.description ?? '',
+        };
+        const selected = field.value === option.value;
+
+        return (
+          <label
+            key={option.value}
+            className={`contract-origin-option${selected ? ' is-selected' : ''}`}
+          >
+            <input
+              type='radio'
+              name={field.name}
+              value={option.value}
+              checked={selected}
+              onChange={() => field.onChange(option.value)}
+            />
+            <span className='contract-origin-option-text'>
+              <span className='contract-origin-option-title'>
+                {content.title}
+              </span>
+              <span className='contract-origin-option-description'>
+                {content.description}
+              </span>
+            </span>
+          </label>
+        );
+      })}
+      {fieldState.error && (
+        <p className='error-message'>{fieldState.error.message}</p>
+      )}
+    </fieldset>
   );
 };
 
@@ -423,7 +485,21 @@ const MultiStepForm = ({
     case 'contract_origin':
       return (
         <div className='contractor-onboarding-form-layout'>
+          <div className='flex flex-col gap-2 text-center mb-6'>
+            <h1 className='text-2xl font-bold text-[#000000]'>
+              Contract options
+            </h1>
+            <p className='text-sm text-[#71717A]'>
+              Managing your relationship with contractors is easy: your contract
+              is fully editable in Remote with legally reviewed contract
+              templates specific to France. After all parties sign in Remote,
+              you're ready to go.
+            </p>
+          </div>
           <ContractOriginStep
+            components={{
+              radio: (props) => <ContractOriginRadio {...props} />,
+            }}
             onSuccess={() => console.log('contract origin set')}
             onError={({ error, fieldErrors }) =>
               setErrors({ apiError: error.message, fieldErrors })

--- a/example/src/css/contractor-onboarding.css
+++ b/example/src/css/contractor-onboarding.css
@@ -78,3 +78,56 @@
   max-width: 140px;
   margin: 0 auto;
 }
+
+.contract-origin-radio {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.contract-origin-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #e4e4e7;
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.contract-origin-option:hover {
+  border-color: #d4d4d8;
+}
+
+.contract-origin-option.is-selected {
+  border-color: #171717;
+  background: #fafafa;
+}
+
+.contract-origin-option input[type='radio'] {
+  margin-top: 2px;
+}
+
+.contract-origin-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.contract-origin-option-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #171717;
+}
+
+.contract-origin-option-description {
+  font-size: 13px;
+  line-height: 18px;
+  color: #71717a;
+}

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -14,6 +14,7 @@ import { OnboardingInvite } from '@/src/flows/ContractorOnboarding/components/On
 import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/components/ContractReviewButton';
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
+import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
 
 export const ContractorOnboardingFlow = ({
   render,
@@ -62,6 +63,7 @@ export const ContractorOnboardingFlow = ({
           SubmitButton: OnboardingSubmit,
           PricingPlanStep: PricingPlanStep,
           EligibilityQuestionnaireStep: EligibilityQuestionnaireStep,
+          ContractOriginStep: ContractOriginStep,
           ContractDetailsStep: ContractDetailsStep,
           ContractPreviewStep: ContractPreviewStep,
           OnboardingInvite: OnboardingInvite,

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -778,6 +778,34 @@ export const useDeleteContractorCorSubscription = () => {
   });
 };
 
+export const useSetContractOrigin = () => {
+  const { client } = useClient();
+  return useMutation({
+    mutationFn: async ({
+      employmentId,
+      contractOrigin,
+      templateType,
+    }: {
+      employmentId: string;
+      contractOrigin: string;
+      templateType?: string;
+    }) => {
+      return (client as Client).post({
+        url: '/v1/employments/{employment_id}/contract-origin',
+        path: { employment_id: employmentId },
+        body: {
+          contract_origin: contractOrigin,
+          ...(templateType ? { template_type: templateType } : {}),
+        },
+        security: [
+          { scheme: 'bearer', type: 'http' },
+          { scheme: 'bearer', type: 'http' },
+        ],
+      });
+    },
+  });
+};
+
 export const useCountriesSchemaField = (
   options?: Omit<FlowOptions, 'jsonSchemaVersion'> & {
     queryOptions?: { enabled?: boolean };

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -23,6 +23,7 @@ import {
 } from '@/src/client';
 import { useClient } from '@/src/context';
 import { signatureSchema } from '@/src/flows/ContractorOnboarding/json-schemas/signature';
+import { contractOriginSchema } from '@/src/flows/ContractorOnboarding/json-schemas/contractOrigin';
 import { selectContractorSubscriptionStepSchema } from '@/src/flows/ContractorOnboarding/json-schemas/selectContractorSubscriptionStep';
 import {
   JSONSchemaFormResultWithFieldsets,
@@ -803,6 +804,24 @@ export const useSetContractOrigin = () => {
         ],
       });
     },
+  });
+};
+
+export const useGetContractOriginSchema = ({
+  fieldValues,
+  options,
+}: {
+  fieldValues: FieldValues;
+  options?: { queryOptions?: { enabled?: boolean }; jsfModify?: JSFModify };
+}) => {
+  return useQuery({
+    queryKey: ['contract-origin-schema', options?.jsfModify],
+    queryFn: async () => {
+      return createHeadlessForm(contractOriginSchema, fieldValues, {
+        jsfModify: options?.jsfModify,
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
   });
 };
 

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -789,14 +789,14 @@ export const useSetContractOrigin = () => {
     }: {
       employmentId: string;
       contractOrigin: string;
-      templateType?: string;
+      templateType: string;
     }) => {
       return (client as Client).post({
         url: '/v1/employments/{employment_id}/contract-origin',
         path: { employment_id: employmentId },
         body: {
           contract_origin: contractOrigin,
-          ...(templateType ? { template_type: templateType } : {}),
+          template_type: templateType,
         },
         security: [
           { scheme: 'bearer', type: 'http' },

--- a/src/flows/ContractorOnboarding/components/ContractOriginStep.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractOriginStep.tsx
@@ -1,0 +1,81 @@
+import { $TSFixMe, Components } from '@/src/types/remoteFlows';
+import { NormalizedFieldError } from '@/src/lib/mutations';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+import { handleStepError } from '@/src/lib/utils';
+import { UseFormReturn } from 'react-hook-form';
+
+type ContractOriginStepProps = {
+  /**
+   * Components to override the default field components used in the form.
+   */
+  components?: Components;
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: { contract_origin: string }) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: { contractOrigin: string }) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function ContractOriginStep({
+  components,
+  onSubmit,
+  onSuccess,
+  onError,
+}: ContractOriginStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const handleSubmit = async (
+    payload: $TSFixMe,
+    form: UseFormReturn<$TSFixMe>,
+  ) => {
+    try {
+      const parsedValues =
+        await contractorOnboardingBag.parseFormValues(payload);
+      await onSubmit?.(parsedValues as { contract_origin: string });
+      const response = await contractorOnboardingBag.onSubmit(payload);
+
+      if (response?.data) {
+        await onSuccess?.(response.data as { contractOrigin: string });
+        if (!(response as $TSFixMe)?._skipNextStep) {
+          contractorOnboardingBag?.next();
+        }
+        return;
+      }
+    } catch (error: unknown) {
+      const structuredError = handleStepError(
+        error,
+        contractorOnboardingBag.meta?.fields?.contract_origin,
+        form,
+      );
+      onError?.(structuredError);
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.contract_origin ||
+    contractorOnboardingBag.initialValues.contract_origin;
+
+  return (
+    <ContractorOnboardingForm
+      components={components}
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/components/ContractOriginStep.tsx
+++ b/src/flows/ContractorOnboarding/components/ContractOriginStep.tsx
@@ -52,9 +52,7 @@ export function ContractOriginStep({
 
       if (response?.data) {
         await onSuccess?.(response.data as { contractOrigin: string });
-        if (!(response as $TSFixMe)?._skipNextStep) {
-          contractorOnboardingBag?.next();
-        }
+        contractorOnboardingBag?.next();
         return;
       }
     } catch (error: unknown) {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1270,6 +1270,10 @@ export const useContractorOnboarding = ({
 
         setIncludeContractDetails(!isProvidedByCustomer);
         setIncludeContractPreview(!isProvidedByCustomer);
+        if (isProvidedByCustomer) {
+          setIncludeEligibilityQuestionnaire(false);
+          setPendingNavigationStep('review');
+        }
 
         return { data: { contractOrigin } };
       }

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -31,6 +31,7 @@ import {
   CONTRACT_PRODUCT_TITLES,
   useHasCompanySignedContract,
   useCompanyOpenTasks,
+  useSetContractOrigin,
 } from '@/src/flows/ContractorOnboarding/api';
 import {
   ContractorOnboardingFlowProps,
@@ -82,6 +83,7 @@ type useContractorOnboardingProps = Omit<
 const stepToFormSchemaMap: Record<StepKeys, JSONSchemaFormType | null> = {
   select_country: null,
   basic_information: 'employment_basic_information',
+  contract_origin: null,
   contract_details: null,
   eligibility_questionnaire: null,
   pricing_plan: null,
@@ -123,6 +125,7 @@ export const useContractorOnboarding = ({
   const fieldsMetaRef = useRef<{
     select_country: Meta;
     basic_information: Meta;
+    contract_origin: Meta;
     contract_details: Meta;
     contract_preview: Meta;
     pricing_plan: Meta;
@@ -130,6 +133,7 @@ export const useContractorOnboarding = ({
   }>({
     select_country: {},
     basic_information: {},
+    contract_origin: {},
     contract_details: {},
     contract_preview: {},
     pricing_plan: {},
@@ -146,6 +150,9 @@ export const useContractorOnboarding = ({
   const [includeContractPreview, setIncludeContractPreview] =
     useState<boolean>(true);
 
+  const [includeContractDetails, setIncludeContractDetails] =
+    useState<boolean>(true);
+
   const [pendingNavigationStep, setPendingNavigationStep] =
     useState<StepKeys | null>(null);
 
@@ -153,10 +160,12 @@ export const useContractorOnboarding = ({
     () =>
       buildSteps({
         includeSelectCountry: !skipSteps?.includes('select_country'),
+        includeContractOrigin: !skipSteps?.includes('contract_origin'),
         includeEligibilityQuestionnaire: includeEligibilityQuestionnaire,
+        includeContractDetails: includeContractDetails,
         includeContractPreview: includeContractPreview,
       }),
-    [includeEligibilityQuestionnaire, includeContractPreview, skipSteps],
+    [includeEligibilityQuestionnaire, includeContractDetails, includeContractPreview, skipSteps],
   );
 
   const {
@@ -232,6 +241,7 @@ export const useContractorOnboarding = ({
     usePostCreateEligibilityQuestionnaire();
   const manageContractorCorSubscriptionMutation =
     usePostManageContractorCorSubscription();
+  const setContractOriginMutation = useSetContractOrigin();
 
   const { mutateAsyncOrThrow: updateEmploymentMutationAsync } =
     mutationToPromise(updateEmploymentMutation);
@@ -261,6 +271,9 @@ export const useContractorOnboarding = ({
 
   const { mutateAsyncOrThrow: deleteContractorCorSubscriptionMutationAsync } =
     mutationToPromise(deleteContractorCorSubscriptionMutation);
+
+  const { mutateAsyncOrThrow: setContractOriginMutationAsync } =
+    mutationToPromise(setContractOriginMutation);
 
   // if the employment is loaded, country code has not been set yet
   // we set the internal country code with the employment country code
@@ -634,6 +647,7 @@ export const useContractorOnboarding = ({
     () => ({
       select_country: selectCountryForm?.fields || [],
       basic_information: basicInformationForm?.fields || [],
+      contract_origin: [],
       pricing_plan: selectContractorSubscriptionForm?.fields || [],
       eligibility_questionnaire: eligibilityQuestionnaireForm?.fields || [],
       contract_details: contractorOnboardingDetailsForm?.fields || [],
@@ -656,6 +670,7 @@ export const useContractorOnboarding = ({
   > = {
     select_country: null,
     basic_information: basicInformationForm?.meta['x-jsf-fieldsets'],
+    contract_origin: null,
     pricing_plan: null,
     contract_details: contractorOnboardingDetailsForm?.meta['x-jsf-fieldsets'],
     eligibility_questionnaire: null,
@@ -669,6 +684,7 @@ export const useContractorOnboarding = ({
   > = {
     select_country: selectCountryForm?.meta?.['x-jsf-presentation'],
     basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
+    contract_origin: null,
     pricing_plan:
       selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
     eligibility_questionnaire:
@@ -858,6 +874,7 @@ export const useContractorOnboarding = ({
           stepFields.basic_information,
           { skipMoneyConversion: true },
         ),
+        contract_origin: {},
         contract_details: prettifyFormValues(
           contractDetailsInitialValues,
           stepFields.contract_details,
@@ -883,6 +900,7 @@ export const useContractorOnboarding = ({
       setStepValues({
         select_country: selectCountryInitialValues,
         basic_information: basicInformationInitialValues,
+        contract_origin: {},
         contract_details: contractDetailsInitialValues,
         contract_preview: contractPreviewInitialValues,
         pricing_plan: pricingPlanInitialValues,
@@ -1240,6 +1258,22 @@ export const useContractorOnboarding = ({
         throw createStructuredError('invalid selection');
       }
 
+      case 'contract_origin': {
+        const contractOrigin = values.contract_origin as string;
+        const isProvidedByCustomer = contractOrigin === 'provided_by_customer';
+
+        await setContractOriginMutationAsync({
+          employmentId: internalEmploymentId as string,
+          contractOrigin,
+          templateType: isProvidedByCustomer ? undefined : 'contractor_agreement',
+        });
+
+        setIncludeContractDetails(!isProvidedByCustomer);
+        setIncludeContractPreview(!isProvidedByCustomer);
+
+        return { data: { contractOrigin } };
+      }
+
       case 'eligibility_questionnaire': {
         try {
           const response = await createEligibilityQuestionnaireMutationAsync({
@@ -1473,7 +1507,8 @@ export const useContractorOnboarding = ({
       uploadFileMutation.isPending ||
       createEligibilityQuestionnaireMutation.isPending ||
       manageContractorCorSubscriptionMutation.isPending ||
-      deleteContractorCorSubscriptionMutation.isPending,
+      deleteContractorCorSubscriptionMutation.isPending ||
+      setContractOriginMutation.isPending,
 
     /**
      * Document preview PDF data

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -32,6 +32,7 @@ import {
   useHasCompanySignedContract,
   useCompanyOpenTasks,
   useSetContractOrigin,
+  useGetContractOriginSchema,
 } from '@/src/flows/ContractorOnboarding/api';
 import {
   ContractorOnboardingFlowProps,
@@ -165,7 +166,12 @@ export const useContractorOnboarding = ({
         includeContractDetails: includeContractDetails,
         includeContractPreview: includeContractPreview,
       }),
-    [includeEligibilityQuestionnaire, includeContractDetails, includeContractPreview, skipSteps],
+    [
+      includeEligibilityQuestionnaire,
+      includeContractDetails,
+      includeContractPreview,
+      skipSteps,
+    ],
   );
 
   const {
@@ -619,6 +625,10 @@ export const useContractorOnboarding = ({
     },
   });
 
+  const { data: contractOriginForm } = useGetContractOriginSchema({
+    fieldValues: fieldValues,
+  });
+
   const {
     data: documentPreviewPdf,
     isLoading: isLoadingDocumentPreviewForm,
@@ -647,7 +657,7 @@ export const useContractorOnboarding = ({
     () => ({
       select_country: selectCountryForm?.fields || [],
       basic_information: basicInformationForm?.fields || [],
-      contract_origin: [],
+      contract_origin: contractOriginForm?.fields || [],
       pricing_plan: selectContractorSubscriptionForm?.fields || [],
       eligibility_questionnaire: eligibilityQuestionnaireForm?.fields || [],
       contract_details: contractorOnboardingDetailsForm?.fields || [],
@@ -657,6 +667,7 @@ export const useContractorOnboarding = ({
     [
       selectCountryForm?.fields,
       basicInformationForm?.fields,
+      contractOriginForm?.fields,
       selectContractorSubscriptionForm?.fields,
       contractorOnboardingDetailsForm?.fields,
       signatureSchemaForm?.fields,
@@ -684,7 +695,7 @@ export const useContractorOnboarding = ({
   > = {
     select_country: selectCountryForm?.meta?.['x-jsf-presentation'],
     basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
-    contract_origin: null,
+    contract_origin: contractOriginForm?.meta?.['x-jsf-presentation'],
     pricing_plan:
       selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
     eligibility_questionnaire:
@@ -738,6 +749,14 @@ export const useContractorOnboarding = ({
     convertedIr35File,
     stepFields.basic_information,
   ]);
+
+  const contractOriginInitialValues = useMemo(() => {
+    const initialValues = {
+      ...onboardingInitialValues,
+      contract_origin: employment?.contract_details?.contract_origin,
+    };
+    return getInitialValues(stepFields.contract_origin, initialValues);
+  }, [stepFields.contract_origin, onboardingInitialValues]);
 
   const contractDetailsInitialValues = useMemo(() => {
     const hardcodedValues = {
@@ -807,6 +826,7 @@ export const useContractorOnboarding = ({
     return {
       select_country: selectCountryInitialValues,
       basic_information: basicInformationInitialValues,
+      contract_origin: contractOriginInitialValues,
       contract_details: contractDetailsInitialValues,
       contract_preview: contractPreviewInitialValues,
       pricing_plan: pricingPlanInitialValues,
@@ -815,6 +835,7 @@ export const useContractorOnboarding = ({
   }, [
     selectCountryInitialValues,
     basicInformationInitialValues,
+    contractOriginInitialValues,
     contractDetailsInitialValues,
     contractPreviewInitialValues,
     pricingPlanInitialValues,
@@ -991,6 +1012,15 @@ export const useContractorOnboarding = ({
           isPartialValidation: false,
         },
       );
+    }
+
+    if (
+      contractOriginForm &&
+      stepState.currentStep.name === 'contract_origin'
+    ) {
+      return await parseJSFToValidate(values, contractOriginForm?.fields, {
+        isPartialValidation: false,
+      });
     }
 
     return {};
@@ -1265,7 +1295,9 @@ export const useContractorOnboarding = ({
         await setContractOriginMutationAsync({
           employmentId: internalEmploymentId as string,
           contractOrigin,
-          templateType: isProvidedByCustomer ? undefined : 'contractor_agreement',
+          templateType: isProvidedByCustomer
+            ? undefined
+            : 'contractor_agreement',
         });
 
         setIncludeContractDetails(!isProvidedByCustomer);
@@ -1478,6 +1510,18 @@ export const useContractorOnboarding = ({
           { isPartialValidation: false },
         );
         return eligibilityQuestionnaireForm?.handleValidation(parsedValues);
+      }
+
+      if (
+        contractOriginForm &&
+        stepState.currentStep.name === 'contract_origin'
+      ) {
+        const parsedValues = await parseJSFToValidate(
+          values,
+          contractOriginForm?.fields,
+          { isPartialValidation: false },
+        );
+        return contractOriginForm?.handleValidation(parsedValues);
       }
 
       return null;

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1292,19 +1292,26 @@ export const useContractorOnboarding = ({
         const contractOrigin = values.contract_origin as string;
         const isProvidedByCustomer = contractOrigin === 'provided_by_customer';
 
-        await setContractOriginMutationAsync({
-          employmentId: internalEmploymentId as string,
-          contractOrigin,
-          templateType: isProvidedByCustomer
-            ? undefined
-            : 'contractor_agreement',
-        });
-
-        setIncludeContractDetails(!isProvidedByCustomer);
-        setIncludeContractPreview(!isProvidedByCustomer);
+        // Only "provided_by_customer" needs to hit the backend (it changes the
+        // flow by dropping the contract steps). The normal flow just proceeds
+        // to the next step, exactly like before.
         if (isProvidedByCustomer) {
+          await setContractOriginMutationAsync({
+            employmentId: internalEmploymentId as string,
+            contractOrigin,
+            // The gateway enforces template_type's enum + required on every
+            // request. It's ignored server-side for provided_by_customer, but
+            // must still be a valid enum value, so we always send one.
+            templateType: 'contractor_agreement',
+          });
+
+          setIncludeContractDetails(false);
+          setIncludeContractPreview(false);
           setIncludeEligibilityQuestionnaire(false);
           setPendingNavigationStep('review');
+        } else {
+          setIncludeContractDetails(true);
+          setIncludeContractPreview(true);
         }
 
         return { data: { contractOrigin } };

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -336,21 +336,23 @@ export const useContractorOnboarding = ({
     );
   }, [contractorSubscriptions]);
 
-  useEffect(() => {
-    if (hasEligibilityQuestionnaireSubmitted) {
-      setIncludeEligibilityQuestionnaire(false);
-      return;
-    } else if (selectedProduct === corProductIdentifier) {
-      setIncludeEligibilityQuestionnaire(true);
-    } else {
-      setIncludeEligibilityQuestionnaire(false);
-    }
+  // Whether the eligibility questionnaire / contract preview steps belong in
+  // the flow. Both are also derived here so the contract_origin step can
+  // restore them when the user switches back to the normal flow.
+  const shouldIncludeEligibilityQuestionnaire = useMemo(() => {
+    if (hasEligibilityQuestionnaireSubmitted) return false;
+    return selectedProduct === corProductIdentifier;
   }, [hasEligibilityQuestionnaireSubmitted, selectedProduct]);
 
+  const shouldIncludeContractPreview = employment?.contractor_type !== 'cor';
+
   useEffect(() => {
-    const isCor = employment?.contractor_type === 'cor';
-    setIncludeContractPreview(!isCor);
-  }, [employment?.contractor_type]);
+    setIncludeEligibilityQuestionnaire(shouldIncludeEligibilityQuestionnaire);
+  }, [shouldIncludeEligibilityQuestionnaire]);
+
+  useEffect(() => {
+    setIncludeContractPreview(shouldIncludeContractPreview);
+  }, [shouldIncludeContractPreview]);
 
   const eligibilityAnswers = useMemo(() => {
     return contractorSubscriptions?.find(
@@ -1294,7 +1296,10 @@ export const useContractorOnboarding = ({
 
         // Only "provided_by_customer" needs to hit the backend (it changes the
         // flow by dropping the contract steps). The normal flow just proceeds
-        // to the next step, exactly like before.
+        // to the next step, exactly like before. In both cases we defer
+        // navigation via pendingNavigationStep (and skip the step's synchronous
+        // next()) so it runs against the rebuilt steps, not stale ones — this
+        // is what lets the user switch options back and forth reliably.
         if (isProvidedByCustomer) {
           await setContractOriginMutationAsync({
             employmentId: internalEmploymentId as string,
@@ -1310,11 +1315,20 @@ export const useContractorOnboarding = ({
           setIncludeEligibilityQuestionnaire(false);
           setPendingNavigationStep('review');
         } else {
+          // Restore the normal flow steps to their effect-derived state.
           setIncludeContractDetails(true);
-          setIncludeContractPreview(true);
+          setIncludeContractPreview(shouldIncludeContractPreview);
+          setIncludeEligibilityQuestionnaire(
+            shouldIncludeEligibilityQuestionnaire,
+          );
+          setPendingNavigationStep(
+            shouldIncludeEligibilityQuestionnaire
+              ? 'eligibility_questionnaire'
+              : 'contract_details',
+          );
         }
 
-        return { data: { contractOrigin } };
+        return { data: { contractOrigin }, _skipNextStep: true };
       }
 
       case 'eligibility_questionnaire': {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -336,9 +336,6 @@ export const useContractorOnboarding = ({
     );
   }, [contractorSubscriptions]);
 
-  // Whether the eligibility questionnaire / contract preview steps belong in
-  // the flow. Both are also derived here so the contract_origin step can
-  // restore them when the user switches back to the normal flow.
   const shouldIncludeEligibilityQuestionnaire = useMemo(() => {
     if (hasEligibilityQuestionnaireSubmitted) return false;
     return selectedProduct === corProductIdentifier;
@@ -1291,31 +1288,17 @@ export const useContractorOnboarding = ({
       }
 
       case 'contract_origin': {
-        const contractOrigin = values.contract_origin as string;
-        const isProvidedByCustomer = contractOrigin === 'provided_by_customer';
-
-        // Only "provided_by_customer" needs to hit the backend (it changes the
-        // flow by dropping the contract steps). The normal flow just proceeds
-        // to the next step, exactly like before. In both cases we defer
-        // navigation via pendingNavigationStep (and skip the step's synchronous
-        // next()) so it runs against the rebuilt steps, not stale ones — this
-        // is what lets the user switch options back and forth reliably.
-        if (isProvidedByCustomer) {
+        if (values.contract_origin === 'provided_by_customer') {
           await setContractOriginMutationAsync({
             employmentId: internalEmploymentId as string,
-            contractOrigin,
-            // The gateway enforces template_type's enum + required on every
-            // request. It's ignored server-side for provided_by_customer, but
-            // must still be a valid enum value, so we always send one.
+            contractOrigin: 'provided_by_customer',
             templateType: 'contractor_agreement',
           });
-
           setIncludeContractDetails(false);
           setIncludeContractPreview(false);
           setIncludeEligibilityQuestionnaire(false);
           setPendingNavigationStep('review');
         } else {
-          // Restore the normal flow steps to their effect-derived state.
           setIncludeContractDetails(true);
           setIncludeContractPreview(shouldIncludeContractPreview);
           setIncludeEligibilityQuestionnaire(
@@ -1328,7 +1311,10 @@ export const useContractorOnboarding = ({
           );
         }
 
-        return { data: { contractOrigin }, _skipNextStep: true };
+        return {
+          data: { contractOrigin: values.contract_origin },
+          _skipNextStep: true,
+        };
       }
 
       case 'eligibility_questionnaire': {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -773,7 +773,11 @@ export const useContractorOnboarding = ({
       contract_origin: employment?.contract_details?.contract_origin,
     };
     return getInitialValues(stepFields.contract_origin, initialValues);
-  }, [stepFields.contract_origin, onboardingInitialValues]);
+  }, [
+    stepFields.contract_origin,
+    onboardingInitialValues,
+    employment?.contract_details?.contract_origin,
+  ]);
 
   const contractDetailsInitialValues = useMemo(() => {
     const hardcodedValues = {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -343,13 +343,31 @@ export const useContractorOnboarding = ({
 
   const shouldIncludeContractPreview = employment?.contractor_type !== 'cor';
 
-  useEffect(() => {
-    setIncludeEligibilityQuestionnaire(shouldIncludeEligibilityQuestionnaire);
-  }, [shouldIncludeEligibilityQuestionnaire]);
+  const selectedContractOrigin =
+    (fieldValues.contract_origin as string | undefined) ??
+    (stepState.values?.contract_origin?.contract_origin as
+      | string
+      | undefined) ??
+    employment?.contract_details?.contract_origin;
+
+  const isContractProvidedByCustomer =
+    selectedContractOrigin === 'provided_by_customer';
 
   useEffect(() => {
-    setIncludeContractPreview(shouldIncludeContractPreview);
-  }, [shouldIncludeContractPreview]);
+    setIncludeContractDetails(!isContractProvidedByCustomer);
+  }, [isContractProvidedByCustomer]);
+
+  useEffect(() => {
+    setIncludeEligibilityQuestionnaire(
+      !isContractProvidedByCustomer && shouldIncludeEligibilityQuestionnaire,
+    );
+  }, [isContractProvidedByCustomer, shouldIncludeEligibilityQuestionnaire]);
+
+  useEffect(() => {
+    setIncludeContractPreview(
+      !isContractProvidedByCustomer && shouldIncludeContractPreview,
+    );
+  }, [isContractProvidedByCustomer, shouldIncludeContractPreview]);
 
   const eligibilityAnswers = useMemo(() => {
     return contractorSubscriptions?.find(
@@ -1288,32 +1306,20 @@ export const useContractorOnboarding = ({
       }
 
       case 'contract_origin': {
+        // Step visibility is already reconciled reactively from the selected
+        // value, so a plain next() lands on the right step (review when the
+        // customer provides their own contract, otherwise eligibility /
+        // contract_details). We only persist the choice server-side here.
         if (values.contract_origin === 'provided_by_customer') {
           await setContractOriginMutationAsync({
             employmentId: internalEmploymentId as string,
             contractOrigin: 'provided_by_customer',
             templateType: 'contractor_agreement',
           });
-          setIncludeContractDetails(false);
-          setIncludeContractPreview(false);
-          setIncludeEligibilityQuestionnaire(false);
-          setPendingNavigationStep('review');
-        } else {
-          setIncludeContractDetails(true);
-          setIncludeContractPreview(shouldIncludeContractPreview);
-          setIncludeEligibilityQuestionnaire(
-            shouldIncludeEligibilityQuestionnaire,
-          );
-          setPendingNavigationStep(
-            shouldIncludeEligibilityQuestionnaire
-              ? 'eligibility_questionnaire'
-              : 'contract_details',
-          );
         }
 
         return {
           data: { contractOrigin: values.contract_origin },
-          _skipNextStep: true,
         };
       }
 

--- a/src/flows/ContractorOnboarding/json-schemas/contractOrigin.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/contractOrigin.ts
@@ -1,0 +1,28 @@
+export const contractOriginSchema = {
+  type: 'object',
+  properties: {
+    contract_origin: {
+      description: '',
+      oneOf: [
+        {
+          const: 'provided_by_remote',
+          description:
+            'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
+          title: 'Contractor services agreement',
+        },
+        {
+          const: 'provided_by_customer',
+          description: 'Use your own agreement outside Remote.',
+          title: 'Without an agreement',
+        },
+      ],
+      title: 'Contract options',
+      type: 'string',
+      'x-jsf-presentation': {
+        direction: 'column',
+        inputType: 'radio',
+      },
+    },
+  },
+  required: ['contract_origin'],
+};

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -33,10 +33,13 @@ import {
   fillBasicInformation,
   fillContractDetails,
   fillContractorSubscription,
+  fillContractOrigin,
   fillEligibilityQuestionnaire,
   fillSignature,
   generateUniqueEmploymentId,
 } from '@/src/flows/ContractorOnboarding/tests/helpers';
+import { RemoteFlowContext } from '@/src/context';
+import { client as apiClient } from '@/src/client/client.gen';
 import { employmentUpdatedResponse } from '@/src/flows/Onboarding/tests/fixtures';
 import { mockBaseResponse } from '@/src/common/api/fixtures/base';
 import {
@@ -58,10 +61,11 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [0]: 'Select Country',
   [1]: 'Basic Information',
   [2]: 'Pricing Plan',
-  [3]: 'Eligibility Questionnaire',
-  [4]: 'Contract Details',
-  [5]: 'Contract Preview',
-  [6]: 'Review',
+  [3]: 'Contract Origin',
+  [4]: 'Eligibility Questionnaire',
+  [5]: 'Contract Details',
+  [6]: 'Contract Preview',
+  [7]: 'Review',
 };
 
 function createMockRenderImplementation(
@@ -97,6 +101,7 @@ describe('ContractorOnboardingFlow', () => {
       ContractDetailsStep,
       ContractPreviewStep,
       PricingPlanStep,
+      ContractOriginStep,
       SubmitButton,
       BackButton,
       OnboardingInvite,
@@ -174,6 +179,18 @@ describe('ContractorOnboardingFlow', () => {
             <SubmitButton>Next Step</SubmitButton>
           </>
         );
+      case 'contract_origin':
+        return (
+          <>
+            <ContractOriginStep
+              onSubmit={mockOnSubmit}
+              onSuccess={mockOnSuccess}
+              onError={mockOnError}
+            />
+            <BackButton>Back</BackButton>
+            <SubmitButton>Next Step</SubmitButton>
+          </>
+        );
       case 'review':
         return (
           <div className='contractor-onboarding-review'>
@@ -218,6 +235,7 @@ describe('ContractorOnboardingFlow', () => {
       ContractPreviewStep,
       PricingPlanStep,
       EligibilityQuestionnaireStep,
+      ContractOriginStep,
       SubmitButton,
       BackButton,
       OnboardingInvite,
@@ -244,6 +262,18 @@ describe('ContractorOnboardingFlow', () => {
         return (
           <>
             <PricingPlanStep
+              onSubmit={mockOnSubmit}
+              onSuccess={mockOnSuccess}
+              onError={mockOnError}
+            />
+            <BackButton>Back</BackButton>
+            <SubmitButton>Next Step</SubmitButton>
+          </>
+        );
+      case 'contract_origin':
+        return (
+          <>
+            <ContractOriginStep
               onSubmit={mockOnSubmit}
               onSuccess={mockOnSuccess}
               onError={mockOnError}
@@ -507,6 +537,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Contract Details/i);
 
     const serviceDurationInput = await screen.findByTestId(
@@ -671,6 +705,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Contract Details/i);
 
     await fillContractDetails();
@@ -745,6 +783,10 @@ describe('ContractorOnboardingFlow', () => {
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
+
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
 
     await screen.findByText(/Step: Contract Details/i);
     await fillContractDetails();
@@ -834,6 +876,10 @@ describe('ContractorOnboardingFlow', () => {
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
+
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
 
     await screen.findByText(/Step: Contract Details/i);
 
@@ -1134,6 +1180,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Contract Details/i);
 
     await fillContractDetails();
@@ -1234,6 +1284,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Contract Details/i);
 
     // Verify the field is pre-filled with the value from the mock (2025-11-26)
@@ -1309,6 +1363,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Contract Details/i);
 
     await fillContractDetails();
@@ -1361,6 +1419,10 @@ describe('ContractorOnboardingFlow', () => {
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
+
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
 
     await screen.findByText(/Step: Contract Details/i);
 
@@ -1463,6 +1525,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Eligibility Questionnaire/i);
 
     await fillEligibilityQuestionnaire();
@@ -1491,6 +1557,10 @@ describe('ContractorOnboardingFlow', () => {
     nextButton.click();
 
     // Assert that we navigate to contract_details step
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin();
+    screen.getByText(/Next Step/i).click();
+
     await screen.findByText(/Step: Contract Details/i);
 
     // Optionally verify form fields are present
@@ -1499,6 +1569,80 @@ describe('ContractorOnboardingFlow', () => {
         screen.getByTestId('service_duration.provisional_start_date'),
       ).toBeInTheDocument();
     });
+  });
+
+  it('should skip the contract steps and go straight to review when choosing "Without an agreement"', async () => {
+    const setContractOriginSpy = vi.fn();
+
+    server.use(
+      http.post('*/v1/employments/*/contract-origin', async ({ request }) => {
+        const requestBody = await request.json();
+        setContractOriginSpy(requestBody);
+        return HttpResponse.json({
+          data: { contract_origin: 'provided_by_customer' },
+        });
+      }),
+    );
+
+    mockRender.mockImplementation(
+      createMockRenderImplementation(MultiStepFormWithoutCountry),
+    );
+
+    // useSetContractOrigin calls client.post directly, so the flow needs a
+    // real client in context (TestProviders doesn't provide one; the SDK-based
+    // mutations fall back to the global client, but this raw .post does not).
+    render(
+      <RemoteFlowContext.Provider value={{ client: apiClient }}>
+        <ContractorOnboardingFlow
+          countryCode='PRT'
+          skipSteps={['select_country']}
+          employmentId='test-employment-id'
+          {...defaultProps}
+        />
+      </RemoteFlowContext.Provider>,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    await fillBasicInformation();
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+
+    await fillContractorSubscription();
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    // Choose "Without an agreement" (contract provided by the customer)
+    await screen.findByText(/Step: Contract Origin/i);
+    await fillContractOrigin('Without an agreement');
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    // Should jump straight to review, skipping the contract details / preview steps
+    await screen.findByText(/Step: Review/i);
+
+    // The contract origin was persisted as provided_by_customer
+    await waitFor(() => {
+      expect(setContractOriginSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(setContractOriginSpy.mock.calls[0][0]).toMatchObject({
+      contract_origin: 'provided_by_customer',
+    });
+
+    // The contract details and preview steps are not part of the flow anymore
+    expect(
+      screen.queryByText(/Step: Contract Details/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Step: Contract Preview/i),
+    ).not.toBeInTheDocument();
   });
 
   describe('Saudi Arabia edge case', () => {
@@ -1919,6 +2063,10 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Eligibility Questionnaire/i);
     });
 
@@ -1965,6 +2113,10 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
+
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Eligibility Questionnaire/i);
 
@@ -2031,6 +2183,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Contract Details/i);
     });
 
@@ -2089,6 +2245,10 @@ describe('ContractorOnboardingFlow', () => {
       await waitFor(() => {
         expect(deleteSpy).toHaveBeenCalled();
       });
+
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Contract Details/i);
 
@@ -2203,6 +2363,10 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
+
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Eligibility Questionnaire/i);
 
@@ -2767,6 +2931,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -2887,6 +3055,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Contract Details/i);
 
       // Fill contract details
@@ -2974,6 +3146,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton.click();
 
       // Fill eligibility questionnaire (required for COR)
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3071,6 +3247,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3153,6 +3333,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3228,6 +3412,10 @@ describe('ContractorOnboardingFlow', () => {
       await fillContractorSubscription();
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
+
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Contract Details/i);
       await fillContractDetails();
@@ -3355,6 +3543,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Contract Details/i);
       await fillContractDetails();
 
@@ -3449,6 +3641,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Contract Details/i);
       await fillContractDetails();
 
@@ -3526,6 +3722,10 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
+
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3600,6 +3800,10 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
+
+      await screen.findByText(/Step: Contract Origin/i);
+      await fillContractOrigin();
+      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Contract Details/i);
 

--- a/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
@@ -30,10 +30,11 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [0]: 'Select Country',
   [1]: 'Basic Information',
   [2]: 'Pricing Plan',
-  [3]: 'Eligibility Questionnaire',
-  [4]: 'Contract Details',
-  [5]: 'Contract Preview',
-  [6]: 'Review',
+  [3]: 'Contract Origin',
+  [4]: 'Eligibility Questionnaire',
+  [5]: 'Contract Details',
+  [6]: 'Contract Preview',
+  [7]: 'Review',
 };
 
 const mockSuccess = vi.fn();

--- a/src/flows/ContractorOnboarding/tests/helpers.ts
+++ b/src/flows/ContractorOnboarding/tests/helpers.ts
@@ -88,6 +88,17 @@ export async function fillContractorSubscription(plan?: string) {
   await fillRadio('Payment terms', plan || 'Contractor Management Plus');
 }
 
+export async function fillContractOrigin(
+  option: string = 'Contractor services agreement',
+) {
+  await waitFor(() => {
+    expect(
+      screen.getByRole('radio', { name: new RegExp(option, 'i') }),
+    ).toBeInTheDocument();
+  });
+  await fillRadio('Contract options', option);
+}
+
 export async function fillEligibilityQuestionnaire(
   values?: Partial<{
     controlTheWayContractorsWork: string;

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -15,6 +15,7 @@ import { ContractPreviewStep } from '@/src/flows/ContractorOnboarding/components
 import { OnboardingInvite } from '@/src/flows/ContractorOnboarding/components/OnboardingInvite';
 import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/components/ContractReviewButton';
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
+import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
 import { ProductType } from '@/src/flows/ContractorOnboarding/constants';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 
@@ -44,6 +45,7 @@ export type ContractorOnboardingRenderProps = {
     BackButton: typeof OnboardingBack;
     SubmitButton: typeof OnboardingSubmit;
     PricingPlanStep: typeof PricingPlanStep;
+    ContractOriginStep: typeof ContractOriginStep;
     ContractDetailsStep: typeof ContractDetailsStep;
     ContractPreviewStep: typeof ContractPreviewStep;
     OnboardingInvite: typeof OnboardingInvite;
@@ -94,9 +96,9 @@ export type ContractorOnboardingFlowProps = {
   externalId?: string;
 
   /**
-   * The steps to skip for the onboarding. We only support skipping the select_country step for now.
+   * The steps to skip for the onboarding.
    */
-  skipSteps?: ['select_country'];
+  skipSteps?: Array<'select_country' | 'contract_origin'>;
 
   /**
    * The render prop function with the params passed by the useContractorOnboarding hook and the components available to use for this flow

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -12,6 +12,7 @@ import { Employment } from '@/src/flows/Onboarding/types';
 export type StepKeys =
   | 'select_country'
   | 'basic_information'
+  | 'contract_origin'
   | 'contract_details'
   | 'eligibility_questionnaire'
   | 'contract_preview'
@@ -20,7 +21,9 @@ export type StepKeys =
 
 type StepConfig = {
   includeSelectCountry?: boolean;
+  includeContractOrigin?: boolean;
   includeEligibilityQuestionnaire?: boolean;
+  includeContractDetails?: boolean;
   includeContractPreview?: boolean;
 };
 
@@ -46,6 +49,11 @@ export function buildSteps(config: StepConfig = {}) {
       visible: true,
     },
     {
+      name: 'contract_origin',
+      label: 'Contract Options',
+      visible: Boolean(config?.includeContractOrigin ?? true),
+    },
+    {
       name: 'eligibility_questionnaire',
       label: 'Eligibility Questionnaire',
       visible: Boolean(config?.includeEligibilityQuestionnaire),
@@ -53,7 +61,7 @@ export function buildSteps(config: StepConfig = {}) {
     {
       name: 'contract_details',
       label: 'Contract Details',
-      visible: true,
+      visible: Boolean(config?.includeContractDetails ?? true),
     },
     {
       name: 'contract_preview',


### PR DESCRIPTION
Add new step Contracts Options leading to choose "without an agreement" option which lead to review screen. 

https://www.loom.com/share/4c9be8a23778445798fe5d9e365012ce

How to test: 

- Open example app
- Create contractor
- Select without an agreement and finish the flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters contractor onboarding step ordering and branching tied to employment contract origin; incorrect visibility or API persistence could skip required contract steps or leave employments in the wrong state, though coverage includes the customer-provided shortcut path.
> 
> **Overview**
> Adds a **Contract options** step after pricing plan so employers choose Remote’s contractor agreement or **continue without an agreement** (customer-provided contract).
> 
> Choosing **without an agreement** (`provided_by_customer`) **drops** eligibility questionnaire (when it would apply), contract details, and contract preview from the step list and advances to **review** after persisting the choice via `POST /v1/employments/{employment_id}/contract-origin`. The Remote-agreement path is unchanged aside from passing through the new step.
> 
> The SDK exposes `ContractOriginStep`, a JSON-schema radio form, and `skipSteps` now supports `contract_origin`. The example app wires a custom radio UI and styles for that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc967e9c4bf05950c584d2980fcb34e176746bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->