### PR TITLE
Refactor to permit jsModify to work on contractOriginStep

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -141,23 +141,6 @@ const Switcher = (props: JSFCustomComponentProps) => {
   );
 };
 
-// Consumer-side copy for each contract origin option. The SDK only ships the
-// option values; we decide here how each radio is labelled and described.
-const CONTRACT_ORIGIN_CONTENT: Record<
-  string,
-  { title: string; description: string }
-> = {
-  provided_by_remote: {
-    title: 'Contractor services agreement',
-    description:
-      'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
-  },
-  provided_by_customer: {
-    title: 'Continue without an agreement',
-    description: 'Use your own agreement outside Remote.',
-  },
-};
-
 const ContractOriginRadio = ({
   field,
   fieldData,
@@ -165,11 +148,17 @@ const ContractOriginRadio = ({
 }: RadioGroupComponentProps) => {
   return (
     <fieldset className='contract-origin-radio'>
+      <div className='flex flex-col gap-2 text-center mb-6'>
+        {fieldData.label && (
+          <h1 className='text-2xl font-bold text-[#000000]'>
+            {fieldData.label}
+          </h1>
+        )}
+        {fieldData.description && (
+          <p className='text-sm text-[#71717A]'>{fieldData.description}</p>
+        )}
+      </div>
       {fieldData.options?.map((option) => {
-        const content = CONTRACT_ORIGIN_CONTENT[option.value] ?? {
-          title: option.label,
-          description: option.description ?? '',
-        };
         const selected = field.value === option.value;
 
         return (
@@ -186,11 +175,13 @@ const ContractOriginRadio = ({
             />
             <span className='contract-origin-option-text'>
               <span className='contract-origin-option-title'>
-                {content.title}
+                {option.label}
               </span>
-              <span className='contract-origin-option-description'>
-                {content.description}
-              </span>
+              {option.description && (
+                <span className='contract-origin-option-description'>
+                  {option.description}
+                </span>
+              )}
             </span>
           </label>
         );
@@ -485,17 +476,6 @@ const MultiStepForm = ({
     case 'contract_origin':
       return (
         <div className='contractor-onboarding-form-layout'>
-          <div className='flex flex-col gap-2 text-center mb-6'>
-            <h1 className='text-2xl font-bold text-[#000000]'>
-              Contract options
-            </h1>
-            <p className='text-sm text-[#71717A]'>
-              Managing your relationship with contractors is easy: your contract
-              is fully editable in Remote with legally reviewed contract
-              templates specific to France. After all parties sign in Remote,
-              you're ready to go.
-            </p>
-          </div>
           <ContractOriginStep
             components={{
               radio: (props) => <ContractOriginRadio {...props} />,
@@ -665,6 +645,28 @@ export const ContractorOnboardingWithProps = ({
                           <Switcher {...props} />
                         ),
                       },
+                    },
+                  },
+                },
+                contract_origin: {
+                  fields: {
+                    contract_origin: {
+                      title: 'Contract options',
+                      description:
+                        "Managing your relationship with contractors is easy: your contract is fully editable in Remote with legally reviewed contract templates specific to France. After all parties sign in Remote, you're ready to go.",
+                      oneOf: [
+                        {
+                          const: 'provided_by_remote',
+                          title: 'Contractor services agreement',
+                          description:
+                            'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
+                        },
+                        {
+                          const: 'provided_by_customer',
+                          title: 'Continue without an agreement',
+                          description: 'Use your own agreement outside Remote.',
+                        },
+                      ],
                     },
                   },
                 },

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -644,6 +644,9 @@ export const useContractorOnboarding = ({
 
   const { data: contractOriginForm } = useGetContractOriginSchema({
     fieldValues: fieldValues,
+    options: {
+      jsfModify: options?.jsfModify?.contract_origin,
+    },
   });
 
   const {

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -1253,6 +1253,59 @@ describe('ContractorOnboardingFlow', () => {
     });
   });
 
+  it('should override contract_origin field title using jsfModify options', async () => {
+    const customTitle = 'Choose how the contract is provided';
+
+    mockRender.mockImplementation(
+      createMockRenderImplementation(MultiStepFormWithoutCountry),
+    );
+
+    render(
+      <ContractorOnboardingFlow
+        {...defaultProps}
+        countryCode='PRT'
+        skipSteps={['select_country']}
+        options={{
+          jsfModify: {
+            contract_origin: {
+              fields: {
+                contract_origin: {
+                  title: customTitle,
+                },
+              },
+            },
+          },
+        }}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    await fillBasicInformation();
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+
+    await fillContractorSubscription();
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Origin/i);
+
+    // The default schema title for this field is "Contract options"; jsfModify
+    // should replace it with our custom title.
+    await waitFor(() => {
+      expect(screen.getByText(customTitle)).toBeInTheDocument();
+      expect(screen.queryByText('Contract options')).not.toBeInTheDocument();
+    });
+  });
+
   it('should display description message when service_duration.provisional_start_date differs from employment provisional_start_date', async () => {
     const employmentId = generateUniqueEmploymentId();
 

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -75,6 +75,7 @@ type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
     contract_preview?: JSFModify;
     eligibility_questionnaire?: JSFModify;
     pricing_plan?: JSFModify;
+    contract_origin?: JSFModify;
   };
 };
 


### PR DESCRIPTION
**Description**

jsmodify was not working to override title and description on the radio buttons in ContractOriginStep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to contract-origin UI and schema customization; no auth or persistence logic changes beyond passing existing jsfModify through.
> 
> **Overview**
> **Contract origin step** now honors `options.jsfModify.contract_origin` the same way other onboarding steps do: the hook passes that block into `useGetContractOriginSchema`, and the flow options type includes `contract_origin?: JSFModify`.
> 
> The example app stops hardcoding step headings and radio copy (`CONTRACT_ORIGIN_CONTENT` and the `contract_origin` case layout). **`ContractOriginRadio`** renders the field **title/description** from `fieldData` and each option’s **label/description** from the schema, so overrides from `jsfModify` (including `oneOf` titles) actually show up.
> 
> Default France-facing copy in the demo is moved into **`jsfModify.contract_origin`** on `ContractorOnboardingFlow`. A test asserts a custom `contract_origin` field title replaces the default “Contract options” text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1abbf2425e89373146d23eed9eedd9913b7ccc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->