### PR TITLE
fix(forms): always call the latest checkFieldUpdates

### DIFF
--- a/src/components/form/tests/useJSONSchemaForm.test.tsx
+++ b/src/components/form/tests/useJSONSchemaForm.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useJSONSchemaForm } from '../useJSONSchemaForm';
+
+describe('useJSONSchemaForm', () => {
+  it('calls the latest checkFieldUpdates after it changes', async () => {
+    // The watch subscription is created once, so a callback that closes over
+    // the current headless form (as the playground does) must not be captured
+    // for the lifetime of the form — otherwise a schema change leaves the form
+    // validating against the previous schema.
+    const firstCallback = vi.fn();
+    const latestCallback = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ checkFieldUpdates }) =>
+        useJSONSchemaForm({
+          handleValidation: async () => null,
+          defaultValues: { country: 'FR' },
+          checkFieldUpdates,
+        }),
+      { initialProps: { checkFieldUpdates: firstCallback } },
+    );
+
+    rerender({ checkFieldUpdates: latestCallback });
+
+    act(() => {
+      result.current.setValue('country', 'IT');
+    });
+
+    await waitFor(() => expect(latestCallback).toHaveBeenCalled());
+    expect(firstCallback).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/form/useJSONSchemaForm.tsx
+++ b/src/components/form/useJSONSchemaForm.tsx
@@ -18,6 +18,12 @@ export function useJSONSchemaForm({
 }: UseJsonSchemaFormOptions): UseFormReturn<$TSFixMe> {
   const resolver = useJsonSchemasValidationFormResolver(handleValidation);
   const prevValuesRef = useRef(defaultValues);
+  // The watch subscription below is created once, so it would capture the
+  // first checkFieldUpdates forever. That is fine when it is a plain setState,
+  // but not when it closes over the current headless form — after a schema
+  // change the stale closure validates against the previous schema.
+  const checkFieldUpdatesRef = useRef(checkFieldUpdates);
+  checkFieldUpdatesRef.current = checkFieldUpdates;
 
   const form = useForm({
     resolver,
@@ -30,7 +36,7 @@ export function useJSONSchemaForm({
     const subscription = form?.watch((values) => {
       const hasChanged = !equal(values, prevValuesRef.current);
       if (hasChanged) {
-        checkFieldUpdates(values);
+        checkFieldUpdatesRef.current(values);
         prevValuesRef.current = JSON.parse(JSON.stringify(values));
       }
     });


### PR DESCRIPTION
## Problem

On the playground, switching to the Italy APL schema and selecting **yes** on the non-compete question renders nothing below it. The conditional fields (`non_compete_clause_compensation_percentage`, `non_compete_clause_halt_period_months`) never appear.

The trigger is the schema switch. Starting directly on Italy APL works fine — but the example app starts on `france-wage-portage`, so you always have to switch, and always hit the bug.

## Cause

The watch subscription in `useJSONSchemaForm` is created once with empty deps, so it captures whatever `checkFieldUpdates` was passed on the first render:

```ts
useEffect(() => {
  const subscription = form?.watch((values) => {
    checkFieldUpdates(values); // captured on first render
  });
}, []);

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fe5dd94c715ec0cee9ce4bc1127ec747e71f7971. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->