### PR TITLE
feat(gp): example app demo for employee self-onboarding flow (PBYR-4044)

### DIFF
--- a/example/api/jwt_auth.js
+++ b/example/api/jwt_auth.js
@@ -85,6 +85,11 @@ async function fetchCompanyManagerToken() {
 
 // Express route handler
 async function getCompanyManagerToken(req, res) {
+  if (process.env.NODE_ENV === 'production') {
+    return res
+      .status(403)
+      .json({ error: 'This endpoint is not available in production mode' });
+  }
   try {
     const { accessToken, expiresIn } = await fetchCompanyManagerToken();
 
@@ -100,8 +105,88 @@ async function getCompanyManagerToken(req, res) {
   }
 }
 
+const EMPLOYEE_SCOPES = 'all:write';
+
+async function fetchEmployeeToken(employmentId) {
+  const { VITE_CLIENT_ID, VITE_CLIENT_SECRET, VITE_REMOTE_GATEWAY } =
+    process.env;
+
+  if (
+    !VITE_CLIENT_ID ||
+    (!VITE_CLIENT_SECRET && VITE_REMOTE_GATEWAY !== 'local') ||
+    !VITE_REMOTE_GATEWAY ||
+    !employmentId
+  ) {
+    throw new Error(
+      'Missing VITE_CLIENT_ID, VITE_CLIENT_SECRET, or employmentId',
+    );
+  }
+
+  const gatewayUrl = buildGatewayURL();
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + 5 * 60;
+
+  const payload = {
+    iss: VITE_CLIENT_ID,
+    sub: `urn:remote-api:employee:employment:${employmentId}`,
+    aud: `${gatewayUrl}/auth`,
+    exp,
+    scope: EMPLOYEE_SCOPES,
+    iat: now,
+  };
+
+  const jwtToken = jwt.sign(payload, VITE_CLIENT_SECRET, {
+    algorithm: 'HS256',
+  });
+
+  const encodedCredentials = Buffer.from(
+    `${VITE_CLIENT_ID}:${VITE_CLIENT_SECRET}`,
+  ).toString('base64');
+
+  const response = await fetch(`${gatewayUrl}/auth/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${encodedCredentials}`,
+    },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwtToken,
+      scope: EMPLOYEE_SCOPES,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  const data = await response.json();
+  return { accessToken: data.access_token, expiresIn: data.expires_in };
+}
+
+async function getEmployeeToken(req, res) {
+  if (process.env.NODE_ENV === 'production') {
+    return res
+      .status(403)
+      .json({ error: 'This endpoint is not available in production mode' });
+  }
+  const { employmentId } = req.params;
+  try {
+    const { accessToken, expiresIn } = await fetchEmployeeToken(employmentId);
+    return res
+      .status(200)
+      .json({ access_token: accessToken, expires_in: expiresIn });
+  } catch (error) {
+    console.error('Error fetching employee token:', error);
+    return res.status(500).json({ error: error.message });
+  }
+}
+
 module.exports = {
   getCompanyManagerToken,
   generateJWTToken,
   fetchCompanyManagerToken,
+  fetchEmployeeToken,
+  getEmployeeToken,
 };

--- a/example/api/proxy.js
+++ b/example/api/proxy.js
@@ -3,25 +3,30 @@ const {
   fetchClientCredentialsAccessToken,
   fetchAccessToken,
 } = require('./get_token.js');
+const { fetchEmployeeToken } = require('./jwt_auth.js');
 const { buildGatewayURL } = require('./utils.js');
 
 /**
  * Determines which token type to use based on HTTP method and path
  * @param {string} method - HTTP method (GET, POST, PUT, PATCH, etc.)
  * @param {string} path - The API path (e.g., '/v1/countries' or '/v2/countries?foo=bar')
- * @returns {'client-credentials' | 'user-token'} The token type to use
+ * @returns {'client-credentials' | 'user-token' | 'employee-assertion'} The token type to use
  */
 function getTokenType(method, path) {
   const normalizedMethod = method.toUpperCase();
   // Extract pathname without query parameters
   const pathname = path.split('?')[0].toLowerCase();
 
-  // GET /v1/countries or /v2/countries
+  // GET /v1/countries or /v2/countries — these don't require a user identity;
+  // use client_credentials so the call works in CI where no user token is
+  // available. Local dev without a client secret can opt into a user token
+  // by setting VITE_REMOTE_GATEWAY=... and ensuring VITE_CLIENT_TOKEN works.
   if (normalizedMethod === 'GET' && /^\/v[12]\/countries$/.test(pathname)) {
     return 'client-credentials';
   }
 
-  // GET /v1/countries/{country_code}/address_details or /v2/countries/{country_code}/address_details
+  // GET /v[12]/countries/{country_code}/address_details — public reference
+  // data; also use client credentials.
   if (
     normalizedMethod === 'GET' &&
     /^\/v[12]\/countries\/[^/]+\/address_details$/.test(pathname)
@@ -48,6 +53,13 @@ function getTokenType(method, path) {
     /^\/v[12]\/companies\/[^/]+$/.test(pathname)
   ) {
     return 'client-credentials';
+  }
+
+  // /v1/employee/* endpoints need an employment-scoped assertion. The FE
+  // identifies which employment via the x-rf-employment-id header; the proxy
+  // mints the JWT-bearer token server-side so the FE never sees it.
+  if (/^\/v1\/employee\//.test(pathname)) {
+    return 'employee-assertion';
   }
 
   // All other requests use user token
@@ -94,11 +106,25 @@ async function createProxyRequest(path, method = 'GET', options = {}) {
   // Add authentication if required
   if (requiresAuth) {
     const tokenType = getTokenType(method, path);
-    const { accessToken } =
-      tokenType === 'client-credentials'
-        ? await fetchClientCredentialsAccessToken()
-        : await fetchAccessToken();
+    let accessToken;
+    if (tokenType === 'client-credentials') {
+      ({ accessToken } = await fetchClientCredentialsAccessToken());
+    } else if (tokenType === 'employee-assertion') {
+      const employmentId = headers['x-rf-employment-id'];
+      if (!employmentId) {
+        throw Object.assign(
+          new Error('Missing x-rf-employment-id header for employee request'),
+          {
+            response: { status: 400, data: { error: 'employmentId required' } },
+          },
+        );
+      }
+      ({ accessToken } = await fetchEmployeeToken(employmentId));
+    } else {
+      ({ accessToken } = await fetchAccessToken());
+    }
     requestConfig.headers.Authorization = `Bearer ${accessToken}`;
+    delete requestConfig.headers['x-rf-employment-id'];
   }
 
   return axios(requestConfig);

--- a/example/api/routes.js
+++ b/example/api/routes.js
@@ -1,11 +1,12 @@
 const { getToken } = require('./get_token.js');
-const { getCompanyManagerToken } = require('./jwt_auth.js');
+const { getCompanyManagerToken, getEmployeeToken } = require('./jwt_auth.js');
 const { createProxyMiddleware } = require('./proxy.js');
 
 function setupRoutes(app) {
   // API routes
   app.get('/api/fetch-refresh-token', getToken);
   app.get('/api/fetch-company-manager', getCompanyManagerToken);
+  app.get('/api/fetch-employee-token/:employmentId', getEmployeeToken);
 
   // Proxy all versioned API routes (v1, v2, etc.)
   app.use(/^\/v\d+/, createProxyMiddleware());

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -49,6 +49,7 @@ import { MagicLinkTest } from './MagicLinkTest';
 import { JsonSchemaComparisonDemo } from './JsonSchemaComparisonDemo';
 import { JsonSchemaPlayground } from './flows/JsonSchemaPlayground/JsonSchemaPlayground';
 import { SandboxPaymentApproval } from './SandboxPaymentApproval';
+import { PayrollEmployeeOnboardingForm } from './PayrollEmployeeOnboarding';
 import ContractorOnboardingCode from './ContractorOnboarding?raw';
 import CreateCompanyCode from './CreateCompany?raw';
 import MagicLinkTestCode from './MagicLinkTest?raw';
@@ -192,6 +193,13 @@ const additionalDemos = [
     description: 'Test and experiment with different JSON schemas',
     component: JsonSchemaPlayground,
     sourceCode: JsonSchemaPlaygroundCode,
+  },
+  {
+    id: 'payroll-employee-onboarding',
+    title: 'GP Employee Onboarding',
+    description: 'Global Payroll employee self-onboarding flow',
+    component: PayrollEmployeeOnboardingForm,
+    sourceCode: '',
   },
 ];
 

--- a/example/src/PayrollEmployeeOnboarding.tsx
+++ b/example/src/PayrollEmployeeOnboarding.tsx
@@ -190,7 +190,21 @@ function EmployeeFlowInner({
           if (key === 'state_taxes') return isUSA && !!jurisdiction;
           return true;
         });
-        const lastStepKey = visibleSteps[visibleSteps.length - 1][0];
+
+        // The last *reachable* step mirrors the SDK's own step visibility: tax
+        // steps only become navigable post-enrollment (employeeBag.isComplete).
+        // Basing "last step" on this — not on the sidebar list above, which
+        // surfaces upcoming tax steps early — is what makes Submit/completion
+        // fire on the real final step (e.g. bank_account on a pre-enrollment
+        // USA run).
+        const reachableSteps = Object.entries(STEP_LABELS).filter(([key]) => {
+          if (key === 'bank_account') return hasBankAccount;
+          if (key === 'federal_taxes') return isUSA && employeeBag.isComplete;
+          if (key === 'state_taxes')
+            return isUSA && !!jurisdiction && employeeBag.isComplete;
+          return true;
+        });
+        const lastStepKey = reachableSteps[reachableSteps.length - 1][0];
         const isLastStep = currentStep === lastStepKey;
 
         const federalAvail = employeeBag.taxStepsAvailability.federal_taxes;
@@ -348,9 +362,11 @@ function EmployeeFlowInner({
                     ) : (
                       <button
                         className='submit-button'
-                        onClick={() => employeeBag.next()}
+                        onClick={() =>
+                          isLastStep ? setDone(true) : employeeBag.next()
+                        }
                       >
-                        Skip
+                        {isLastStep ? 'Finish' : 'Skip'}
                       </button>
                     )}
                   </div>

--- a/example/src/PayrollEmployeeOnboarding.tsx
+++ b/example/src/PayrollEmployeeOnboarding.tsx
@@ -1,0 +1,532 @@
+import { useState } from 'react';
+import {
+  PayrollEmployeeOnboardingFlow,
+  PayrollEmployeeOnboardingRenderProps,
+  TaxStepUnavailableReason,
+  useEmploymentQuery,
+} from '@remoteoss/remote-flows';
+import { RemoteFlows } from './RemoteFlows';
+import { AlertError } from './AlertError';
+import './css/main.css';
+
+const EMPLOYMENT_ID = (import.meta.env.VITE_EMPLOYMENT_ID as string) || '';
+
+const STEP_LABELS: Record<string, string> = {
+  personal_details: 'Personal Details',
+  home_address: 'Home Address',
+  bank_account: 'Bank Account',
+  federal_taxes: 'Federal Taxes (W-4)',
+  state_taxes: 'State Taxes',
+};
+
+const STEP_DESCRIPTIONS: Record<string, string> = {
+  personal_details:
+    'Provide your personal information for the employment record.',
+  home_address: 'Enter your home address for payroll and compliance purposes.',
+  bank_account: 'Add your bank account details to receive payroll payments.',
+  federal_taxes:
+    'Set your federal income tax withholding preferences (USA only). Becomes available after your employment is activated.',
+  state_taxes:
+    'Set your state tax withholding preferences for the selected jurisdiction (USA only). Becomes available after your employment is activated.',
+};
+
+type Errors = {
+  apiError: string;
+  fieldErrors: {
+    field: string;
+    messages: string[];
+    userFriendlyLabel: string;
+  }[];
+};
+
+const emptyErrors: Errors = { apiError: '', fieldErrors: [] };
+
+// ── Outer-context loader (company manager token) ────────────────────────────
+//
+// The employee assertion token can't fetch /v1/employments/:id (returns
+// {message} only), so we read country + work jurisdiction from the employment
+// here, in the outer RemoteFlows context, and hand them down to the inner
+// (employee-token) context as props. This keeps consumers from having to
+// hardcode VITE_GP_COUNTRY_CODE / VITE_GP_STATE_JURISDICTION.
+//
+// The bank substep is derived inside the flow from the bag's
+// `selfOnboardingSubsteps`, so it isn't fetched here.
+
+function useEmployeeFlowContext(employmentId: string) {
+  const { data: employment, isLoading: isLoadingEmployment } =
+    useEmploymentQuery({ employmentId });
+
+  const countryCode = employment?.country?.code;
+  // Prefer the work address state when present; fall back to the home address
+  // state. State code is only meaningful for USA — the SDK ignores
+  // `jurisdiction` for non-USA employments.
+  const workState = (
+    employment?.work_address_details as { state?: string } | undefined
+  )?.state;
+  const homeState = (
+    employment?.address_details as { state?: string } | undefined
+  )?.state;
+  const jurisdiction = workState || homeState;
+
+  return {
+    countryCode,
+    jurisdiction,
+    isLoading: isLoadingEmployment,
+  };
+}
+
+function TaxStepNotAvailable({
+  reason,
+  jurisdiction,
+}: {
+  reason: TaxStepUnavailableReason;
+  jurisdiction?: string;
+}) {
+  let message: string;
+  if (reason === 'unsupported_country') {
+    message = 'Tax steps are only available for USA employments.';
+  } else if (reason === 'no_jurisdiction') {
+    message =
+      'A US state code is required to submit state taxes — pass a `jurisdiction` prop on the flow.';
+  } else if (reason === 'schema_unavailable') {
+    message = jurisdiction
+      ? `The backend didn't return a form schema for state_taxes (jurisdiction "${jurisdiction}"). Check that the gateway has the schema configured for this country/jurisdiction.`
+      : `The backend didn't return a form schema for federal_taxes. Check that the gateway has the schema configured for USA.`;
+  } else {
+    message = jurisdiction
+      ? `Your employment isn't active yet, so the tax_task for jurisdiction "${jurisdiction}" hasn't been created. Come back after activation.`
+      : `Your employment isn't active yet, so the federal_taxes tax_task hasn't been created. Come back after activation.`;
+  }
+  return (
+    <div
+      className='alert'
+      style={{ background: '#fff8e1', borderColor: '#fbc02d' }}
+    >
+      <p style={{ margin: 0 }}>
+        <strong>Step unavailable.</strong> {message}
+      </p>
+    </div>
+  );
+}
+
+// ── Employee form (employee-scoped token, inner context) ────────────────────
+
+function EmployeeFlowInner({
+  employmentId,
+  countryCode,
+  jurisdiction,
+}: {
+  employmentId: string;
+  countryCode: string;
+  jurisdiction: string | undefined;
+}) {
+  const [errors, setErrors] = useState<Errors>(emptyErrors);
+  const [done, setDone] = useState(false);
+
+  const clearErrors = () => setErrors(emptyErrors);
+  const handleError = (error: Error, fieldErrors: Errors['fieldErrors']) =>
+    setErrors({ apiError: error.message, fieldErrors });
+
+  const isUSA = countryCode === 'USA';
+
+  if (done) {
+    return (
+      <div className='card' style={{ marginBottom: 20 }}>
+        <h1 className='heading'>Self-onboarding Complete</h1>
+        <p style={{ color: '#22356f', marginBottom: 16 }}>
+          All your information has been submitted. Your employer will review and
+          activate your employment.
+        </p>
+        <div className='buttons-container'>
+          <button
+            className='submit-button'
+            onClick={() => {
+              setDone(false);
+              clearErrors();
+            }}
+          >
+            Start over
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PayrollEmployeeOnboardingFlow
+      employmentId={employmentId}
+      countryCode={countryCode}
+      jurisdiction={isUSA ? jurisdiction : undefined}
+      render={({
+        employeeBag,
+        components,
+      }: PayrollEmployeeOnboardingRenderProps) => {
+        const {
+          PersonalDetailsStep,
+          HomeAddressStep,
+          BankAccountStep,
+          FederalTaxesStep,
+          StateTaxesStep,
+          SubmitButton,
+          BackButton,
+        } = components;
+
+        const currentStep = employeeBag.stepState.currentStep.name;
+
+        if (employeeBag.isLoading && !employeeBag.fields.length) {
+          return <p>Loading...</p>;
+        }
+
+        // Visible steps depend on country + bank substep + jurisdiction. The
+        // bank substep comes from the bag (selfOnboardingSubsteps); tax steps
+        // are surfaced for USA even if not yet active — the bag exposes a
+        // not-available reason so we can render a friendly state in-place.
+        const hasBankAccount = employeeBag.selfOnboardingSubsteps.some(
+          (s: { type: string }) => s.type === 'employee_provides_bank_details',
+        );
+        const visibleSteps = Object.entries(STEP_LABELS).filter(([key]) => {
+          if (key === 'bank_account') return hasBankAccount;
+          if (key === 'federal_taxes') return isUSA;
+          if (key === 'state_taxes') return isUSA && !!jurisdiction;
+          return true;
+        });
+        const lastStepKey = visibleSteps[visibleSteps.length - 1][0];
+        const isLastStep = currentStep === lastStepKey;
+
+        const federalAvail = employeeBag.taxStepsAvailability.federal_taxes;
+        const stateAvail = employeeBag.taxStepsAvailability.state_taxes;
+
+        return (
+          <>
+            <div className='steps-navigation'>
+              <ul>
+                {visibleSteps.map(([key, label], index) => (
+                  <li
+                    key={key}
+                    className={`step-item ${key === currentStep ? 'active' : ''}`}
+                  >
+                    <span className='step-number'>{index + 1}</span>
+                    {label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className='card' style={{ marginBottom: 20 }}>
+              <h1 className='heading'>{STEP_LABELS[currentStep]}</h1>
+              <p style={{ fontSize: 14, color: '#71717A', marginBottom: 24 }}>
+                {STEP_DESCRIPTIONS[currentStep]}
+              </p>
+
+              {currentStep === 'personal_details' && (
+                <>
+                  <PersonalDetailsStep
+                    onError={(e) =>
+                      handleError(
+                        e.error,
+                        e.fieldErrors.map((fe) => ({
+                          ...fe,
+                          userFriendlyLabel: fe.field,
+                        })),
+                      )
+                    }
+                    onSuccess={clearErrors}
+                  />
+                  <AlertError errors={errors} />
+                  {employeeBag.fields.length > 0 && (
+                    <div className='buttons-container'>
+                      <SubmitButton
+                        className='submit-button'
+                        onClick={clearErrors}
+                      >
+                        Save &amp; Continue
+                      </SubmitButton>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {currentStep === 'home_address' && (
+                <>
+                  <HomeAddressStep
+                    onError={(e) =>
+                      handleError(
+                        e.error,
+                        e.fieldErrors.map((fe) => ({
+                          ...fe,
+                          userFriendlyLabel: fe.field,
+                        })),
+                      )
+                    }
+                    onSuccess={() => {
+                      clearErrors();
+                      if (isLastStep) setDone(true);
+                    }}
+                  />
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    <SubmitButton
+                      className='submit-button'
+                      onClick={clearErrors}
+                    >
+                      {isLastStep ? 'Submit' : 'Save & Continue'}
+                    </SubmitButton>
+                  </div>
+                </>
+              )}
+
+              {currentStep === 'bank_account' && hasBankAccount && (
+                <>
+                  <BankAccountStep
+                    onError={(e) =>
+                      handleError(
+                        e.error,
+                        e.fieldErrors.map((fe) => ({
+                          ...fe,
+                          userFriendlyLabel: fe.field,
+                        })),
+                      )
+                    }
+                    onSuccess={() => {
+                      clearErrors();
+                      if (isLastStep) setDone(true);
+                    }}
+                  />
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    <SubmitButton
+                      className='submit-button'
+                      onClick={clearErrors}
+                    >
+                      {isLastStep ? 'Submit' : 'Save & Continue'}
+                    </SubmitButton>
+                  </div>
+                </>
+              )}
+
+              {currentStep === 'federal_taxes' && (
+                <>
+                  {federalAvail.isAvailable ? (
+                    <FederalTaxesStep
+                      onError={(e) =>
+                        handleError(
+                          e.error,
+                          e.fieldErrors.map((fe) => ({
+                            ...fe,
+                            userFriendlyLabel: fe.field,
+                          })),
+                        )
+                      }
+                      onSuccess={() => {
+                        clearErrors();
+                        if (isLastStep) setDone(true);
+                      }}
+                    />
+                  ) : (
+                    <TaxStepNotAvailable
+                      reason={federalAvail.unavailableReason!}
+                    />
+                  )}
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    {federalAvail.isAvailable ? (
+                      <SubmitButton
+                        className='submit-button'
+                        onClick={clearErrors}
+                      >
+                        {isLastStep ? 'Submit' : 'Save & Continue'}
+                      </SubmitButton>
+                    ) : (
+                      <button
+                        className='submit-button'
+                        onClick={() => employeeBag.next()}
+                      >
+                        Skip
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+
+              {currentStep === 'state_taxes' && (
+                <>
+                  {stateAvail.isAvailable ? (
+                    <StateTaxesStep
+                      onError={(e) =>
+                        handleError(
+                          e.error,
+                          e.fieldErrors.map((fe) => ({
+                            ...fe,
+                            userFriendlyLabel: fe.field,
+                          })),
+                        )
+                      }
+                      onSuccess={() => {
+                        clearErrors();
+                        setDone(true);
+                      }}
+                    />
+                  ) : (
+                    <TaxStepNotAvailable
+                      reason={stateAvail.unavailableReason!}
+                      jurisdiction={employeeBag.jurisdiction}
+                    />
+                  )}
+                  <AlertError errors={errors} />
+                  <div className='buttons-container'>
+                    <BackButton className='back-button' onClick={clearErrors}>
+                      Previous Step
+                    </BackButton>
+                    {stateAvail.isAvailable ? (
+                      <SubmitButton
+                        className='submit-button'
+                        onClick={clearErrors}
+                      >
+                        Submit
+                      </SubmitButton>
+                    ) : (
+                      <button
+                        className='submit-button'
+                        onClick={() => setDone(true)}
+                      >
+                        Finish
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          </>
+        );
+      }}
+    />
+  );
+}
+
+// ── Step info loader (company manager context) then hands off to employee ctx ─
+
+function EmployeeFlowForm({ employmentId }: { employmentId: string }) {
+  const { countryCode, jurisdiction, isLoading } =
+    useEmployeeFlowContext(employmentId);
+
+  if (isLoading) return <p>Loading...</p>;
+  if (!countryCode) {
+    return (
+      <div
+        className='alert'
+        style={{ background: '#fee', borderColor: '#c33' }}
+      >
+        <p style={{ margin: 0 }}>
+          <strong>Could not determine country</strong> for employment{' '}
+          <code>{employmentId}</code>. Check that the employment exists and your
+          company-manager token has access.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    // Inner context: the proxy mints the employee-scoped JWT-bearer token
+    // server-side when it sees the x-rf-employment-id header on /v1/employee/*
+    // routes. The FE never holds the employee token.
+    <RemoteFlows
+      proxy={{
+        url: window.location.origin,
+        headers: { 'x-rf-employment-id': employmentId },
+      }}
+      authType='none'
+    >
+      <EmployeeFlowInner
+        employmentId={employmentId}
+        countryCode={countryCode}
+        jurisdiction={jurisdiction}
+      />
+    </RemoteFlows>
+  );
+}
+
+// ── Employment ID entry ──────────────────────────────────────────────────────
+
+function GPEmployeeOnboardingInner() {
+  const [employmentId, setEmploymentId] = useState(EMPLOYMENT_ID);
+  const [submitted, setSubmitted] = useState(!!EMPLOYMENT_ID);
+
+  if (!submitted) {
+    return (
+      <div className='card' style={{ marginBottom: 20 }}>
+        <h1 className='heading'>Employee Self-onboarding</h1>
+        <p style={{ fontSize: 14, color: '#71717A', marginBottom: 24 }}>
+          Enter the employment ID created by the GP Admin flow to begin
+          self-onboarding.
+        </p>
+        <div className='alert' style={{ marginBottom: 16 }}>
+          <p style={{ margin: 0 }}>
+            <strong>Prerequisite:</strong> The admin must complete the GP Admin
+            Onboarding flow and <strong>send the invitation</strong> first. The
+            employee endpoints only activate after the invitation is sent. The
+            federal/state tax steps additionally require the employment to be{' '}
+            <strong>active</strong>.
+          </p>
+        </div>
+        <div className='onboarding-form-group'>
+          <label className='onboarding-form-label' htmlFor='employment-id'>
+            Employment ID
+          </label>
+          <input
+            id='employment-id'
+            className='onboarding-form-input'
+            type='text'
+            placeholder='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+            value={employmentId}
+            onChange={(e) => setEmploymentId(e.target.value.trim())}
+          />
+        </div>
+        <div className='buttons-container'>
+          <button
+            className='submit-button'
+            disabled={!employmentId}
+            onClick={() => setSubmitted(true)}
+          >
+            Start onboarding
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p style={{ fontSize: 12, color: '#94a3b8', marginBottom: 16 }}>
+        Employment:{' '}
+        <code style={{ fontFamily: 'monospace' }}>{employmentId}</code>{' '}
+        <button
+          className='button-inline'
+          onClick={() => setSubmitted(false)}
+          style={{ fontSize: 12 }}
+        >
+          change
+        </button>
+      </p>
+      <EmployeeFlowForm employmentId={employmentId} />
+    </div>
+  );
+}
+
+export function PayrollEmployeeOnboardingForm() {
+  return (
+    // Outer context: the proxy mints the company-manager token server-side
+    // for /v1/employments/* and /v1/companies/*, so the FE never sees one.
+    <RemoteFlows proxy={{ url: window.location.origin }} authType='none'>
+      <GPEmployeeOnboardingInner />
+    </RemoteFlows>
+  );
+}

--- a/example/src/PayrollEmployeeOnboarding.tsx
+++ b/example/src/PayrollEmployeeOnboarding.tsx
@@ -41,13 +41,19 @@ type Errors = {
 
 const emptyErrors: Errors = { apiError: '', fieldErrors: [] };
 
-// ── Outer-context loader (company manager token) ────────────────────────────
+// ── Outer-context loader ─────────────────────────────────────────────────────
 //
 // The employee assertion token can't fetch /v1/employments/:id (returns
 // {message} only), so we read country + work jurisdiction from the employment
-// here, in the outer RemoteFlows context, and hand them down to the inner
+// here, in an outer RemoteFlows context, and hand them down to the inner
 // (employee-token) context as props. This keeps consumers from having to
 // hardcode VITE_GP_COUNTRY_CODE / VITE_GP_STATE_JURISDICTION.
+//
+// This outer context also uses authType='none': the FE doesn't hold a token
+// here either — example/api/proxy.js decides the auth strategy per-path via
+// getTokenType(), and today that falls through to the same refresh-token
+// ('user-token') flow used by most other demos behind this dev proxy, not a
+// dedicated company-manager mint.
 //
 // The bank substep is derived inside the flow from the bag's
 // `selfOnboardingSubsteps`, so it isn't fetched here.
@@ -460,7 +466,7 @@ function EmployeeFlowForm({ employmentId }: { employmentId: string }) {
         <p style={{ margin: 0 }}>
           <strong>Could not determine country</strong> for employment{' '}
           <code>{employmentId}</code>. Check that the employment exists and your
-          company-manager token has access.
+          dev-proxy token (see example/api/proxy.js) has access.
         </p>
       </div>
     );
@@ -555,8 +561,9 @@ function GPEmployeeOnboardingInner() {
 
 export function PayrollEmployeeOnboardingForm() {
   return (
-    // Outer context: the proxy mints the company-manager token server-side
-    // for /v1/employments/* and /v1/companies/*, so the FE never sees one.
+    // Outer context: authType='none' since the FE doesn't hold a token here
+    // either — see the useEmployeeFlowContext comment above for how auth is
+    // actually resolved for /v1/employments/* through the dev proxy.
     <RemoteFlows proxy={{ url: window.location.origin }} authType='none'>
       <GPEmployeeOnboardingInner />
     </RemoteFlows>

--- a/example/src/PayrollEmployeeOnboarding.tsx
+++ b/example/src/PayrollEmployeeOnboarding.tsx
@@ -121,36 +121,27 @@ function EmployeeFlowInner({
   jurisdiction: string | undefined;
 }) {
   const [errors, setErrors] = useState<Errors>(emptyErrors);
+  // `done` is set only by the explicit "Finish" action on an unavailable tax
+  // step. Submit-driven completion is derived reactively from the last
+  // successfully-submitted step vs the current last reachable step (below), so
+  // a step that stops being last (e.g. enrollment adds tax steps after a bank
+  // save) no longer marks the flow complete from a stale render.
   const [done, setDone] = useState(false);
+  const [lastSubmittedStep, setLastSubmittedStep] = useState<string | null>(
+    null,
+  );
 
   const clearErrors = () => setErrors(emptyErrors);
   const handleError = (error: Error, fieldErrors: Errors['fieldErrors']) =>
     setErrors({ apiError: error.message, fieldErrors });
 
-  const isUSA = countryCode === 'USA';
+  const startOver = () => {
+    setDone(false);
+    setLastSubmittedStep(null);
+    clearErrors();
+  };
 
-  if (done) {
-    return (
-      <div className='card' style={{ marginBottom: 20 }}>
-        <h1 className='heading'>Self-onboarding Complete</h1>
-        <p style={{ color: '#22356f', marginBottom: 16 }}>
-          All your information has been submitted. Your employer will review and
-          activate your employment.
-        </p>
-        <div className='buttons-container'>
-          <button
-            className='submit-button'
-            onClick={() => {
-              setDone(false);
-              clearErrors();
-            }}
-          >
-            Start over
-          </button>
-        </div>
-      </div>
-    );
-  }
+  const isUSA = countryCode === 'USA';
 
   return (
     <PayrollEmployeeOnboardingFlow
@@ -207,6 +198,28 @@ function EmployeeFlowInner({
         const lastStepKey = reachableSteps[reachableSteps.length - 1][0];
         const isLastStep = currentStep === lastStepKey;
 
+        // Complete when the user explicitly finished, or when the last
+        // successfully-submitted step is still the last reachable one. Deriving
+        // this per-render (rather than latching in an onSuccess closure) means a
+        // step that stops being last — e.g. enrollment flips isComplete and adds
+        // tax steps — correctly keeps the flow going instead of completing.
+        if (done || lastSubmittedStep === lastStepKey) {
+          return (
+            <div className='card' style={{ marginBottom: 20 }}>
+              <h1 className='heading'>Self-onboarding Complete</h1>
+              <p style={{ color: '#22356f', marginBottom: 16 }}>
+                All your information has been submitted. Your employer will
+                review and activate your employment.
+              </p>
+              <div className='buttons-container'>
+                <button className='submit-button' onClick={startOver}>
+                  Start over
+                </button>
+              </div>
+            </div>
+          );
+        }
+
         const federalAvail = employeeBag.taxStepsAvailability.federal_taxes;
         const stateAvail = employeeBag.taxStepsAvailability.state_taxes;
 
@@ -244,7 +257,10 @@ function EmployeeFlowInner({
                         })),
                       )
                     }
-                    onSuccess={clearErrors}
+                    onSuccess={() => {
+                      clearErrors();
+                      setLastSubmittedStep(currentStep);
+                    }}
                   />
                   <AlertError errors={errors} />
                   {employeeBag.fields.length > 0 && (
@@ -274,7 +290,7 @@ function EmployeeFlowInner({
                     }
                     onSuccess={() => {
                       clearErrors();
-                      if (isLastStep) setDone(true);
+                      setLastSubmittedStep(currentStep);
                     }}
                   />
                   <AlertError errors={errors} />
@@ -306,7 +322,7 @@ function EmployeeFlowInner({
                     }
                     onSuccess={() => {
                       clearErrors();
-                      if (isLastStep) setDone(true);
+                      setLastSubmittedStep(currentStep);
                     }}
                   />
                   <AlertError errors={errors} />
@@ -339,7 +355,7 @@ function EmployeeFlowInner({
                       }
                       onSuccess={() => {
                         clearErrors();
-                        if (isLastStep) setDone(true);
+                        setLastSubmittedStep(currentStep);
                       }}
                     />
                   ) : (
@@ -388,7 +404,7 @@ function EmployeeFlowInner({
                       }
                       onSuccess={() => {
                         clearErrors();
-                        setDone(true);
+                        setLastSubmittedStep(currentStep);
                       }}
                     />
                   ) : (

--- a/example/src/RemoteFlows.tsx
+++ b/example/src/RemoteFlows.tsx
@@ -46,7 +46,11 @@ type RemoteFlowsProps = Omit<RemoteFlowsSDKProps, 'auth'> & {
   children: ReactNode;
   auth?: RemoteFlowsSDKProps['auth'];
   isClientToken?: boolean;
-  authType?: 'refresh-token' | 'company-manager' | 'client';
+  /**
+   * `'none'` skips the FE-side auth callback entirely — use it when the proxy
+   * mints tokens server-side and the FE never needs to hold one.
+   */
+  authType?: 'refresh-token' | 'company-manager' | 'client' | 'none';
 };
 
 export const RemoteFlows = ({
@@ -56,6 +60,9 @@ export const RemoteFlows = ({
   ...props
 }: RemoteFlowsProps) => {
   const auth = useMemo(() => {
+    if (authType === 'none') {
+      return undefined;
+    }
     if (authType === 'company-manager') {
       return fetchCompanyManagerToken;
     }


### PR DESCRIPTION
## Summary
- Split out of #1171 per review request, so this demo can be reviewed standalone without comments on the admin demo mixed in.
- Adds the Global Payroll employee self-onboarding demo (`example/src/PayrollEmployeeOnboarding.tsx`) and its server-side auth plumbing (employee-assertion JWT minting in `jwt_auth.js`, path-based token routing in `proxy.js`, the `/api/fetch-employee-token/:employmentId` route).
- Includes the two follow-up fixes already reviewed/applied on #1171: correct last-reachable-step detection and reactive (non-stale-closure) completion tracking.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run check-format`
- [x] `npx vitest run` (823 tests passing)
- [ ] Manual click-through of the demo in a browser (reviewer to verify, needs sandbox credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces server-side OAuth JWT minting and path-based token selection in the example API; mitigated by production 403 guards and confinement to the example dev proxy, but it still handles client secrets and broad employee write scopes.
> 
> **Overview**
> Adds a **GP Employee Self-onboarding** example demo wired to `PayrollEmployeeOnboardingFlow`, including step navigation, USA tax availability handling, and completion logic that tracks the **last reachable** step (so tax steps appearing after enrollment do not prematurely finish the flow).
> 
> **Dev-proxy auth** is extended so `/v1/employee/*` calls use an **employment-scoped JWT-bearer** minted server-side: the proxy reads `x-rf-employment-id`, exchanges a signed assertion for an access token, and strips that header before forwarding. A non-production **`/api/fetch-employee-token/:employmentId`** route mirrors the existing company-manager helper. **`RemoteFlows`** gains **`authType='none'`** so the browser does not fetch tokens when the proxy handles auth per path.
> 
> The demo uses a **two-layer** setup: an outer context loads employment country/jurisdiction via `/v1/employments/*` (user-token path through the proxy), then an inner context sends employee API traffic with the employment header only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a4bb3a931f3acf96f0e837aa9f2a7bcd531fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->