### PR TITLE
fix(form-fields): render help center link on text, select, tel, time …

### DIFF
--- a/src/components/form/fields/CurrencyConversionField.tsx
+++ b/src/components/form/fields/CurrencyConversionField.tsx
@@ -1,11 +1,14 @@
 import { ReactNode, useState, useCallback, useEffect, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
+import omit from 'lodash.omit';
 import { TextField } from '@/src/components/form/fields/TextField';
 import { useConvertCurrency } from '@/src/flows/Onboarding/api';
 import { JSFField } from '@/src/types/remoteFlows';
+import { HelpCenterDataProps } from '@/src/types/fields';
 import { useFormFields } from '@/src/context';
 import { useDebounce } from '@/src/common/hooks';
 import { FormDescription } from '@/src/components/ui/form';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import {
   convertFromCents,
   convertToCents,
@@ -14,6 +17,7 @@ import {
 
 type DescriptionWithConversionProps = {
   description: ReactNode;
+  helpCenter: ReactNode;
   showConversion: boolean;
   targetCurrency: string;
   className: string;
@@ -22,6 +26,7 @@ type DescriptionWithConversionProps = {
 
 const DescriptionWithConversion = ({
   description,
+  helpCenter,
   showConversion,
   targetCurrency,
   className,
@@ -39,7 +44,9 @@ const DescriptionWithConversion = ({
 
   return (
     <span className={className}>
-      <FormDescription as='span'>{description}</FormDescription>{' '}
+      <FormDescription as='span' helpCenter={helpCenter}>
+        {description}
+      </FormDescription>{' '}
       <CustomButton
         className={`${className.replace('-description', '-button')}`}
         data-type='inline'
@@ -63,6 +70,9 @@ export type CurrencyConversionFieldProps = JSFField & {
   useProxy?: boolean;
   classNamePrefix: string;
   conversionType?: 'spread' | 'no_spread';
+  meta?: {
+    helpCenter?: HelpCenterDataProps;
+  };
 };
 
 export const CurrencyConversionField = ({
@@ -74,6 +84,7 @@ export const CurrencyConversionField = ({
   classNamePrefix,
   description,
   conversionType = 'spread',
+  meta,
   ...props
 }: CurrencyConversionFieldProps) => {
   const [showConversion, setShowConversion] = useState(false);
@@ -174,10 +185,14 @@ export const CurrencyConversionField = ({
     }
   };
 
+  // when we render the conversion toggle we also render the help center link ourselves,
+  // so it stays next to the description instead of being appended after the toggle.
+  // The link is then stripped from the meta we forward, to avoid rendering it twice.
   const extraDescription = canShowConversion ? (
     <DescriptionWithConversion
       targetCurrency={targetCurrency}
       description={description}
+      helpCenter={<HelpCenter helpCenter={meta?.helpCenter} />}
       showConversion={showConversion}
       className={`${classNamePrefix}-description`}
       onClick={toggleConversion}
@@ -190,6 +205,7 @@ export const CurrencyConversionField = ({
     <>
       <TextField
         {...props}
+        meta={canShowConversion ? omit(meta, 'helpCenter') : meta}
         name={mainFieldName || props.name}
         additionalProps={{ currency: sourceCurrency }}
         description={extraDescription}

--- a/src/components/form/fields/default/FileUploadFieldDefault.tsx
+++ b/src/components/form/fields/default/FileUploadFieldDefault.tsx
@@ -6,6 +6,7 @@ import {
   FormMessage,
 } from '@/src/components/ui/form';
 import { FileUploader } from '@/src/components/ui/file-uploader';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import { cn } from '@/src/lib/utils';
 import { FileComponentProps } from '@/src/types/fields';
 
@@ -31,9 +32,12 @@ export function FileUploadFieldDefault({
           files={field.value}
         />
       </FormControl>
-      {description && (
+      {(description || fieldData.meta?.helpCenter) && (
         <div className='flex items-center justify-between'>
-          <FormDescription className='RemoteFlows__FileUpload__Description'>
+          <FormDescription
+            className='RemoteFlows__FileUpload__Description'
+            helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+          >
             {description}
           </FormDescription>
         </div>

--- a/src/components/form/fields/default/MultiSelectFieldDefault.tsx
+++ b/src/components/form/fields/default/MultiSelectFieldDefault.tsx
@@ -7,6 +7,7 @@ import {
   FormMessage,
 } from '@/src/components/ui/form';
 import { MultiSelect, Option } from '@/src/components/ui/multi-select';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import { FieldComponentProps } from '@/src/types/fields';
 
 export const MultiSelectFieldDefault = ({
@@ -44,7 +45,13 @@ export const MultiSelectFieldDefault = ({
           }}
         />
       </FormControl>
-      {description && <FormDescription>{description}</FormDescription>}
+      {(description || fieldData.meta?.helpCenter) && (
+        <FormDescription
+          helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+        >
+          {description}
+        </FormDescription>
+      )}
       {fieldState.error && <FormMessage />}
     </FormItem>
   );

--- a/src/components/form/fields/default/SelectFieldDefault.tsx
+++ b/src/components/form/fields/default/SelectFieldDefault.tsx
@@ -5,6 +5,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/src/components/ui/form';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import { FieldComponentProps } from '@/src/types/fields';
 import {
   Select,
@@ -62,7 +63,13 @@ export function SelectFieldDefault({
           </Select>
         </div>
       </FormControl>
-      {description && <FormDescription>{description}</FormDescription>}
+      {(description || fieldData.meta?.helpCenter) && (
+        <FormDescription
+          helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+        >
+          {description}
+        </FormDescription>
+      )}
       {fieldState.error && <FormMessage />}
     </FormItem>
   );

--- a/src/components/form/fields/default/TelFieldDefault.tsx
+++ b/src/components/form/fields/default/TelFieldDefault.tsx
@@ -1,5 +1,6 @@
 import { FormDescription, FormMessage } from '@/src/components/ui/form';
 import { FormItem, FormLabel } from '@/src/components/ui/form';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import { TelFieldComponentProps } from '@/src/types/fields';
 import {
   Select,
@@ -101,8 +102,11 @@ export function TelFieldDefault({
         </div>
       </div>
 
-      {description && (
-        <FormDescription className='RemoteFlows__TelField__Description'>
+      {(description || fieldData.meta?.helpCenter) && (
+        <FormDescription
+          className='RemoteFlows__TelField__Description'
+          helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+        >
           {description}
         </FormDescription>
       )}

--- a/src/components/form/fields/default/TextFieldDefault.tsx
+++ b/src/components/form/fields/default/TextFieldDefault.tsx
@@ -1,6 +1,7 @@
 import { FormDescription, FormMessage } from '@/src/components/ui/form';
 import { FormControl, FormItem, FormLabel } from '@/src/components/ui/form';
 import { Input } from '@/src/components/ui/input';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import { TextFieldComponentProps } from '@/src/types/fields';
 
 export function TextFieldDefault({
@@ -30,8 +31,11 @@ export function TextFieldDefault({
           maxLength={maxLength}
         />
       </FormControl>
-      {description && (
-        <FormDescription className='RemoteFlows__TextField__Description'>
+      {(description || fieldData.meta?.helpCenter) && (
+        <FormDescription
+          className='RemoteFlows__TextField__Description'
+          helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+        >
           {description}
         </FormDescription>
       )}

--- a/src/components/form/fields/default/TimeFieldDefault.tsx
+++ b/src/components/form/fields/default/TimeFieldDefault.tsx
@@ -1,6 +1,7 @@
 import { FormDescription, FormMessage } from '@/src/components/ui/form';
 import { FormControl, FormItem, FormLabel } from '@/src/components/ui/form';
 import { Input } from '@/src/components/ui/input';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 import { TimeFieldComponentProps } from '@/src/types/fields';
 
 export function TimeFieldDefault({
@@ -29,8 +30,11 @@ export function TimeFieldDefault({
           placeholder={label}
         />
       </FormControl>
-      {description && (
-        <FormDescription className='RemoteFlows__TimeField__Description'>
+      {(description || fieldData.meta?.helpCenter) && (
+        <FormDescription
+          className='RemoteFlows__TimeField__Description'
+          helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+        >
           {description}
         </FormDescription>
       )}

--- a/src/components/form/fields/tests/CurrencyConversionField.test.tsx
+++ b/src/components/form/fields/tests/CurrencyConversionField.test.tsx
@@ -17,6 +17,15 @@ import {
 import { useState } from 'react';
 import { TextFieldDefault } from '@/src/components/form/fields/default/TextFieldDefault';
 import { ButtonDefault } from '@/src/components/form/fields/default/ButtonDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+
+vi.mock('@/src/components/shared/zendesk-drawer/ZendeskTriggerButton', () => ({
+  ZendeskTriggerButton: ({ zendeskId, children, className }: $TSFixMe) => (
+    <button className={className} data-testid={`zendesk-button-${zendeskId}`}>
+      {children}
+    </button>
+  ),
+}));
 
 const queryClient = new QueryClient();
 
@@ -37,6 +46,18 @@ const defaultProps: CurrencyConversionFieldProps = {
   schema: string(),
   scopedJsonSchema: {},
   type: 'text',
+};
+
+const propsWithHelpCenter: CurrencyConversionFieldProps = {
+  ...defaultProps,
+  meta: {
+    helpCenter: {
+      callToAction: 'Learn more',
+      id: 12345,
+      content: '<p>How salaries are calculated</p>',
+      title: 'How salaries are calculated',
+    },
+  },
 };
 
 // Helper function to render the component with a form context
@@ -288,6 +309,24 @@ describe('CurrencyFieldWithConversion', () => {
     expect(descriptionElement?.parentElement).toHaveClass(
       'CustomPrefix-description',
     );
+  });
+
+  it('renders the help center link once, before the conversion toggle', () => {
+    renderWithFormContext(propsWithHelpCenter);
+
+    expect(screen.getAllByTestId('zendesk-button-12345')).toHaveLength(1);
+    expect(
+      screen.getByText(/Enter your test salary/i).parentElement?.parentElement,
+    ).toHaveTextContent(
+      'Enter your test salary Learn more Show EUR conversion',
+    );
+  });
+
+  it('renders the help center link when there is no conversion toggle', () => {
+    renderWithFormContext({ ...propsWithHelpCenter, targetCurrency: 'USD' });
+
+    expect(screen.getByTestId('zendesk-button-12345')).toBeInTheDocument();
+    expect(screen.queryByText('Show USD conversion')).not.toBeInTheDocument();
   });
 
   it('resets conversion field when source currency changes', async () => {

--- a/src/components/form/fields/tests/TextField.test.tsx
+++ b/src/components/form/fields/tests/TextField.test.tsx
@@ -16,6 +16,14 @@ vi.mock('@/src/context', async (importOriginal) => {
   };
 });
 
+vi.mock('@/src/components/shared/zendesk-drawer/ZendeskTriggerButton', () => ({
+  ZendeskTriggerButton: ({ zendeskId, children, className }: $TSFixMe) => (
+    <button className={className} data-testid={`zendesk-button-${zendeskId}`}>
+      {children}
+    </button>
+  ),
+}));
+
 describe('TextField Component', () => {
   const mockOnChange = vi.fn();
   const defaultProps: TextFieldProps = {
@@ -64,6 +72,24 @@ describe('TextField Component', () => {
     expect(screen.getByText('Test Field')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Test Field')).toBeInTheDocument();
     expect(screen.getByText('This is a test field')).toBeInTheDocument();
+  });
+
+  it('renders the help center link from meta', () => {
+    renderWithFormContext({
+      ...defaultProps,
+      meta: {
+        helpCenter: {
+          callToAction: 'Learn more',
+          id: 12345,
+          content: '<p>How salaries are calculated</p>',
+          title: 'How salaries are calculated',
+        },
+      },
+    });
+
+    expect(screen.getByTestId('zendesk-button-12345')).toHaveTextContent(
+      'Learn more',
+    );
   });
 
   it('handles input change correctly', () => {


### PR DESCRIPTION
Help center was not handled in all fields types. I added the possibility to have one for each ones. This will fix a bug for Italy APL onboarding which have not "learn more" button under Gross Salary. But it will fix also lots of cases which could appears in the future I think (or some we did not detect because it is non blocker bugs so not easy to see it). 

Just a little specificity for currencyConversionField because it uses same meta for two fields, and we just want to handle help center for one. So we need to omit helpCenter in the second field. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only form presentation changes with no auth, data, or API impact; limited regression surface covered by new tests.
> 
> **Overview**
> Fixes **Zendesk help center links** from `meta.helpCenter` not appearing on several form field defaults (text, select, tel, time, multi-select, file upload), including money/salary fields that route through `TextFieldDefault`.
> 
> Each updated default now passes `HelpCenter` into `FormDescription` and shows the description row when **either** a description or help center meta is present, so help-only fields still get a link.
> 
> **`CurrencyConversionField`** is special-cased: when the currency conversion toggle is shown, the help link is rendered inline with the description (before the toggle) and `helpCenter` is omitted from `meta` forwarded to the inner `TextField` so the link is not duplicated.
> 
> Tests cover help center rendering on `TextField` and `CurrencyConversionField` (placement and single-render behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1955c3ce6f82433323f1946ef2d60028a0e504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->