### PR TITLE
canInvite is now depending of onboarding-reserve-status pending request

### DIFF
--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -85,6 +85,7 @@ const getLoadingStates = ({
   basicInformationFields,
   contractDetailsFields,
   arePreOnboardingRequirementsFulfilled,
+  isLoadingOnboardingReservesStatus,
 }: {
   isLoadingBasicInformationForm: boolean;
   isLoadingContractDetailsForm: boolean;
@@ -102,6 +103,7 @@ const getLoadingStates = ({
   basicInformationFields: JSFFields;
   contractDetailsFields: JSFFields;
   arePreOnboardingRequirementsFulfilled: boolean;
+  isLoadingOnboardingReservesStatus: boolean;
 }) => {
   const initialLoading =
     isLoadingBasicInformationForm ||
@@ -122,7 +124,8 @@ const getLoadingStates = ({
   const canInvite =
     employmentStatus &&
     !disabledInviteButtonEmploymentStatus.includes(employmentStatus) &&
-    arePreOnboardingRequirementsFulfilled;
+    arePreOnboardingRequirementsFulfilled &&
+    !isLoadingOnboardingReservesStatus;
 
   const shouldHandleReadOnlyEmployment = Boolean(
     employmentId && isEmploymentReadOnly && currentStepName !== 'review',
@@ -319,12 +322,14 @@ export const useOnboarding = ({
       stepState.currentStep.name === 'review') ||
     false;
 
-  const { data: onboardingReservesStatus } =
-    useEmploymentOnboardingReservesStatus(
-      companyId,
-      internalEmploymentId,
-      isOnboardingReservesEnabled,
-    );
+  const {
+    data: onboardingReservesStatus,
+    isLoading: isLoadingOnboardingReservesStatus,
+  } = useEmploymentOnboardingReservesStatus(
+    companyId,
+    internalEmploymentId,
+    isOnboardingReservesEnabled,
+  );
 
   const isPreOnboardingRequirementsEnabled = Boolean(
     options?.features?.includes('pre_onboarding_requirements') &&
@@ -801,6 +806,7 @@ export const useOnboarding = ({
           contractDetailsFields: stepFields.contract_details,
           currentStepName: currentStepName,
           arePreOnboardingRequirementsFulfilled,
+          isLoadingOnboardingReservesStatus,
         }),
       [
         isLoadingBasicInformationForm,
@@ -819,6 +825,7 @@ export const useOnboarding = ({
         stepFields.contract_details,
         currentStepName,
         arePreOnboardingRequirementsFulfilled,
+        isLoadingOnboardingReservesStatus,
       ],
     );
 


### PR DESCRIPTION
**Description**
it turns out that if GET /companies/:id/employments/:id/onboarding-reserves-status is too slow, we can still click the invite button if we are very fast. I think we should prevent this by disabling the invite button while the API request is pending.

**Solution**
canInvite is now depending of `GET /companies/:id/employments/:id/onboarding-reserves-status` pending request status. So we cannot click invite until request is finished. 

**How to test**
Not easy to test whithout forcing `GET /companies/:id/employments/:id/onboarding-reserves-status` to be slow. 

You can add code like this to the proxy : 

`// the invite button disabled-while-loading behavior. Remove before merging.
    if (
      req.method === 'GET' &&
      /\/onboarding-reserves-status(\?|$)/.test(req.originalUrl)
    ) {
      await new Promise((resolve) => setTimeout(resolve, 15000));
    }`
    
   And then make a test on an onBoarding, invite button should be disabled during 15seconds while request is finished. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small onboarding UX guard with no auth or data-model changes; only gates the invite button during an existing API fetch.
> 
> **Overview**
> Fixes a race on the review step where users could click **Invite** before `GET .../onboarding-reserves-status` finished.
> 
> `useEmploymentOnboardingReservesStatus` now exposes **`isLoading`**, wired through `getLoadingStates` as `isLoadingOnboardingReservesStatus`. **`canInvite`** stays false while that request is pending (along with existing employment status and pre-onboarding checks), which keeps the invite control disabled via `OnboardingInvite` until reserves status is known.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fc9524342879f02661e3fba62614ca602b18ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->