### PR TITLE
fix(query-config) - avoid refetching data on window focus

### DIFF
--- a/src/queryConfig.ts
+++ b/src/queryConfig.ts
@@ -1,3 +1,10 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const getQueryClient = () => new QueryClient();
+export const getQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  });


### PR DESCRIPTION
This is strange but it looks it was the explicit behavior until now

If you clicked an anchor that opened a new tab, then come back to the embedded, the whole thing would reload which I don't want

Demo: 
https://www.loom.com/share/57846c11c43c435ead80078a1a2f7173?focus_title=1&muted=1&from_recorder=1