### PR TITLE
fix: select standard plan so contract_origin step is visible in jsfMo…

### DIFF
--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -1271,7 +1271,7 @@ describe('ContractorOnboardingFlow', () => {
     await screen.findByText(/Step: Pricing Plan/i);
     await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
 
-    await fillContractorSubscription();
+    await fillContractorSubscription('Contractor Management');
 
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -82,6 +82,12 @@ function createMockRenderImplementation(
     return (
       <>
         <h1>Step: {stepsMap[currentStepIndex]}</h1>
+        <div data-testid='visible-steps'>
+          {contractorOnboardingBag.steps
+            .filter((step) => step.visible !== false)
+            .map((step) => step.name)
+            .join(' ')}
+        </div>
         <FormComponent
           contractorOnboardingBag={contractorOnboardingBag}
           components={components}
@@ -1274,9 +1280,9 @@ describe('ContractorOnboardingFlow', () => {
     await fillContractorSubscription('Contractor Management');
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('radio', { name: /^Contractor Management$/i }),
-      ).toBeChecked();
+      expect(screen.getByTestId('visible-steps')).toHaveTextContent(
+        'contract_origin',
+      );
     });
 
     nextButton = screen.getByText(/Next Step/i);

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -1273,6 +1273,12 @@ describe('ContractorOnboardingFlow', () => {
 
     await fillContractorSubscription('Contractor Management');
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole('radio', { name: /^Contractor Management$/i }),
+      ).toBeChecked();
+    });
+
     nextButton = screen.getByText(/Next Step/i);
     nextButton.click();
 


### PR DESCRIPTION
…dify test

The contract_origin step only renders when the selected pricing plan is the standard product ('Contractor Management'). The test defaulted to 'Contractor Management Plus', hiding the step and causing a timeout after merging PRs #1147 and #1148.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths affected.
> 
> **Overview**
> Fixes a flaky **Contractor Onboarding** integration test that exercises `jsfModify` on the **Contract Origin** step.
> 
> The test now selects **Contractor Management** (standard plan) instead of relying on the helper default **Contractor Management Plus**, because `contract_origin` is only in the visible step list for the standard product. It also asserts via a new `visible-steps` test hook that `contract_origin` is present before advancing, and the shared test renderer exposes visible step names for that check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5709dd022133428a6dbcc33b6a4064c19725e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->