### PR TITLE
Release/1.42.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ### Patch Changes
 
+#### Fixes
+- Fix steps order bug (eligibility questionnaire should be the next step after selecting pricing plan) [#1147](https://github.com/remoteoss/remote-flows/pull/1147)
+- ContractOriginStep titles and options are now overridable by jsModify (see example here : https://github.com/remoteoss/remote-flows/blob/fa252eaa6ae065590bf00cacdf06debc70f516b1/example/src/ContractorOnboarding.tsx#L651-L671) [#1148](https://github.com/remoteoss/remote-flows/pull/1148)
+
+#### Chores
 - datepicker dropdown navigation + JSF logging + build heap (#1134) [#1134](https://github.com/remoteoss/remote-flows/pull/1134)
-- select standard plan so contract_origin step is visible in jsfModify test [#1147](https://github.com/remoteoss/remote-flows/pull/1147)
-- wait for pricing plan selection to settle before navigating
-- wait for contract_origin step to be reconciled before navigating
-- trigger CI rebuild on latest commit
+
+
 
 ## 1.42.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Patch Changes
 
 #### Fixes
+
 - Fix steps order bug (eligibility questionnaire should be the next step after selecting pricing plan) [#1147](https://github.com/remoteoss/remote-flows/pull/1147)
 - ContractOriginStep titles and options are now overridable by jsModify (see example here : https://github.com/remoteoss/remote-flows/blob/fa252eaa6ae065590bf00cacdf06debc70f516b1/example/src/ContractorOnboarding.tsx#L651-L671) [#1148](https://github.com/remoteoss/remote-flows/pull/1148)
 
 #### Chores
+
 - datepicker dropdown navigation + JSF logging + build heap (#1134) [#1134](https://github.com/remoteoss/remote-flows/pull/1134)
-
-
 
 ## 1.42.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @remoteoss/remote-flows
 
+## 1.42.1
+
+### Patch Changes
+
+- datepicker dropdown navigation + JSF logging + build heap (#1134) [#1134](https://github.com/remoteoss/remote-flows/pull/1134)
+- select standard plan so contract_origin step is visible in jsfModify test [#1147](https://github.com/remoteoss/remote-flows/pull/1147)
+- wait for pricing plan selection to settle before navigating
+- wait for contract_origin step to be reconciled before navigating
+- trigger CI rebuild on latest commit
+
 ## 1.42.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release; behavioral changes are already shipped via referenced patch PRs.
> 
> **Overview**
> **Release 1.42.1** — bumps `@remoteoss/remote-flows` from **1.42.0** to **1.42.1** in `package.json` / lockfile and adds the **1.42.1** changelog section.
> 
> Documented patch contents (from already-merged work):
> 
> - **Onboarding flow:** fixes step order so the eligibility questionnaire follows pricing plan selection ([#1147](https://github.com/remoteoss/remote-flows/pull/1147)).
> - **`ContractOriginStep`:** titles and options can be overridden via `jsModify` ([#1148](https://github.com/remoteoss/remote-flows/pull/1148)).
> - **Chores:** datepicker dropdown navigation, JSF logging, and build heap / Node memory for production builds ([#1134](https://github.com/remoteoss/remote-flows/pull/1134)).
> 
> No application source changes appear in this diff—only version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6211735353e22ce80ee78a0f7f4df9fb44b11f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->