### PR TITLE
fix(gp): merge initialValues with saved step values in admin steps

### DIFF
--- a/src/flows/PayrollAdminOnboarding/components/AdministrativeDetailsStep.tsx
+++ b/src/flows/PayrollAdminOnboarding/components/AdministrativeDetailsStep.tsx
@@ -7,12 +7,18 @@ export function AdministrativeDetailsStep(props: GPStepCallbacks) {
   const { adminBag } = usePayrollAdminOnboardingContext();
   const handleSubmit = useStepSubmitHandler(props);
 
-  const defaultValues =
-    (adminBag.stepState.values?.administrative_details as Record<
+  // Merge (not ||): an empty {} saved after a no-edit advance is truthy and
+  // would blank the form; initialValues is the base, saved edits override.
+  const defaultValues = {
+    ...(adminBag.initialValues?.administrative_details as Record<
       string,
       unknown
-    >) ||
-    (adminBag.initialValues?.administrative_details as Record<string, unknown>);
+    >),
+    ...(adminBag.stepState.values?.administrative_details as Record<
+      string,
+      unknown
+    >),
+  };
 
   return (
     <PayrollAdminForm onSubmit={handleSubmit} defaultValues={defaultValues} />

--- a/src/flows/PayrollAdminOnboarding/components/ContractDetailsStep.tsx
+++ b/src/flows/PayrollAdminOnboarding/components/ContractDetailsStep.tsx
@@ -7,9 +7,12 @@ export function ContractDetailsStep(props: GPStepCallbacks) {
   const { adminBag } = usePayrollAdminOnboardingContext();
   const handleSubmit = useStepSubmitHandler(props);
 
-  const defaultValues =
-    (adminBag.stepState.values?.contract_details as Record<string, unknown>) ||
-    (adminBag.initialValues?.contract_details as Record<string, unknown>);
+  // Merge (not ||): an empty {} saved after a no-edit advance is truthy and
+  // would blank the form; initialValues is the base, saved edits override.
+  const defaultValues = {
+    ...(adminBag.initialValues?.contract_details as Record<string, unknown>),
+    ...(adminBag.stepState.values?.contract_details as Record<string, unknown>),
+  };
 
   return (
     <PayrollAdminForm onSubmit={handleSubmit} defaultValues={defaultValues} />

--- a/src/flows/PayrollAdminOnboarding/components/SelectCountryStep.tsx
+++ b/src/flows/PayrollAdminOnboarding/components/SelectCountryStep.tsx
@@ -7,9 +7,13 @@ export function SelectCountryStep(props: GPStepCallbacks) {
   const { adminBag } = usePayrollAdminOnboardingContext();
   const handleSubmit = useStepSubmitHandler(props);
 
-  const defaultValues =
-    (adminBag.stepState.values?.select_country as Record<string, unknown>) ||
-    (adminBag.initialValues?.basic_information as Record<string, unknown>);
+  // Merge (not ||): stepState.values can be an empty {} after advancing without
+  // edits, which is truthy and would blank the form — so initialValues is the
+  // base and saved edits override it.
+  const defaultValues = {
+    ...(adminBag.initialValues?.basic_information as Record<string, unknown>),
+    ...(adminBag.stepState.values?.select_country as Record<string, unknown>),
+  };
 
   return (
     // Remount the form when the country changes so it re-initializes against


### PR DESCRIPTION
## What

Follow-up flagged during the employee-flow review (#1168): the admin flow's step components used `stepState.values?.<step> || initialValues?.<step>` for `defaultValues`. `useStepState` stores an empty `{}` when the user advances without editing prefilled data (since `useJSONSchemaForm` only syncs on watch-detected changes), and `{}` is truthy — so it won over `initialValues` and blanked the form on revisit.

## Fix

Switched `SelectCountryStep`, `ContractDetailsStep`, and `AdministrativeDetailsStep` to a **merge**: `{ ...initialValues[step], ...stepState.values[step] }` — `initialValues` is the base, genuine edits override. Same fix already applied to the employee flow in #1168.

## Verification

type-check ✅ · oxfmt ✅ · oxlint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized form default-value logic in three admin onboarding step components; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes payroll admin onboarding steps that **blanked prefilled fields** when users navigated back after advancing without editing.
> 
> `defaultValues` no longer uses `stepState.values?.<step> || initialValues?.<step>`. Advancing without edits can persist an empty `{}` in step state, which is truthy and previously replaced real `initialValues`. The three affected steps now **spread-merge** prefills first and saved step values on top: `SelectCountryStep`, `ContractDetailsStep`, and `AdministrativeDetailsStep` (same pattern as the employee flow in #1168).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6ecdf0c658f37b6576d7c6f23c6190b14c9d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->