### PR TITLE
1.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @remoteoss/remote-flows
 
+## 1.45.0
+
+### Minor Changes
+
+- update actions/checkout digest to 3d3c42e
+- add configurable schemas option with Italy APL example
+- update actions/setup-node digest to 2499707 (#1186) [#1186](https://github.com/remoteoss/remote-flows/pull/1186)
+- update dependency postcss to v8.5.18 [security] (#1191) [#1191](https://github.com/remoteoss/remote-flows/pull/1191)
+- update dependency @playwright/test to v1.61.1 (#1192) [#1192](https://github.com/remoteoss/remote-flows/pull/1192)
+- update vitest monorepo to v4.1.10 (#1194) [#1194](https://github.com/remoteoss/remote-flows/pull/1194)
+- update dependency filesize to v11.0.22 (#1193) [#1193](https://github.com/remoteoss/remote-flows/pull/1193)
+- fix france arch problems only on playground (#1195) [#1195](https://github.com/remoteoss/remote-flows/pull/1195)
+- always call the latest checkFieldUpdates (#1198) [#1198](https://github.com/remoteoss/remote-flows/pull/1198)
+- add sandbox payment approval (#1200) [#1200](https://github.com/remoteoss/remote-flows/pull/1200)
+- example app demo for employee self-onboarding flow (PBYR-4044) (#1201) [#1201](https://github.com/remoteoss/remote-flows/pull/1201)
+- render help center link on text, select, tel, time and file fields
+- example app demo for admin onboarding flow (PBYR-4044) (#1171) [#1171](https://github.com/remoteoss/remote-flows/pull/1171)
+- add some tests for FRA (#1205) [#1205](https://github.com/remoteoss/remote-flows/pull/1205)
+- converge employee onboarding on a single RemoteFlows provider (PBYR-4044) (#1204) [#1204](https://github.com/remoteoss/remote-flows/pull/1204)
+- read Italy APL contract details as a jsf v1 schema (PBYR-4321)
+- keep invisible values when revalidating a jsf v1 form
+- freeze basic information json schema (#1207) [#1207](https://github.com/remoteoss/remote-flows/pull/1207)
+
 ## 1.44.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,34 @@
 
 ### Minor Changes
 
-- update actions/checkout digest to 3d3c42e
-- add configurable schemas option with Italy APL example
-- update actions/setup-node digest to 2499707 (#1186) [#1186](https://github.com/remoteoss/remote-flows/pull/1186)
-- update dependency postcss to v8.5.18 [security] (#1191) [#1191](https://github.com/remoteoss/remote-flows/pull/1191)
-- update dependency @playwright/test to v1.61.1 (#1192) [#1192](https://github.com/remoteoss/remote-flows/pull/1192)
-- update vitest monorepo to v4.1.10 (#1194) [#1194](https://github.com/remoteoss/remote-flows/pull/1194)
-- update dependency filesize to v11.0.22 (#1193) [#1193](https://github.com/remoteoss/remote-flows/pull/1193)
-- fix france arch problems only on playground (#1195) [#1195](https://github.com/remoteoss/remote-flows/pull/1195)
+#### Features
+
+- Italy APL and France SAS applies new contract details architecture
+
+#### Fixes
+
 - always call the latest checkFieldUpdates (#1198) [#1198](https://github.com/remoteoss/remote-flows/pull/1198)
+- freeze basic information json schema (#1207) [#1207](https://github.com/remoteoss/remote-flows/pull/1207)
+
+#### Docs
+
+- fix france arch problems only on playground (#1195) [#1195](https://github.com/remoteoss/remote-flows/pull/1195)
 - add sandbox payment approval (#1200) [#1200](https://github.com/remoteoss/remote-flows/pull/1200)
 - example app demo for employee self-onboarding flow (PBYR-4044) (#1201) [#1201](https://github.com/remoteoss/remote-flows/pull/1201)
 - render help center link on text, select, tel, time and file fields
 - example app demo for admin onboarding flow (PBYR-4044) (#1171) [#1171](https://github.com/remoteoss/remote-flows/pull/1171)
 - add some tests for FRA (#1205) [#1205](https://github.com/remoteoss/remote-flows/pull/1205)
 - converge employee onboarding on a single RemoteFlows provider (PBYR-4044) (#1204) [#1204](https://github.com/remoteoss/remote-flows/pull/1204)
-- read Italy APL contract details as a jsf v1 schema (PBYR-4321)
-- keep invisible values when revalidating a jsf v1 form
-- freeze basic information json schema (#1207) [#1207](https://github.com/remoteoss/remote-flows/pull/1207)
+
+#### Chores
+
+- update actions/checkout digest to 3d3c42e
+- update dependency postcss to v8.5.18 [security] (#1191) [#1191](https://github.com/remoteoss/remote-flows/pull/1191)
+- update dependency @playwright/test to v1.61.1 (#1192) [#1192](https://github.com/remoteoss/remote-flows/pull/1192)
+- update vitest monorepo to v4.1.10 (#1194) [#1194](https://github.com/remoteoss/remote-flows/pull/1194)
+- update dependency filesize to v11.0.22 (#1193) [#1193](https://github.com/remoteoss/remote-flows/pull/1193)
+- update actions/setup-node digest to 2499707 (#1186) [#1186](https://github.com/remoteoss/remote-flows/pull/1186)
+
 
 ## 1.44.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@
 - update dependency filesize to v11.0.22 (#1193) [#1193](https://github.com/remoteoss/remote-flows/pull/1193)
 - update actions/setup-node digest to 2499707 (#1186) [#1186](https://github.com/remoteoss/remote-flows/pull/1186)
 
-
 ## 1.44.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.45.0

### Minor Changes

#### Features

- Italy APL and France SAS applies new contract details architecture

#### Fixes

- always call the latest checkFieldUpdates (#1198) [#1198](https://github.com/remoteoss/remote-flows/pull/1198)
- freeze basic information json schema (#1207) [#1207](https://github.com/remoteoss/remote-flows/pull/1207)

#### Docs

- fix france arch problems only on playground (#1195) [#1195](https://github.com/remoteoss/remote-flows/pull/1195)
- add sandbox payment approval (#1200) [#1200](https://github.com/remoteoss/remote-flows/pull/1200)
- example app demo for employee self-onboarding flow (PBYR-4044) (#1201) [#1201](https://github.com/remoteoss/remote-flows/pull/1201)
- render help center link on text, select, tel, time and file fields
- example app demo for admin onboarding flow (PBYR-4044) (#1171) [#1171](https://github.com/remoteoss/remote-flows/pull/1171)
- add some tests for FRA (#1205) [#1205](https://github.com/remoteoss/remote-flows/pull/1205)
- converge employee onboarding on a single RemoteFlows provider (PBYR-4044) (#1204) [#1204](https://github.com/remoteoss/remote-flows/pull/1204)

#### Chores

- update actions/checkout digest to 3d3c42e
- update dependency postcss to v8.5.18 [security] (#1191) [#1191](https://github.com/remoteoss/remote-flows/pull/1191)
- update dependency @playwright/test to v1.61.1 (#1192) [#1192](https://github.com/remoteoss/remote-flows/pull/1192)
- update vitest monorepo to v4.1.10 (#1194) [#1194](https://github.com/remoteoss/remote-flows/pull/1194)
- update dependency filesize to v11.0.22 (#1193) [#1193](https://github.com/remoteoss/remote-flows/pull/1193)
- update actions/setup-node digest to 2499707 (#1186) [#1186](https://github.com/remoteoss/remote-flows/pull/1186)


---

This release was automatically generated from conventional commits.