### PR TITLE
fix(createHeadlessForm) - rely on new property

### DIFF
--- a/src/common/createHeadlessForm.tsx
+++ b/src/common/createHeadlessForm.tsx
@@ -85,7 +85,12 @@ export const createHeadlessForm = (
 
   return {
     meta: {
-      'x-jsf-fieldsets': jsfSchema['x-jsf-fieldsets'] as JSFFieldset,
+      // Support for both x-jsf-fieldsets and x-rmt-flatFieldsets
+      // before x-jsf-fieldsets was used, but it was migrated to x-rmt-flatFieldsets
+      // this allows to everything to keep working as expected without renaming the whole thing
+      'x-jsf-fieldsets':
+        (jsfSchema['x-jsf-fieldsets'] as JSFFieldset) ||
+        (jsfSchema['x-rmt-flatFieldsets'] as JSFFieldset),
       'x-jsf-presentation': jsfSchema['x-jsf-presentation'] as
         | Record<string, unknown>
         | undefined,


### PR DESCRIPTION
It seems like internally they renamed the x-jsf-fieldsets property to x-rmt-flatFieldsets which has make the SDK flat fieldsets to stop working

https://gitlab.com/remote-com/employ-starbase/tiger/-/merge_requests/87376#note_3566430581

With this fieldsets will be back again, the problem is that old versions of the SDK are kind of broken...