### PR TITLE
feat(gp): example app demo for admin onboarding flow (PBYR-4044)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -49,6 +49,7 @@ import { MagicLinkTest } from './MagicLinkTest';
 import { JsonSchemaComparisonDemo } from './JsonSchemaComparisonDemo';
 import { JsonSchemaPlayground } from './flows/JsonSchemaPlayground/JsonSchemaPlayground';
 import { SandboxPaymentApproval } from './SandboxPaymentApproval';
+import { PayrollAdminOnboardingForm } from './PayrollAdminOnboarding';
 import { PayrollEmployeeOnboardingForm } from './PayrollEmployeeOnboarding';
 import ContractorOnboardingCode from './ContractorOnboarding?raw';
 import CreateCompanyCode from './CreateCompany?raw';
@@ -193,6 +194,13 @@ const additionalDemos = [
     description: 'Test and experiment with different JSON schemas',
     component: JsonSchemaPlayground,
     sourceCode: JsonSchemaPlaygroundCode,
+  },
+  {
+    id: 'payroll-admin-onboarding',
+    title: 'GP Admin Onboarding',
+    description: 'Global Payroll admin onboarding flow',
+    component: PayrollAdminOnboardingForm,
+    sourceCode: '',
   },
   {
     id: 'payroll-employee-onboarding',

--- a/example/src/PayrollAdminOnboarding.tsx
+++ b/example/src/PayrollAdminOnboarding.tsx
@@ -1,0 +1,257 @@
+import { useState } from 'react';
+import {
+  PayrollAdminOnboardingFlow,
+  PayrollAdminOnboardingRenderProps,
+  useGPLegalEntities,
+} from '@remoteoss/remote-flows';
+import { RemoteFlows } from './RemoteFlows';
+import { AlertError } from './AlertError';
+import './css/main.css';
+
+const COMPANY_ID = import.meta.env.VITE_COMPANY_ID as string;
+
+const STEP_LABELS: Record<string, string> = {
+  select_country: 'Country & Basic Info',
+  contract_details: 'Contract Details',
+  administrative_details: 'Administrative Details',
+  invite: 'Send Invitation',
+};
+
+const STEP_DESCRIPTIONS: Record<string, string> = {
+  select_country:
+    "Select the employee's country and fill in their basic information.",
+  contract_details:
+    'Define the employment contract terms for this Global Payroll employee.',
+  administrative_details:
+    'Provide administrative details required for payroll processing.',
+  invite:
+    'Send the invitation email so the employee can complete their self-onboarding.',
+};
+
+type Errors = {
+  apiError: string;
+  fieldErrors: {
+    field: string;
+    messages: string[];
+    userFriendlyLabel: string;
+  }[];
+};
+
+const emptyErrors: Errors = { apiError: '', fieldErrors: [] };
+
+function AdminFlowForm({ legalEntityId }: { legalEntityId: string }) {
+  const [errors, setErrors] = useState<Errors>(emptyErrors);
+  const [done, setDone] = useState(false);
+
+  const clearErrors = () => setErrors(emptyErrors);
+
+  const handleError = (error: Error, fieldErrors: Errors['fieldErrors']) => {
+    setErrors({ apiError: error.message, fieldErrors });
+  };
+
+  if (done) {
+    return (
+      <div className='card' style={{ marginBottom: 20 }}>
+        <h1 className='heading'>Invitation Sent</h1>
+        <p style={{ color: '#22356f', marginBottom: 16 }}>
+          The employee will receive an email to complete their self-onboarding.
+        </p>
+        <div className='buttons-container'>
+          <button
+            className='submit-button'
+            onClick={() => {
+              setDone(false);
+              clearErrors();
+            }}
+          >
+            Start a new onboarding
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PayrollAdminOnboardingFlow
+      companyId={COMPANY_ID}
+      legalEntityId={legalEntityId}
+      render={({ adminBag, components }: PayrollAdminOnboardingRenderProps) => {
+        const {
+          SelectCountryStep,
+          ContractDetailsStep,
+          AdministrativeDetailsStep,
+          InvitationStep,
+          SubmitButton,
+          BackButton,
+        } = components;
+
+        const currentStep = adminBag.stepState.currentStep.name;
+        const allSteps = Object.entries(STEP_LABELS);
+
+        if (adminBag.isLoading && !adminBag.countryCode) {
+          return <p>Loading...</p>;
+        }
+
+        const onStepError = (e: {
+          error: Error;
+          fieldErrors: { field: string; messages: string[] }[];
+        }) =>
+          handleError(
+            e.error,
+            e.fieldErrors.map((fe) => ({
+              ...fe,
+              userFriendlyLabel: fe.field,
+            })),
+          );
+
+        const renderStep = () => {
+          switch (currentStep) {
+            case 'select_country': {
+              const isFormReady =
+                !!adminBag.countryCode && adminBag.fields.length > 0;
+              return (
+                <>
+                  <SelectCountryStep
+                    onError={onStepError}
+                    onSuccess={clearErrors}
+                  />
+                  <AlertError errors={errors} />
+                  {isFormReady && (
+                    <div className='buttons-container'>
+                      <SubmitButton
+                        className='submit-button'
+                        onClick={clearErrors}
+                      >
+                        Create Employment & Continue
+                      </SubmitButton>
+                    </div>
+                  )}
+                </>
+              );
+            }
+            case 'contract_details':
+              return (
+                <>
+                  <ContractDetailsStep
+                    onError={onStepError}
+                    onSuccess={clearErrors}
+                  />
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    <SubmitButton
+                      className='submit-button'
+                      onClick={clearErrors}
+                    >
+                      Save & Continue
+                    </SubmitButton>
+                  </div>
+                </>
+              );
+            case 'administrative_details':
+              return (
+                <>
+                  <AdministrativeDetailsStep
+                    onError={onStepError}
+                    onSuccess={clearErrors}
+                  />
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    <SubmitButton
+                      className='submit-button'
+                      onClick={clearErrors}
+                    >
+                      Save & Continue
+                    </SubmitButton>
+                  </div>
+                </>
+              );
+            case 'invite':
+              return (
+                <>
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    <InvitationStep
+                      onSuccess={() => {
+                        clearErrors();
+                        setDone(true);
+                      }}
+                      onError={onStepError}
+                    >
+                      Send Invitation
+                    </InvitationStep>
+                  </div>
+                </>
+              );
+            default:
+              return null;
+          }
+        };
+
+        return (
+          <>
+            <div className='steps-navigation'>
+              <ul>
+                {allSteps.map(([key, label], index) => (
+                  <li
+                    key={key}
+                    className={`step-item ${key === currentStep ? 'active' : ''}`}
+                  >
+                    <span className='step-number'>{index + 1}</span>
+                    {label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className='card' style={{ marginBottom: 20 }}>
+              <h1 className='heading'>{STEP_LABELS[currentStep]}</h1>
+              <p style={{ fontSize: 14, color: '#71717A', marginBottom: 24 }}>
+                {STEP_DESCRIPTIONS[currentStep]}
+              </p>
+              {renderStep()}
+            </div>
+          </>
+        );
+      }}
+    />
+  );
+}
+
+function GPAdminOnboardingInner() {
+  const { data: legalEntities, isLoading } = useGPLegalEntities(COMPANY_ID);
+
+  if (isLoading) {
+    return <p>Loading…</p>;
+  }
+
+  if (!legalEntities || legalEntities.length === 0) {
+    return (
+      <div className='alert'>
+        <p>
+          <strong>No GP-enabled legal entity found.</strong> The company{' '}
+          <code>{COMPANY_ID}</code> has no legal entity with Global Payroll
+          enabled.
+        </p>
+      </div>
+    );
+  }
+
+  return <AdminFlowForm legalEntityId={legalEntities[0].id} />;
+}
+
+export function PayrollAdminOnboardingForm() {
+  return (
+    <RemoteFlows proxy={{ url: window.location.origin }} authType='none'>
+      <GPAdminOnboardingInner />
+    </RemoteFlows>
+  );
+}

--- a/example/src/PayrollAdminOnboarding.tsx
+++ b/example/src/PayrollAdminOnboarding.tsx
@@ -90,6 +90,21 @@ function AdminFlowForm() {
           return <p>Loading...</p>;
         }
 
+        if (!adminBag.isLoading && adminBag.isErrorLegalEntities) {
+          return (
+            <div
+              className='alert'
+              style={{ background: '#fee', borderColor: '#c33' }}
+            >
+              <p>
+                <strong>Could not load legal entities</strong> for company{' '}
+                <code>{COMPANY_ID}</code>. Check your connection and
+                permissions, then reload.
+              </p>
+            </div>
+          );
+        }
+
         if (!adminBag.isLoading && adminBag.legalEntities.length === 0) {
           return (
             <div className='alert'>

--- a/example/src/PayrollAdminOnboarding.tsx
+++ b/example/src/PayrollAdminOnboarding.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import {
   PayrollAdminOnboardingFlow,
   PayrollAdminOnboardingRenderProps,
-  useGPLegalEntities,
 } from '@remoteoss/remote-flows';
 import { RemoteFlows } from './RemoteFlows';
 import { AlertError } from './AlertError';
@@ -39,7 +38,7 @@ type Errors = {
 
 const emptyErrors: Errors = { apiError: '', fieldErrors: [] };
 
-function AdminFlowForm({ legalEntityId }: { legalEntityId: string }) {
+function AdminFlowForm() {
   const [errors, setErrors] = useState<Errors>(emptyErrors);
   const [done, setDone] = useState(false);
 
@@ -74,7 +73,6 @@ function AdminFlowForm({ legalEntityId }: { legalEntityId: string }) {
   return (
     <PayrollAdminOnboardingFlow
       companyId={COMPANY_ID}
-      legalEntityId={legalEntityId}
       render={({ adminBag, components }: PayrollAdminOnboardingRenderProps) => {
         const {
           SelectCountryStep,
@@ -88,8 +86,20 @@ function AdminFlowForm({ legalEntityId }: { legalEntityId: string }) {
         const currentStep = adminBag.stepState.currentStep.name;
         const allSteps = Object.entries(STEP_LABELS);
 
-        if (adminBag.isLoading && !adminBag.countryCode) {
+        if (adminBag.isLoading && adminBag.fields.length === 0) {
           return <p>Loading...</p>;
+        }
+
+        if (!adminBag.isLoading && adminBag.legalEntities.length === 0) {
+          return (
+            <div className='alert'>
+              <p>
+                <strong>No GP-enabled legal entity found.</strong> The company{' '}
+                <code>{COMPANY_ID}</code> has no legal entity with Global
+                Payroll enabled.
+              </p>
+            </div>
+          );
         }
 
         const onStepError = (e: {
@@ -116,16 +126,15 @@ function AdminFlowForm({ legalEntityId }: { legalEntityId: string }) {
                     onSuccess={clearErrors}
                   />
                   <AlertError errors={errors} />
-                  {isFormReady && (
-                    <div className='buttons-container'>
-                      <SubmitButton
-                        className='submit-button'
-                        onClick={clearErrors}
-                      >
-                        Create Employment & Continue
-                      </SubmitButton>
-                    </div>
-                  )}
+                  <div className='buttons-container'>
+                    <SubmitButton
+                      className='submit-button'
+                      onClick={clearErrors}
+                      disabled={!isFormReady}
+                    >
+                      Create Employment & Continue
+                    </SubmitButton>
+                  </div>
                 </>
               );
             }
@@ -226,32 +235,10 @@ function AdminFlowForm({ legalEntityId }: { legalEntityId: string }) {
   );
 }
 
-function GPAdminOnboardingInner() {
-  const { data: legalEntities, isLoading } = useGPLegalEntities(COMPANY_ID);
-
-  if (isLoading) {
-    return <p>Loading…</p>;
-  }
-
-  if (!legalEntities || legalEntities.length === 0) {
-    return (
-      <div className='alert'>
-        <p>
-          <strong>No GP-enabled legal entity found.</strong> The company{' '}
-          <code>{COMPANY_ID}</code> has no legal entity with Global Payroll
-          enabled.
-        </p>
-      </div>
-    );
-  }
-
-  return <AdminFlowForm legalEntityId={legalEntities[0].id} />;
-}
-
 export function PayrollAdminOnboardingForm() {
   return (
     <RemoteFlows proxy={{ url: window.location.origin }} authType='none'>
-      <GPAdminOnboardingInner />
+      <AdminFlowForm />
     </RemoteFlows>
   );
 }

--- a/src/flows/PayrollAdminOnboarding/PayrollAdminOnboardingFlow.tsx
+++ b/src/flows/PayrollAdminOnboarding/PayrollAdminOnboardingFlow.tsx
@@ -2,15 +2,12 @@ import { useId } from 'react';
 import { usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding/hooks';
 import { PayrollAdminOnboardingContext } from '@/src/flows/PayrollAdminOnboarding/context';
 import type { PayrollAdminOnboardingFlowProps } from '@/src/flows/PayrollAdminOnboarding/types';
-
-// Stable module-level references — prevents consumer subtrees from unmounting on parent re-renders.
-// Each will be replaced with a real implementation in PBYR-4044.
-const SelectCountryStep = () => null;
-const ContractDetailsStep = () => null;
-const AdministrativeDetailsStep = () => null;
-const InvitationStep = () => null;
-const SubmitButton = () => null;
-const BackButton = () => null;
+import { SelectCountryStep } from '@/src/flows/PayrollAdminOnboarding/components/SelectCountryStep';
+import { ContractDetailsStep } from '@/src/flows/PayrollAdminOnboarding/components/ContractDetailsStep';
+import { AdministrativeDetailsStep } from '@/src/flows/PayrollAdminOnboarding/components/AdministrativeDetailsStep';
+import { InvitationStep } from '@/src/flows/PayrollAdminOnboarding/components/InvitationStep';
+import { SubmitButton } from '@/src/flows/PayrollAdminOnboarding/components/SubmitButton';
+import { BackButton } from '@/src/flows/PayrollAdminOnboarding/components/BackButton';
 
 export const PayrollAdminOnboardingFlow = ({
   companyId,

--- a/src/flows/PayrollAdminOnboarding/hooks.tsx
+++ b/src/flows/PayrollAdminOnboarding/hooks.tsx
@@ -54,10 +54,12 @@ export const usePayrollAdminOnboarding = ({
   initialValues,
   options,
 }: Omit<PayrollAdminOnboardingFlowProps, 'render'>) => {
-  // Only fetch when the caller hasn't already pinned a legal entity — avoids
-  // an unnecessary request for callers that already know theirs.
+  // Always fetch, even when the caller already pinned a legal entity — so
+  // `legalEntities` below stays accurate for callers that inspect it (e.g. to
+  // render their own "no GP-enabled legal entity" state) instead of always
+  // reporting empty just because the fetch was skipped.
   const { data: legalEntities, isLoading: isLoadingLegalEntities } =
-    useGPLegalEntities(providedLegalEntityId ? undefined : companyId);
+    useGPLegalEntities(companyId);
 
   // If there are no GP-enabled legal entities, this stays undefined — the
   // consumer is expected to check `legalEntities` and not render the flow.

--- a/src/flows/PayrollAdminOnboarding/hooks.tsx
+++ b/src/flows/PayrollAdminOnboarding/hooks.tsx
@@ -1,6 +1,9 @@
 import { useState, useMemo, useCallback } from 'react';
 import type { FieldValues } from 'react-hook-form';
-import { useGPOnboardingSteps } from '@/src/common/api/gpOnboarding';
+import {
+  useGPOnboardingSteps,
+  useGPLegalEntities,
+} from '@/src/common/api/gpOnboarding';
 import { useStepState } from '@/src/flows/useStepState';
 import type { Step } from '@/src/flows/useStepState';
 import type { PayrollAdminOnboardingFlowProps } from '@/src/flows/PayrollAdminOnboarding/types';
@@ -45,12 +48,21 @@ const buildAdminSteps = (
 
 export const usePayrollAdminOnboarding = ({
   companyId,
-  legalEntityId,
+  legalEntityId: providedLegalEntityId,
   countryCode: initialCountryCode,
   employmentId: initialEmploymentId,
   initialValues,
   options,
 }: Omit<PayrollAdminOnboardingFlowProps, 'render'>) => {
+  // Only fetch when the caller hasn't already pinned a legal entity — avoids
+  // an unnecessary request for callers that already know theirs.
+  const { data: legalEntities, isLoading: isLoadingLegalEntities } =
+    useGPLegalEntities(providedLegalEntityId ? undefined : companyId);
+
+  // If there are no GP-enabled legal entities, this stays undefined — the
+  // consumer is expected to check `legalEntities` and not render the flow.
+  const legalEntityId = providedLegalEntityId ?? legalEntities?.[0]?.id;
+
   const [internalEmploymentId, setInternalEmploymentId] = useState<
     string | undefined
   >(initialEmploymentId);
@@ -234,6 +246,12 @@ export const usePayrollAdminOnboarding = ({
             return data;
           }
 
+          if (!legalEntityId) {
+            throw new Error(
+              'No GP-enabled legal entity available. Cannot create an employment.',
+            );
+          }
+
           const data = await createEmploymentAsync({
             countryCode,
             legalEntityId,
@@ -299,11 +317,12 @@ export const usePayrollAdminOnboarding = ({
 
   return {
     stepState,
-    isLoading: isLoadingSteps || isLoadingSchema,
+    isLoading: isLoadingSteps || isLoadingSchema || isLoadingLegalEntities,
     isSubmitting,
     isComplete: isComplete ?? false,
     companyId,
     legalEntityId,
+    legalEntities: legalEntities ?? [],
     countryCode: internalCountryCode,
     employmentId: internalEmploymentId,
     initialValues,

--- a/src/flows/PayrollAdminOnboarding/hooks.tsx
+++ b/src/flows/PayrollAdminOnboarding/hooks.tsx
@@ -58,8 +58,11 @@ export const usePayrollAdminOnboarding = ({
   // `legalEntities` below stays accurate for callers that inspect it (e.g. to
   // render their own "no GP-enabled legal entity" state) instead of always
   // reporting empty just because the fetch was skipped.
-  const { data: legalEntities, isLoading: isLoadingLegalEntities } =
-    useGPLegalEntities(companyId);
+  const {
+    data: legalEntities,
+    isLoading: isLoadingLegalEntities,
+    isError: isErrorLegalEntities,
+  } = useGPLegalEntities(companyId);
 
   // If there are no GP-enabled legal entities, this stays undefined — the
   // consumer is expected to check `legalEntities` and not render the flow.
@@ -325,6 +328,10 @@ export const usePayrollAdminOnboarding = ({
     companyId,
     legalEntityId,
     legalEntities: legalEntities ?? [],
+    // An empty `legalEntities` array means "no GP-enabled legal entity" only
+    // when this is false — check it before treating empty as that state,
+    // since a failed fetch also leaves `legalEntities` empty.
+    isErrorLegalEntities,
     countryCode: internalCountryCode,
     employmentId: internalEmploymentId,
     initialValues,

--- a/src/flows/PayrollAdminOnboarding/tests/hooks.test.tsx
+++ b/src/flows/PayrollAdminOnboarding/tests/hooks.test.tsx
@@ -67,7 +67,13 @@ describe('usePayrollAdminOnboarding — legal entities', () => {
     expect(result.current.legalEntityId).toBeUndefined();
   });
 
-  it('uses an explicitly provided legalEntityId as-is', () => {
+  it('uses an explicitly provided legalEntityId as-is, while still exposing the fetched legalEntities', async () => {
+    server.use(
+      http.get('*/v1/companies/*/legal-entities', () =>
+        HttpResponse.json(legalEntitiesResponse([gpEnabledLegalEntity])),
+      ),
+    );
+
     const { result } = renderHook(
       () =>
         usePayrollAdminOnboarding({
@@ -78,5 +84,13 @@ describe('usePayrollAdminOnboarding — legal entities', () => {
     );
 
     expect(result.current.legalEntityId).toBe('explicit-le');
+
+    // legalEntities is still fetched and populated — it must not read as
+    // empty just because an explicit legalEntityId skipped derivation, or
+    // callers following the "empty legalEntities means no GP legal entity"
+    // contract would be misled.
+    await waitFor(() => {
+      expect(result.current.legalEntities).toEqual([gpEnabledLegalEntity]);
+    });
   });
 });

--- a/src/flows/PayrollAdminOnboarding/tests/hooks.test.tsx
+++ b/src/flows/PayrollAdminOnboarding/tests/hooks.test.tsx
@@ -93,4 +93,26 @@ describe('usePayrollAdminOnboarding — legal entities', () => {
       expect(result.current.legalEntities).toEqual([gpEnabledLegalEntity]);
     });
   });
+
+  it('exposes isErrorLegalEntities when the fetch fails, instead of reading as no GP-enabled legal entity', async () => {
+    server.use(
+      http.get('*/v1/companies/*/legal-entities', () =>
+        HttpResponse.json(
+          { message: 'Internal server error' },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    const { result } = renderHook(
+      () => usePayrollAdminOnboarding({ companyId: 'company-1' }),
+      { wrapper: TestProviders },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isErrorLegalEntities).toBe(true);
+    });
+    expect(result.current.legalEntities).toEqual([]);
+    expect(result.current.legalEntityId).toBeUndefined();
+  });
 });

--- a/src/flows/PayrollAdminOnboarding/tests/hooks.test.tsx
+++ b/src/flows/PayrollAdminOnboarding/tests/hooks.test.tsx
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/src/tests/server';
+import { usePayrollAdminOnboarding } from '@/src/flows/PayrollAdminOnboarding/hooks';
+import { queryClient, TestProviders } from '@/src/tests/testHelpers';
+
+const gpEnabledLegalEntity = {
+  id: 'le-1',
+  name: 'Acme GP Legal Entity',
+  country_code: 'USA',
+  is_default: true,
+  global_payroll_enabled: true,
+};
+
+const legalEntitiesResponse = (legalEntities: Record<string, unknown>[]) => ({
+  data: {
+    legal_entities: legalEntities,
+    current_page: 1,
+    total_pages: 1,
+    total_count: legalEntities.length,
+  },
+});
+
+describe('usePayrollAdminOnboarding — legal entities', () => {
+  beforeEach(() => {
+    queryClient.clear();
+  });
+
+  it('defaults legalEntityId to the first GP-enabled legal entity when none is provided', async () => {
+    server.use(
+      http.get('*/v1/companies/*/legal-entities', () =>
+        HttpResponse.json(legalEntitiesResponse([gpEnabledLegalEntity])),
+      ),
+    );
+
+    const { result } = renderHook(
+      () => usePayrollAdminOnboarding({ companyId: 'company-1' }),
+      { wrapper: TestProviders },
+    );
+
+    await waitFor(() => {
+      expect(result.current.legalEntityId).toBe('le-1');
+    });
+    expect(result.current.legalEntities).toEqual([gpEnabledLegalEntity]);
+  });
+
+  it('exposes an empty legalEntities array and no legalEntityId when the company has no GP-enabled legal entity', async () => {
+    server.use(
+      http.get('*/v1/companies/*/legal-entities', () =>
+        HttpResponse.json(
+          legalEntitiesResponse([
+            { ...gpEnabledLegalEntity, global_payroll_enabled: false },
+          ]),
+        ),
+      ),
+    );
+
+    const { result } = renderHook(
+      () => usePayrollAdminOnboarding({ companyId: 'company-1' }),
+      { wrapper: TestProviders },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.legalEntities).toEqual([]);
+    expect(result.current.legalEntityId).toBeUndefined();
+  });
+
+  it('uses an explicitly provided legalEntityId as-is', () => {
+    const { result } = renderHook(
+      () =>
+        usePayrollAdminOnboarding({
+          companyId: 'company-1',
+          legalEntityId: 'explicit-le',
+        }),
+      { wrapper: TestProviders },
+    );
+
+    expect(result.current.legalEntityId).toBe('explicit-le');
+  });
+});

--- a/src/flows/PayrollAdminOnboarding/types.ts
+++ b/src/flows/PayrollAdminOnboarding/types.ts
@@ -30,8 +30,13 @@ export type PayrollAdminOnboardingRenderProps = {
 export type PayrollAdminOnboardingFlowProps = {
   /** UUID of the company. */
   companyId: string;
-  /** UUID of the GP-enabled legal entity (required for GP employment creation). */
-  legalEntityId: string;
+  /**
+   * UUID of the GP-enabled legal entity to create the employment under.
+   * Optional — if omitted, the flow fetches the company's GP-enabled legal
+   * entities and uses the first one. Check `adminBag.legalEntities` if you
+   * need to handle the case where the company has none.
+   */
+  legalEntityId?: string;
   /** Optional. Pre-select country and skip country selection. */
   countryCode?: string;
   /** Optional. Resume an existing in-progress GP employment. */

--- a/src/flows/PayrollAdminOnboarding/types.ts
+++ b/src/flows/PayrollAdminOnboarding/types.ts
@@ -34,7 +34,9 @@ export type PayrollAdminOnboardingFlowProps = {
    * UUID of the GP-enabled legal entity to create the employment under.
    * Optional — if omitted, the flow fetches the company's GP-enabled legal
    * entities and uses the first one. Check `adminBag.legalEntities` if you
-   * need to handle the case where the company has none.
+   * need to handle the case where the company has none — but check
+   * `adminBag.isErrorLegalEntities` first, since a failed fetch also leaves
+   * `legalEntities` empty and isn't the same as "no GP legal entity".
    */
   legalEntityId?: string;
   /** Optional. Pre-select country and skip country selection. */


### PR DESCRIPTION
## What

The final piece of the Global Payroll onboarding work (see [split plan](GP_PAYROLL_SPLIT_PLAN.md), PR 5): the **example-app demos** for the admin and employee flows, plus the server-side auth plumbing they need. Both SDK flows (#1142, #1168) are already merged to `main`.

## Contents

- **`example/api/jwt_auth.js`** — server-side minting of an employee-assertion JWT-bearer token (`getEmployeeToken`), plus a production guard on the token endpoints.
- **`example/api/proxy.js`** — path-based token routing: `/v1/employee/*` → employee assertion (employment resolved from the `x-rf-employment-id` header, minted server-side so the FE never holds it); everything else unchanged.
- **`example/api/routes.js`** — wire the `/api/fetch-employee-token/:employmentId` route.
- **`example/src/RemoteFlows.tsx`** — add `authType: 'none'` so the inner (employee) context skips the FE auth callback while the proxy mints tokens.
- **`example/src/PayrollAdminOnboarding.tsx` / `PayrollEmployeeOnboarding.tsx`** — the two demos.
- **`example/src/App.tsx`** — register both demos.

## Design notes (the open questions from the arch doc)

- **Dual-`RemoteFlows`-provider pattern** (employee demo): the outer context uses a company-manager token to read `country`/`jurisdiction` from the employment (the employee assertion token can't fetch `/v1/employments/:id`); the inner context uses the employee-scoped token minted by the proxy.
- **Proxy auth contract**: the FE sends `x-rf-employment-id`; the proxy swaps it for a JWT-bearer employee token on `/v1/employee/*`.

## Notable

- The employee demo derives the bank substep from the flow bag's `selfOnboardingSubsteps` (not a direct hook call), so it needs **no extra SDK export** — consistent with dropping the `useGPOnboardingSteps` public export in #1142.
- Only the GP-relevant files are touched; stale demo-branch changes to unrelated example files were deliberately excluded.

## Verification

- Library build ✅ · example `type-check` (`tsc -b`) ✅ · oxfmt ✅ · oxlint ✅ (0 warnings on the demos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Optional `legalEntityId` is a public API change for integrators; employment creation now depends on legal-entity fetch and new error states must be handled correctly.
> 
> **Overview**
> Adds a **GP Admin Onboarding** example demo that walks through country/basic info, contract, administrative details, and invitation, including handling for legal-entity load failures and missing GP-enabled entities.
> 
> **SDK:** `PayrollAdminOnboardingFlow` now wires in the real step components instead of placeholder null components. **`legalEntityId` is optional** — the hook always loads GP-enabled legal entities for the company, defaults to the first match when omitted, and surfaces `legalEntities` and `isErrorLegalEntities` on `adminBag` so hosts can distinguish fetch errors from “no GP legal entity.” Employment creation throws if no legal entity is available when creating a new employment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a9f85db979ea05d15331659b5551d5c4336cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->