### PR TITLE
Enable pre_onboarding_requirements feature flag in example app

### DIFF
--- a/example/src/Onboarding.tsx
+++ b/example/src/Onboarding.tsx
@@ -596,7 +596,12 @@ const OnboardingWithProps = ({
       employmentId={employmentId}
       externalId={externalId}
       options={{
-        features: ['onboarding_reserves', 'dynamic_steps', 'ea_preview'],
+        features: [
+          'onboarding_reserves',
+          'dynamic_steps',
+          'ea_preview',
+          'pre_onboarding_requirements',
+        ],
         jsonSchemaVersion: {
           employment_basic_information: 3,
         },


### PR DESCRIPTION
## Summary
- The `PreOnboardingRequirements` component is already built and wired into `OnboardingFlow`/`ReviewOnboardingStep`, but its data fetch is gated behind the `pre_onboarding_requirements` feature flag, which the example app didn't enable — so it silently rendered nothing.
- Adds `'pre_onboarding_requirements'` to the `features` array in `example/src/Onboarding.tsx` so the example actually demonstrates the pre-onboarding requirements flow (e.g. Acknowledgement / CSW-style requirements for EOR hires).

## Test plan
- [ ] Run the example app, start an EOR onboarding flow for a country with pre-onboarding requirements configured, and confirm the requirements list renders in the review step
- [ ] Confirm existing onboarding flows without pre-onboarding requirements still render normally (graceful empty state)