### PR TITLE
fix(radio-group) - radio labels can come with html

### DIFF
--- a/src/components/form/fields/default/RadioGroupFieldDefault.tsx
+++ b/src/components/form/fields/default/RadioGroupFieldDefault.tsx
@@ -59,7 +59,9 @@ export const RadioGroupFieldDefault = ({
                   </FormControl>
                   <div>
                     <FormLabel className='font-normal mb-0 RemoteFlows__RadioField__Label'>
-                      {option.label}{' '}
+                      <span
+                        dangerouslySetInnerHTML={{ __html: option.label }}
+                      />{' '}
                       {option.recommended && (
                         <Badge variant='secondary' className='ml-2'>
                           Recommended


### PR DESCRIPTION
How it was looking before

<img width="990" height="145" alt="image" src="https://github.com/user-attachments/assets/0f0e5c6a-fd9c-402d-83ba-f1b8aec58416" />


How it looks now
<img width="626" height="178" alt="image" src="https://github.com/user-attachments/assets/45adcb34-0e3a-4755-b337-3285c1f4bde0" />
