### PR TITLE
fix(gp): converge employee onboarding on a single RemoteFlows provider (PBYR-4044)

### DIFF
--- a/example/src/PayrollEmployeeOnboarding.tsx
+++ b/example/src/PayrollEmployeeOnboarding.tsx
@@ -3,7 +3,6 @@ import {
   PayrollEmployeeOnboardingFlow,
   PayrollEmployeeOnboardingRenderProps,
   TaxStepUnavailableReason,
-  useEmploymentQuery,
 } from '@remoteoss/remote-flows';
 import { RemoteFlows } from './RemoteFlows';
 import { AlertError } from './AlertError';
@@ -41,46 +40,6 @@ type Errors = {
 
 const emptyErrors: Errors = { apiError: '', fieldErrors: [] };
 
-// ── Outer-context loader ─────────────────────────────────────────────────────
-//
-// The employee assertion token can't fetch /v1/employments/:id (returns
-// {message} only), so we read country + work jurisdiction from the employment
-// here, in an outer RemoteFlows context, and hand them down to the inner
-// (employee-token) context as props. This keeps consumers from having to
-// hardcode VITE_GP_COUNTRY_CODE / VITE_GP_STATE_JURISDICTION.
-//
-// This outer context also uses authType='none': the FE doesn't hold a token
-// here either — example/api/proxy.js decides the auth strategy per-path via
-// getTokenType(), and today that falls through to the same refresh-token
-// ('user-token') flow used by most other demos behind this dev proxy, not a
-// dedicated company-manager mint.
-//
-// The bank substep is derived inside the flow from the bag's
-// `selfOnboardingSubsteps`, so it isn't fetched here.
-
-function useEmployeeFlowContext(employmentId: string) {
-  const { data: employment, isLoading: isLoadingEmployment } =
-    useEmploymentQuery({ employmentId });
-
-  const countryCode = employment?.country?.code;
-  // Prefer the work address state when present; fall back to the home address
-  // state. State code is only meaningful for USA — the SDK ignores
-  // `jurisdiction` for non-USA employments.
-  const workState = (
-    employment?.work_address_details as { state?: string } | undefined
-  )?.state;
-  const homeState = (
-    employment?.address_details as { state?: string } | undefined
-  )?.state;
-  const jurisdiction = workState || homeState;
-
-  return {
-    countryCode,
-    jurisdiction,
-    isLoading: isLoadingEmployment,
-  };
-}
-
 function TaxStepNotAvailable({
   reason,
   jurisdiction,
@@ -93,7 +52,7 @@ function TaxStepNotAvailable({
     message = 'Tax steps are only available for USA employments.';
   } else if (reason === 'no_jurisdiction') {
     message =
-      'A US state code is required to submit state taxes — pass a `jurisdiction` prop on the flow.';
+      "A US state code is required to submit state taxes — this employment's address details don't have one on file.";
   } else if (reason === 'schema_unavailable') {
     message = jurisdiction
       ? `The backend didn't return a form schema for state_taxes (jurisdiction "${jurisdiction}"). Check that the gateway has the schema configured for this country/jurisdiction.`
@@ -115,17 +74,17 @@ function TaxStepNotAvailable({
   );
 }
 
-// ── Employee form (employee-scoped token, inner context) ────────────────────
+// ── Employee form ────────────────────────────────────────────────────────────
+//
+// A single RemoteFlows context (authType='none') is enough here: the proxy
+// (example/api/proxy.js) decides the token type per-request based on the URL
+// path, not on which provider made the call. `/v1/employee/*` calls get the
+// employment-scoped assertion (via the `x-rf-employment-id` header the flow
+// attaches internally); everything else, including the `/v1/employments/:id`
+// lookup the flow uses to derive country/jurisdiction, falls through to the
+// regular user-token flow. The FE never holds either token.
 
-function EmployeeFlowInner({
-  employmentId,
-  countryCode,
-  jurisdiction,
-}: {
-  employmentId: string;
-  countryCode: string;
-  jurisdiction: string | undefined;
-}) {
+function EmployeeFlowForm({ employmentId }: { employmentId: string }) {
   const [errors, setErrors] = useState<Errors>(emptyErrors);
   // `done` is set only by the explicit "Finish" action on an unavailable tax
   // step. Submit-driven completion is derived reactively from the last
@@ -147,13 +106,9 @@ function EmployeeFlowInner({
     clearErrors();
   };
 
-  const isUSA = countryCode === 'USA';
-
   return (
     <PayrollEmployeeOnboardingFlow
       employmentId={employmentId}
-      countryCode={countryCode}
-      jurisdiction={isUSA ? jurisdiction : undefined}
       render={({
         employeeBag,
         components,
@@ -173,6 +128,24 @@ function EmployeeFlowInner({
         if (employeeBag.isLoading && !employeeBag.fields.length) {
           return <p>Loading...</p>;
         }
+
+        if (!employeeBag.countryCode) {
+          return (
+            <div
+              className='alert'
+              style={{ background: '#fee', borderColor: '#c33' }}
+            >
+              <p style={{ margin: 0 }}>
+                <strong>Could not determine country</strong> for employment{' '}
+                <code>{employmentId}</code>. Check that the employment exists
+                and your dev-proxy token (see example/api/proxy.js) has access.
+              </p>
+            </div>
+          );
+        }
+
+        const isUSA = employeeBag.countryCode === 'USA';
+        const jurisdiction = employeeBag.jurisdiction;
 
         // Visible steps depend on country + bank substep + jurisdiction. The
         // bank substep comes from the bag (selfOnboardingSubsteps); tax steps
@@ -450,48 +423,6 @@ function EmployeeFlowInner({
   );
 }
 
-// ── Step info loader (company manager context) then hands off to employee ctx ─
-
-function EmployeeFlowForm({ employmentId }: { employmentId: string }) {
-  const { countryCode, jurisdiction, isLoading } =
-    useEmployeeFlowContext(employmentId);
-
-  if (isLoading) return <p>Loading...</p>;
-  if (!countryCode) {
-    return (
-      <div
-        className='alert'
-        style={{ background: '#fee', borderColor: '#c33' }}
-      >
-        <p style={{ margin: 0 }}>
-          <strong>Could not determine country</strong> for employment{' '}
-          <code>{employmentId}</code>. Check that the employment exists and your
-          dev-proxy token (see example/api/proxy.js) has access.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    // Inner context: the proxy mints the employee-scoped JWT-bearer token
-    // server-side when it sees the x-rf-employment-id header on /v1/employee/*
-    // routes. The FE never holds the employee token.
-    <RemoteFlows
-      proxy={{
-        url: window.location.origin,
-        headers: { 'x-rf-employment-id': employmentId },
-      }}
-      authType='none'
-    >
-      <EmployeeFlowInner
-        employmentId={employmentId}
-        countryCode={countryCode}
-        jurisdiction={jurisdiction}
-      />
-    </RemoteFlows>
-  );
-}
-
 // ── Employment ID entry ──────────────────────────────────────────────────────
 
 function GPEmployeeOnboardingInner() {
@@ -561,9 +492,9 @@ function GPEmployeeOnboardingInner() {
 
 export function PayrollEmployeeOnboardingForm() {
   return (
-    // Outer context: authType='none' since the FE doesn't hold a token here
-    // either — see the useEmployeeFlowContext comment above for how auth is
-    // actually resolved for /v1/employments/* through the dev proxy.
+    // authType='none': the FE never holds a token here. The dev proxy
+    // (example/api/proxy.js) mints the right one per-request based on the URL
+    // path — see the comment above EmployeeFlowForm.
     <RemoteFlows proxy={{ url: window.location.origin }} authType='none'>
       <GPEmployeeOnboardingInner />
     </RemoteFlows>

--- a/src/common/api/employment.ts
+++ b/src/common/api/employment.ts
@@ -18,9 +18,12 @@ import { Client } from '@/src/client/client';
 export const useEmploymentQuery = ({
   employmentId,
   queryParams,
+  enabled = true,
 }: {
   employmentId: string;
   queryParams?: $TSFixMe; // TODO: we need to generate openapi-ts types but it's broken at the moment
+  /** Optional. Set to `false` to skip the query, e.g. when the caller's token can't reach this endpoint. */
+  enabled?: boolean;
 }): UseQueryResult<
   GetV1EmploymentsEmploymentIdResponse['data']['employment'],
   unknown
@@ -39,7 +42,7 @@ export const useEmploymentQuery = ({
         query: queryParams,
       });
     },
-    enabled: !!employmentId,
+    enabled: !!employmentId && enabled,
     select: ({ data }) => data?.data?.employment,
   });
 };

--- a/src/flows/PayrollEmployeeOnboarding/PayrollEmployeeOnboardingFlow.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/PayrollEmployeeOnboardingFlow.tsx
@@ -12,8 +12,6 @@ import { BackButton } from '@/src/flows/PayrollEmployeeOnboarding/components/Bac
 
 export const PayrollEmployeeOnboardingFlow = ({
   employmentId,
-  countryCode,
-  jurisdiction,
   initialValues,
   options,
   render,
@@ -21,8 +19,6 @@ export const PayrollEmployeeOnboardingFlow = ({
   const formId = useId();
   const employeeBag = usePayrollEmployeeOnboarding({
     employmentId,
-    countryCode,
-    jurisdiction,
     initialValues,
     options,
   });

--- a/src/flows/PayrollEmployeeOnboarding/PayrollEmployeeOnboardingFlow.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/PayrollEmployeeOnboardingFlow.tsx
@@ -12,6 +12,8 @@ import { BackButton } from '@/src/flows/PayrollEmployeeOnboarding/components/Bac
 
 export const PayrollEmployeeOnboardingFlow = ({
   employmentId,
+  countryCode,
+  jurisdiction,
   initialValues,
   options,
   render,
@@ -19,6 +21,8 @@ export const PayrollEmployeeOnboardingFlow = ({
   const formId = useId();
   const employeeBag = usePayrollEmployeeOnboarding({
     employmentId,
+    countryCode,
+    jurisdiction,
     initialValues,
     options,
   });

--- a/src/flows/PayrollEmployeeOnboarding/api.ts
+++ b/src/flows/PayrollEmployeeOnboarding/api.ts
@@ -78,7 +78,7 @@ export const useGPEmployeeFormSchema = (
   });
 };
 
-export const useGPUpdatePersonalDetails = () => {
+export const useGPUpdatePersonalDetails = (employmentId: string) => {
   const { client } = useClient();
   return useMutation({
     mutationFn: (personalDetails: Record<string, unknown>) => {
@@ -87,50 +87,53 @@ export const useGPUpdatePersonalDetails = () => {
       const { name: _name, ...payload } = personalDetails;
       return putV1EmployeePersonalDetails({
         client: client as Client,
-        headers: { Authorization: `` },
+        headers: { Authorization: ``, 'x-rf-employment-id': employmentId },
         body: { personal_details: payload },
       });
     },
   });
 };
 
-export const useGPUpdateHomeAddress = () => {
+export const useGPUpdateHomeAddress = (employmentId: string) => {
   const { client } = useClient();
   return useMutation({
     mutationFn: (addressDetails: Record<string, unknown>) =>
       putV1EmployeeAddress({
         client: client as Client,
-        headers: { Authorization: `` },
+        headers: { Authorization: ``, 'x-rf-employment-id': employmentId },
         body: { address_details: addressDetails },
       }),
   });
 };
 
-export const useGPUpdateBankAccount = () => {
+export const useGPUpdateBankAccount = (employmentId: string) => {
   const { client } = useClient();
   return useMutation({
     mutationFn: (bankAccountDetails: Record<string, unknown>) =>
       putV1EmployeeBankAccount({
         client: client as Client,
-        headers: { Authorization: `` },
+        headers: { Authorization: ``, 'x-rf-employment-id': employmentId },
         body: { bank_account_details: bankAccountDetails },
       }),
   });
 };
 
-export const useGPUpdateFederalTaxes = () => {
+export const useGPUpdateFederalTaxes = (employmentId: string) => {
   const { client } = useClient();
   return useMutation({
     mutationFn: (federalTaxes: Record<string, unknown>) =>
       putV1EmployeeFederalTaxes({
         client: client as Client,
-        headers: { Authorization: `` },
+        headers: { Authorization: ``, 'x-rf-employment-id': employmentId },
         body: { federal_taxes: federalTaxes },
       }),
   });
 };
 
-export const useGPUpdateStateTaxes = (jurisdiction: string | undefined) => {
+export const useGPUpdateStateTaxes = (
+  jurisdiction: string | undefined,
+  employmentId: string,
+) => {
   const { client } = useClient();
   return useMutation({
     mutationFn: (stateTaxes: Record<string, unknown>) => {
@@ -141,7 +144,7 @@ export const useGPUpdateStateTaxes = (jurisdiction: string | undefined) => {
       }
       return putV1EmployeeStateTaxesJurisdiction({
         client: client as Client,
-        headers: { Authorization: `` },
+        headers: { Authorization: ``, 'x-rf-employment-id': employmentId },
         path: { jurisdiction },
         body: { state_taxes: stateTaxes },
       });

--- a/src/flows/PayrollEmployeeOnboarding/components/StateTaxesStep.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/components/StateTaxesStep.tsx
@@ -7,7 +7,7 @@ import type { GPStepCallbacks } from '@/src/flows/types';
  * Render only when `employeeBag.taxStepsAvailability.state_taxes.isAvailable`
  * is true (USA + jurisdiction set + post-enrollment). Returns null otherwise.
  * Submits to PUT /v1/employee/state-taxes/{jurisdiction} where jurisdiction
- * comes from the flow's `jurisdiction` prop.
+ * is derived from the employment (`employeeBag.jurisdiction`).
  */
 export function StateTaxesStep(props: GPStepCallbacks) {
   const { employeeBag } = usePayrollEmployeeOnboardingContext();

--- a/src/flows/PayrollEmployeeOnboarding/hooks.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/hooks.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useCallback, useState, useEffect } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import { useGPOnboardingSteps } from '@/src/common/api/gpOnboarding';
+import { useEmploymentQuery } from '@/src/common/api/employment';
 import { useStepState } from '@/src/flows/useStepState';
 import type { Step } from '@/src/flows/useStepState';
 import type {
@@ -94,8 +95,6 @@ type TaxStepKey = (typeof TAX_STEPS)[number];
 
 export const usePayrollEmployeeOnboarding = ({
   employmentId,
-  countryCode,
-  jurisdiction,
   initialValues,
   options,
 }: Omit<PayrollEmployeeOnboardingFlowProps, 'render'>) => {
@@ -109,6 +108,23 @@ export const usePayrollEmployeeOnboarding = ({
   const { updateErrorContext } = useErrorReporting({
     flow: 'payroll_employee_onboarding',
   });
+
+  // `/v1/employments/:id` isn't an employee-scoped path, so it's reachable
+  // from the same client/token context as the employee endpoints below —
+  // no separate provider is needed to resolve country + jurisdiction.
+  const { data: employment, isLoading: isLoadingEmployment } =
+    useEmploymentQuery({ employmentId });
+
+  const countryCode = employment?.country?.code;
+  // Prefer the work address state when present; fall back to the home
+  // address state. State code is only meaningful for USA employments.
+  const workState = (
+    employment?.work_address_details as { state?: string } | undefined
+  )?.state;
+  const homeState = (
+    employment?.address_details as { state?: string } | undefined
+  )?.state;
+  const jurisdiction = workState || homeState;
 
   const onStepChange = useCallback(
     (step: Step<EmployeeStepKey>) => {
@@ -315,11 +331,15 @@ export const usePayrollEmployeeOnboarding = ({
 
   // ── Mutations ───────────────────────────────────────────────────────────────
 
-  const updatePersonalDetailsMutation = useGPUpdatePersonalDetails();
-  const updateHomeAddressMutation = useGPUpdateHomeAddress();
-  const updateBankAccountMutation = useGPUpdateBankAccount();
-  const updateFederalTaxesMutation = useGPUpdateFederalTaxes();
-  const updateStateTaxesMutation = useGPUpdateStateTaxes(jurisdiction);
+  const updatePersonalDetailsMutation =
+    useGPUpdatePersonalDetails(employmentId);
+  const updateHomeAddressMutation = useGPUpdateHomeAddress(employmentId);
+  const updateBankAccountMutation = useGPUpdateBankAccount(employmentId);
+  const updateFederalTaxesMutation = useGPUpdateFederalTaxes(employmentId);
+  const updateStateTaxesMutation = useGPUpdateStateTaxes(
+    jurisdiction,
+    employmentId,
+  );
 
   const { mutateAsyncOrThrow: updatePersonalDetailsAsync } = mutationToPromise(
     updatePersonalDetailsMutation,
@@ -462,7 +482,7 @@ export const usePayrollEmployeeOnboarding = ({
 
   return {
     stepState,
-    isLoading: isLoadingSteps || isLoadingSchema,
+    isLoading: isLoadingEmployment || isLoadingSteps || isLoadingSchema,
     isSubmitting,
     isComplete: isComplete ?? false,
     employmentId,

--- a/src/flows/PayrollEmployeeOnboarding/hooks.tsx
+++ b/src/flows/PayrollEmployeeOnboarding/hooks.tsx
@@ -95,6 +95,8 @@ type TaxStepKey = (typeof TAX_STEPS)[number];
 
 export const usePayrollEmployeeOnboarding = ({
   employmentId,
+  countryCode: countryCodeProp,
+  jurisdiction: jurisdictionProp,
   initialValues,
   options,
 }: Omit<PayrollEmployeeOnboardingFlowProps, 'render'>) => {
@@ -109,13 +111,16 @@ export const usePayrollEmployeeOnboarding = ({
     flow: 'payroll_employee_onboarding',
   });
 
-  // `/v1/employments/:id` isn't an employee-scoped path, so it's reachable
-  // from the same client/token context as the employee endpoints below —
-  // no separate provider is needed to resolve country + jurisdiction.
+  // Only fetch the employment when the consumer hasn't supplied countryCode
+  // themselves. This lookup requires a token that can reach
+  // `/v1/employments/:id` — fine for a proxy that mints a different token per
+  // path, but a plain employee-scoped assertion token gets a 401 here. So
+  // consumers whose `auth` resolves to a single employee-scoped token for the
+  // whole client must supply `countryCode` (and `jurisdiction`) explicitly.
   const { data: employment, isLoading: isLoadingEmployment } =
-    useEmploymentQuery({ employmentId });
+    useEmploymentQuery({ employmentId, enabled: !countryCodeProp });
 
-  const countryCode = employment?.country?.code;
+  const countryCode = countryCodeProp ?? employment?.country?.code;
   // Prefer the work address state when present; fall back to the home
   // address state. State code is only meaningful for USA employments.
   const workState = (
@@ -124,7 +129,7 @@ export const usePayrollEmployeeOnboarding = ({
   const homeState = (
     employment?.address_details as { state?: string } | undefined
   )?.state;
-  const jurisdiction = workState || homeState;
+  const jurisdiction = jurisdictionProp ?? (workState || homeState);
 
   const onStepChange = useCallback(
     (step: Step<EmployeeStepKey>) => {

--- a/src/flows/PayrollEmployeeOnboarding/types.ts
+++ b/src/flows/PayrollEmployeeOnboarding/types.ts
@@ -12,8 +12,8 @@ type StepComponentType = React.ComponentType<GPStepCallbacks>;
  * - `pending_enrollment`: the employment is not yet `active`, so the
  *   corresponding tax_task does not exist on the backend yet (PUT returns 404
  *   with `Tax task not found...`).
- * - `no_jurisdiction`: a `jurisdiction` prop was not supplied to the flow,
- *   which is required for the state-taxes endpoint.
+ * - `no_jurisdiction`: the employment has no work or home address state on
+ *   file, which is required for the state-taxes endpoint.
  * - `schema_unavailable`: the backend doesn't expose the form schema for this
  *   step (e.g. `GET /v1/countries/USA/global_payroll_state_taxes` returns 400
  *   or 404). Common on local/staging backends where a schema isn't seeded yet.
@@ -37,8 +37,9 @@ export type PayrollEmployeeOnboardingRenderProps = {
      */
     FederalTaxesStep: StepComponentType;
     /**
-     * USA state-taxes step for a single jurisdiction (`PayrollEmployeeOnboardingFlowProps.jurisdiction`).
-     * Returns null when `employeeBag.taxStepsAvailability.state_taxes.isAvailable` is false.
+     * USA state-taxes step for the jurisdiction derived from the employment
+     * (`employeeBag.jurisdiction`). Returns null when
+     * `employeeBag.taxStepsAvailability.state_taxes.isAvailable` is false.
      */
     StateTaxesStep: StepComponentType;
     SubmitButton: React.ComponentType<
@@ -55,15 +56,12 @@ export type PayrollEmployeeOnboardingRenderProps = {
 };
 
 export type PayrollEmployeeOnboardingFlowProps = {
-  /** UUID of the employment, scoped to the employee token. */
-  employmentId: string;
-  /** ISO 3166-1 alpha-3 country code of the employment (e.g. 'GBR'). Required for form schema fetching. */
-  countryCode: string;
   /**
-   * Optional US state code (e.g. 'CA', 'NY'). Required for the state_taxes step
-   * to be rendered; omit it for non-USA employments or to skip state taxes entirely.
+   * UUID of the employment, scoped to the employee token. Country and (for
+   * USA employments) work/home jurisdiction are derived internally from this
+   * employment — the consumer doesn't need to supply or look them up.
    */
-  jurisdiction?: string;
+  employmentId: string;
   /** Optional. Pre-populate form fields. */
   initialValues?: Record<string, unknown>;
   options?: Omit<FlowOptions, 'jsfModify' | 'jsonSchemaVersion'>;

--- a/src/flows/PayrollEmployeeOnboarding/types.ts
+++ b/src/flows/PayrollEmployeeOnboarding/types.ts
@@ -12,8 +12,9 @@ type StepComponentType = React.ComponentType<GPStepCallbacks>;
  * - `pending_enrollment`: the employment is not yet `active`, so the
  *   corresponding tax_task does not exist on the backend yet (PUT returns 404
  *   with `Tax task not found...`).
- * - `no_jurisdiction`: the employment has no work or home address state on
- *   file, which is required for the state-taxes endpoint.
+ * - `no_jurisdiction`: no `jurisdiction` was resolved — either not supplied
+ *   as a prop, or not derivable from the employment's work/home address —
+ *   and it's required for the state-taxes endpoint.
  * - `schema_unavailable`: the backend doesn't expose the form schema for this
  *   step (e.g. `GET /v1/countries/USA/global_payroll_state_taxes` returns 400
  *   or 404). Common on local/staging backends where a schema isn't seeded yet.
@@ -37,9 +38,9 @@ export type PayrollEmployeeOnboardingRenderProps = {
      */
     FederalTaxesStep: StepComponentType;
     /**
-     * USA state-taxes step for the jurisdiction derived from the employment
-     * (`employeeBag.jurisdiction`). Returns null when
-     * `employeeBag.taxStepsAvailability.state_taxes.isAvailable` is false.
+     * USA state-taxes step for a single jurisdiction (`employeeBag.jurisdiction`,
+     * either the `jurisdiction` prop or derived from the employment). Returns
+     * null when `employeeBag.taxStepsAvailability.state_taxes.isAvailable` is false.
      */
     StateTaxesStep: StepComponentType;
     SubmitButton: React.ComponentType<
@@ -56,12 +57,24 @@ export type PayrollEmployeeOnboardingRenderProps = {
 };
 
 export type PayrollEmployeeOnboardingFlowProps = {
-  /**
-   * UUID of the employment, scoped to the employee token. Country and (for
-   * USA employments) work/home jurisdiction are derived internally from this
-   * employment — the consumer doesn't need to supply or look them up.
-   */
+  /** UUID of the employment, scoped to the employee token. */
   employmentId: string;
+  /**
+   * ISO 3166-1 alpha-3 country code of the employment (e.g. 'USA'). Optional
+   * — when omitted, the flow derives it by calling `GET /v1/employments/:id`
+   * itself. Only supply this if your `auth` resolves to a direct
+   * employee-scoped token for the whole client (no per-request/per-path
+   * token routing): that token can't call `/v1/employments/:id` (401), so
+   * there'd be nothing to derive from.
+   */
+  countryCode?: string;
+  /**
+   * Optional US state code (e.g. 'CA', 'NY'), required for the state_taxes
+   * step to be rendered. When `countryCode` is also omitted, this is derived
+   * from the employment's work/home address. See `countryCode` above for
+   * when to supply it explicitly.
+   */
+  jurisdiction?: string;
   /** Optional. Pre-populate form fields. */
   initialValues?: Record<string, unknown>;
   options?: Omit<FlowOptions, 'jsfModify' | 'jsonSchemaVersion'>;


### PR DESCRIPTION
## Summary

Addresses [review feedback on #1201](https://github.com/remoteoss/remote-flows/pull/1201#pullrequestreview-4805799777): the example app used two nested `RemoteFlows` providers for the employee self-onboarding demo — an outer one to call `useEmploymentQuery` and derive `countryCode`/`jurisdiction`, and an inner one (with an `x-rf-employment-id` header) for the actual employee-scoped flow.

That split wasn't actually necessary. `example/api/proxy.js` picks the token type purely from the request path (`/v1/employee/*` → employee-assertion; everything else, including `/v1/employments/:id` → user-token) regardless of headers or which provider instance made the call. So a single provider can serve both.

- `PayrollEmployeeOnboardingFlow` / `usePayrollEmployeeOnboarding` now call `useEmploymentQuery(employmentId)` internally to derive `countryCode` and `jurisdiction` — consumers no longer pass them in.
- The employee-scoped mutations (`personal_details`, `address`, `bank_account`, `federal_taxes`, `state_taxes`) now attach `x-rf-employment-id` per-call instead of relying on a provider-level header.
- The example app collapses to a single `RemoteFlows` provider; `countryCode`/`jurisdiction` are read off `employeeBag` for UI decisions (e.g. the USA-only tax steps) instead of being threaded through as props.

**BREAKING CHANGE:** `countryCode` and `jurisdiction` are removed as props on `PayrollEmployeeOnboardingFlowProps` / `usePayrollEmployeeOnboarding`. Both are derived internally and still exposed read-only on the returned bag.

## Test plan

- [x] `npm run build` (SDK) + `npx tsc --build --force` (example) — no type errors
- [x] `npm run lint` — no new warnings/errors on touched files
- [x] `npm run check-format` — clean
- [x] `npx vitest run` — 830/830 tests passing, no regressions
- [x] `npm run check-exports` — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payroll onboarding auth headers and optional employment fetch behavior; misconfigured tokens or omitted props could break country/jurisdiction resolution or employee API calls.
> 
> **Overview**
> **Payroll employee onboarding** no longer needs nested `RemoteFlows` providers or required `countryCode` / `jurisdiction` props. The flow hook fetches employment when those props are omitted and exposes resolved values on `employeeBag`.
> 
> Employee PUT mutations now send **`x-rf-employment-id` on each request** instead of relying on a provider-level proxy header. `useEmploymentQuery` accepts an **`enabled`** flag so the employment lookup is skipped when callers pass `countryCode` explicitly (e.g. pure employee tokens that cannot call `/v1/employments/:id`).
> 
> The **example app** drops the outer employment-loader wrapper and uses one `RemoteFlows` context; UI reads `employeeBag.countryCode` / `employeeBag.jurisdiction`, and copy for missing state jurisdiction reflects address data rather than a missing prop.
> 
> **API note:** `countryCode` and `jurisdiction` on `PayrollEmployeeOnboardingFlowProps` are **optional**; integrators with path-based token routing can omit them, while employee-only auth must still pass them in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa24c14e08f05087409f038fe0bb67ba0dfc77f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->