### PR TITLE
Release/1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Minor Changes
 
+#### Features
+
+- Onboarding contractor without contract [#1139] (https://github.com/remoteoss/remote-flows/pull/1139)
+
+#### Fixes
+
+- SDK can handle "active" status and redirect to Review step [#1135] (https://github.com/remoteoss/remote-flows/pull/1135)
+
+#### Chores
+
 - update lucide monorepo
 - update actions/cache digest to caa2961
 - setup nightly e2e (#1121) [#1121](https://github.com/remoteoss/remote-flows/pull/1121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @remoteoss/remote-flows
 
+## 1.42.0
+
+### Minor Changes
+
+- update lucide monorepo
+- update actions/cache digest to caa2961
+- setup nightly e2e (#1121) [#1121](https://github.com/remoteoss/remote-flows/pull/1121)
+- upgrade v3 uk (#1116) [#1116](https://github.com/remoteoss/remote-flows/pull/1116)
+- update dependency oxfmt to v0.56.0
+- build the app and deploy it to vercel (#1123) [#1123](https://github.com/remoteoss/remote-flows/pull/1123)
+- add GBR contract details v3 schema upgrade docs
+- remove since/enforced metadata from GBR v3 docs
+
 ## 1.41.1
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.41.1",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.41.1",
+      "version": "1.42.0",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.41.1",
+  "version": "1.42.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"

--- a/src/flows/ContractorOnboarding/README.md
+++ b/src/flows/ContractorOnboarding/README.md
@@ -14,12 +14,13 @@ The contractor onboarding process consists of the following steps in order:
 2. **Basic Information** - Collect contractor's personal and professional details
 3. **Contract Details** - Define contract terms including services, duration, compensation, and notice periods
 4. **Pricing Plan** - Select and configure subscription/pricing tier
-5. **Contract Preview** - Review and electronically sign the generated contract
-6. **Review** - Final review step (internal)
+5. **Contract Origin** - Choose where the contract comes from
+6. **Contract Preview** - Review and electronically sign the generated contract
+7. **Review** - Final review step (internal)
 
 ### Skipping Steps
 
-You can skip the `select_country` step by passing `skipSteps: ['select_country']` if the country is already known via the `countryCode` prop.
+You can skip the `select_country` step by passing `skipSteps: ['select_country']` if the country is already known via the `countryCode` prop. You can also skip the `contract_origin` step (e.g. `skipSteps: ['contract_origin']`) when the contract origin is not applicable.
 
 ## Usage
 
@@ -48,7 +49,7 @@ import { ContractorOnboardingFlow } from '@remoteoss/remote-flows';
 | `countryCode`   | `string`                                                      | No       | Pre-selected country code for the contractor                                                                                 |
 | `employmentId`  | `string`                                                      | No       | ID of existing employment to update. When provided, fetches existing data from the server                                    |
 | `externalId`    | `string`                                                      | No       | Unique reference code for the employment in external systems (non-Remote). Links to external data sources                    |
-| `skipSteps`     | `['select_country']`                                          | No       | Steps to skip. Currently only supports skipping the select_country step                                                      |
+| `skipSteps`     | `['select_country']`                                          | No       | Steps to skip. Also supports skipping the `contract_origin` step                                                             |
 | `initialValues` | `Record<string, unknown>`                                     | No       | Pre-populate form fields. Flat field values are automatically mapped to the correct step. Server data overrides these values |
 | `options`       | `FlowOptions`                                                 | No       | Configuration options for the flow, including `jsfModify` for customizing specific steps                                     |
 
@@ -70,6 +71,7 @@ The render function receives an object with:
   - `BasicInformationStep` - Contractor details form
   - `ContractDetailsStep` - Contract terms form
   - `PricingPlanStep` - Pricing tier selection
+  - `ContractOriginStep` - Contract origin selection form
   - `ContractPreviewStep` - Contract review and signature
   - `OnboardingInvite` - Invitation/status component
   - `SubmitButton` - Multi-purpose submit button
@@ -121,6 +123,21 @@ Allows selection and configuration of subscription or pricing tiers for the cont
 - `onSubmit?: (payload: PricingPlanFormPayload) => void` - Called before submission
 - `onSuccess?: (response: PricingPlanResponse) => void` - Called on successful submission
 - `onError?: (error: { error: Error; fieldErrors: NormalizedFieldError[] }) => void` - Called on error
+
+### ContractOriginStep
+
+Lets the customer choose where the contract comes from before generating it:
+
+- **Contractor services agreement** (`provided_by_remote`) - Create new terms and conditions and a statement of work. Use this when you don't have an agreement in place or want to renegotiate one.
+- **Without an agreement** (`provided_by_customer`) - Use your own agreement handled outside Remote.
+
+Rendered as a radio group.
+
+**Props:**
+
+- `onSubmit?: (payload: { contract_origin: string }) => void` - Called before submission
+- `onSuccess?: (data: { contractOrigin: string }) => void` - Called on successful submission
+- `onError?: (error: { error: Error; rawError: Record<string, unknown>; fieldErrors: NormalizedFieldError[] }) => void` - Called on error
 
 ### ContractPreviewStep
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> This PR is primarily version and documentation updates; functional changes were merged in earlier PRs and are already in the codebase.
> 
> **Overview**
> **Release 1.42.0** bumps the package from `1.41.1` to `1.42.0` and records the release in `CHANGELOG.md`.
> 
> The **Contractor Onboarding** README now documents a new **Contract Origin** step (after pricing plan, before contract preview), exposing `ContractOriginStep` in render props and allowing `skipSteps: ['contract_origin']`. That step supports onboarding with a Remote-generated agreement (`provided_by_remote`) or **without** using Remote’s contract flow (`provided_by_customer`).
> 
> The changelog also notes **onboarding contractor without contract** (#1139) and an SDK fix so employments in **`active`** status are routed to the **Review** step (#1135); those behaviors ship in this version but are not part of this diff beyond the changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1cc53c25abf3a3067a3f7a817582d55f23a4874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->