### PR TITLE
Fix steps order bug

### DIFF
--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -154,6 +154,9 @@ export const useContractorOnboarding = ({
   const [includeContractDetails, setIncludeContractDetails] =
     useState<boolean>(true);
 
+  const [includeContractOrigin, setIncludeContractOrigin] =
+    useState<boolean>(true);
+
   const [pendingNavigationStep, setPendingNavigationStep] =
     useState<StepKeys | null>(null);
 
@@ -161,12 +164,13 @@ export const useContractorOnboarding = ({
     () =>
       buildSteps({
         includeSelectCountry: !skipSteps?.includes('select_country'),
-        includeContractOrigin: !skipSteps?.includes('contract_origin'),
+        includeContractOrigin: includeContractOrigin,
         includeEligibilityQuestionnaire: includeEligibilityQuestionnaire,
         includeContractDetails: includeContractDetails,
         includeContractPreview: includeContractPreview,
       }),
     [
+      includeContractOrigin,
       includeEligibilityQuestionnaire,
       includeContractDetails,
       includeContractPreview,
@@ -351,6 +355,7 @@ export const useContractorOnboarding = ({
     employment?.contract_details?.contract_origin;
 
   const isContractProvidedByCustomer =
+    selectedProduct === contractorStandardProductIdentifier &&
     selectedContractOrigin === 'provided_by_customer';
 
   useEffect(() => {
@@ -555,6 +560,13 @@ export const useContractorOnboarding = ({
       setSelectedProduct(selectedPricingPlan);
     }
   }, [selectedPricingPlan, selectedProduct]);
+
+  useEffect(() => {
+    setIncludeContractOrigin(
+      !skipSteps?.includes('contract_origin') &&
+        selectedPricingPlan === contractorStandardProductIdentifier,
+    );
+  }, [skipSteps, selectedPricingPlan]);
 
   const eligibilityFields = useMemo(() => {
     return {

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -61,8 +61,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [0]: 'Select Country',
   [1]: 'Basic Information',
   [2]: 'Pricing Plan',
-  [3]: 'Contract Origin',
-  [4]: 'Eligibility Questionnaire',
+  [3]: 'Eligibility Questionnaire',
+  [4]: 'Contract Origin',
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
   [7]: 'Review',
@@ -537,10 +537,6 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
-
     await screen.findByText(/Step: Contract Details/i);
 
     const serviceDurationInput = await screen.findByTestId(
@@ -705,10 +701,6 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
-
     await screen.findByText(/Step: Contract Details/i);
 
     await fillContractDetails();
@@ -783,10 +775,6 @@ describe('ContractorOnboardingFlow', () => {
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
-
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
 
     await screen.findByText(/Step: Contract Details/i);
     await fillContractDetails();
@@ -876,10 +864,6 @@ describe('ContractorOnboardingFlow', () => {
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
-
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
 
     await screen.findByText(/Step: Contract Details/i);
 
@@ -1181,10 +1165,6 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
-
     await screen.findByText(/Step: Contract Details/i);
 
     await fillContractDetails();
@@ -1285,10 +1265,6 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
-
     await screen.findByText(/Step: Contract Details/i);
 
     // Verify the field is pre-filled with the value from the mock (2025-11-26)
@@ -1364,10 +1340,6 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
-
     await screen.findByText(/Step: Contract Details/i);
 
     await fillContractDetails();
@@ -1416,7 +1388,7 @@ describe('ContractorOnboardingFlow', () => {
     await screen.findByText(/Step: Pricing Plan/i);
     await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
 
-    await fillContractorSubscription();
+    await fillContractorSubscription('Contractor Management');
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
@@ -1526,10 +1498,6 @@ describe('ContractorOnboardingFlow', () => {
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 
-    await screen.findByText(/Step: Contract Origin/i);
-    await fillContractOrigin();
-    screen.getByText(/Next Step/i).click();
-
     await screen.findByText(/Step: Eligibility Questionnaire/i);
 
     await fillEligibilityQuestionnaire();
@@ -1614,7 +1582,7 @@ describe('ContractorOnboardingFlow', () => {
 
     await screen.findByText(/Step: Pricing Plan/i);
 
-    await fillContractorSubscription();
+    await fillContractorSubscription('Contractor Management');
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
@@ -2064,10 +2032,6 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Eligibility Questionnaire/i);
     });
 
@@ -2114,10 +2078,6 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
-
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Eligibility Questionnaire/i);
 
@@ -2184,10 +2144,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Contract Details/i);
     });
 
@@ -2246,10 +2202,6 @@ describe('ContractorOnboardingFlow', () => {
       await waitFor(() => {
         expect(deleteSpy).toHaveBeenCalled();
       });
-
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Contract Details/i);
 
@@ -2364,10 +2316,6 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
-
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Eligibility Questionnaire/i);
 
@@ -2932,10 +2880,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3056,10 +3000,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Contract Details/i);
 
       // Fill contract details
@@ -3147,10 +3087,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton.click();
 
       // Fill eligibility questionnaire (required for COR)
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3248,10 +3184,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3334,10 +3266,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3413,10 +3341,6 @@ describe('ContractorOnboardingFlow', () => {
       await fillContractorSubscription();
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
-
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Contract Details/i);
       await fillContractDetails();
@@ -3544,10 +3468,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Contract Details/i);
       await fillContractDetails();
 
@@ -3642,10 +3562,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Contract Details/i);
       await fillContractDetails();
 
@@ -3723,10 +3639,6 @@ describe('ContractorOnboardingFlow', () => {
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
 
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
-
       await screen.findByText(/Step: Eligibility Questionnaire/i);
       await fillEligibilityQuestionnaire();
 
@@ -3801,10 +3713,6 @@ describe('ContractorOnboardingFlow', () => {
 
       nextButton = screen.getByText(/Next Step/i);
       nextButton.click();
-
-      await screen.findByText(/Step: Contract Origin/i);
-      await fillContractOrigin();
-      screen.getByText(/Next Step/i).click();
 
       await screen.findByText(/Step: Contract Details/i);
 

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -1540,6 +1540,58 @@ describe('ContractorOnboardingFlow', () => {
     });
   });
 
+  it('should drop the contract origin step when switching from Contractor Management to Contractor Management Plus mid-session', async () => {
+    mockRender.mockImplementation(
+      createMockRenderImplementation(MultiStepFormWithoutCountry),
+    );
+
+    render(
+      <ContractorOnboardingFlow
+        countryCode='PRT'
+        skipSteps={['select_country']}
+        employmentId='test-employment-id'
+        {...defaultProps}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Full name/i)).toBeInTheDocument();
+    });
+
+    await fillBasicInformation();
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+
+    // Standard plan keeps the contract origin step visible
+    await fillContractorSubscription('Contractor Management');
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Origin/i);
+
+    // Go back and switch to Contractor Management Plus
+    screen.getByText('Back').click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+
+    await fillContractorSubscription('Contractor Management Plus');
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    // Contract origin must be skipped for Plus: we land straight on contract details
+    await screen.findByText(/Step: Contract Details/i);
+    expect(
+      screen.queryByText(/Step: Contract Origin/i),
+    ).not.toBeInTheDocument();
+  });
+
   it('should skip the contract steps and go straight to review when choosing "Without an agreement"', async () => {
     const setContractOriginSpy = vi.fn();
 

--- a/src/flows/ContractorOnboarding/tests/helpers.ts
+++ b/src/flows/ContractorOnboarding/tests/helpers.ts
@@ -85,7 +85,7 @@ export async function fillBasicInformation(
 }
 
 export async function fillContractorSubscription(plan?: string) {
-  await fillRadio('Payment terms', plan || 'Contractor Management Plus');
+  await fillRadio('Payment terms', `^${plan || 'Contractor Management Plus'}$`);
 }
 
 export async function fillContractOrigin(

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -49,14 +49,14 @@ export function buildSteps(config: StepConfig = {}) {
       visible: true,
     },
     {
-      name: 'contract_origin',
-      label: 'Contract Options',
-      visible: Boolean(config?.includeContractOrigin ?? true),
-    },
-    {
       name: 'eligibility_questionnaire',
       label: 'Eligibility Questionnaire',
       visible: Boolean(config?.includeEligibilityQuestionnaire),
+    },
+    {
+      name: 'contract_origin',
+      label: 'Contract Options',
+      visible: Boolean(config?.includeContractOrigin ?? true),
     },
     {
       name: 'contract_details',


### PR DESCRIPTION
**Description**

When selecting Contractor of record in pricing plan, eligibility questionnaire should be the next step and was after contract origin selection. 

**Other bug discovered when fixing that one**
When selecting 'Contractor Management Plus' or 'Contractor of Record' pricing plans, the contract origin selection step is missing from the Remote platform (though it is present in the SDK). This creates a bug when attempting to complete the flow without an agreement on the 'Contractor of Record' plan, as the API requires contract details for this case.

**What has been done**

- Now contract origin is considered after Eligibility Questionnaire (even if the two steps should never be displayed in the same flow). 

- Contract origin step is now displayed only if we are in 'contractor management' pricing plan. 

**How to test**

With our example app in the SDK

- Create contractor, with Contractor of record pricing plan -> Eligibility Questionnaire step should be displayed and not contract origin step.
- At the last step, go back on pricing plan and select 'contractor management' -> Eligibility Questionnaire step should not be displayed and contract origin step should be. 
- Select without an agreement and go to the end of the flow.
- Then go back until pricing plan step and select 'Contractor management plus' -> Contract details should be the next step, contract origin step should not be displayed, Eligibility questionnaire step should not be displayed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-step navigation and skip logic for pricing plans; incorrect gating could block or expose wrong steps in production onboarding.
> 
> **Overview**
> Fixes contractor onboarding step order and which steps appear for each **pricing plan**.
> 
> **Eligibility vs contract origin:** In `buildSteps`, **Contract Options** (`contract_origin`) now comes **after** **Eligibility Questionnaire**, so **Contractor of Record** goes pricing → eligibility → contract details instead of hitting contract origin first.
> 
> **Plan-specific contract origin:** The contract origin step is shown only for **Contractor Management** (standard). `includeContractOrigin` is driven by `selectedPricingPlan === contractorStandardProductIdentifier` (and `skipSteps`), so **Plus** and **COR** skip it—matching platform behavior and avoiding broken “without agreement” flows on COR.
> 
> **“Without an agreement”:** Treating the flow as customer-provided contract now also requires the **standard** product, so Plus/COR aren’t classified that way from stale origin alone.
> 
> Tests and `fillContractorSubscription` helpers are updated for the new order and plan gating, including switching from CM to CM+ mid-flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c874153b1d405e0557b626bac1d6dd2c97a256a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->