### PR TITLE
feat(salary): split description, help center and conversion toggle in grossSalary field

### DIFF
--- a/docs/COMPONENT_CUSTOMIZATION.md
+++ b/docs/COMPONENT_CUSTOMIZATION.md
@@ -325,6 +325,7 @@ type FieldComponentProps = {
   fieldData: {
     label?: string;
     description?: string;
+    descriptionSuffix?: React.ReactNode;
     placeholder?: string;
     options?: Array<{
       value: string;
@@ -335,6 +336,24 @@ type FieldComponentProps = {
   };
 };
 ```
+
+`description`, `meta.helpCenter` and `descriptionSuffix` are three independent slots, so you can render only the ones you need:
+
+```tsx
+const CustomInput = ({ field, fieldData }: FieldComponentProps) => (
+  <div>
+    <label htmlFor={field.name}>{fieldData.label}</label>
+    <input {...field} />
+    <p>{fieldData.description}</p>
+    {/* fieldData.descriptionSuffix carries extra controls the SDK owns,
+        for instance the currency conversion toggle of the salary field.
+        Render it, otherwise your users lose the toggle. */}
+    {fieldData.descriptionSuffix}
+  </div>
+);
+```
+
+> **Salary field:** the three slots are only separate when the flow enables the `split_salary_description` feature — `options={{ features: ['split_salary_description'] }}` on `OnboardingFlow` / `CostCalculatorFlow`. Without it, the salary description keeps packing the help center link and the conversion toggle into `description`, and `descriptionSuffix` stays empty.
 
 ### ButtonComponentProps
 

--- a/example/src/BasicCostCalculator.tsx
+++ b/example/src/BasicCostCalculator.tsx
@@ -4,6 +4,7 @@ import {
   CostCalculatorSubmitButton,
   CostCalculatorResetButton,
 } from '@remoteoss/remote-flows';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { RemoteFlows } from './RemoteFlows';
 import './css/main.css';
 
@@ -23,6 +24,7 @@ export function BasicCostCalculator() {
     <RemoteFlows isClientToken>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
+        options={COST_CALCULATOR_OPTIONS}
         render={(props) => {
           if (props.isLoading) {
             return <div>Loading...</div>;

--- a/example/src/BasicCostCalculatorDefaultValues.tsx
+++ b/example/src/BasicCostCalculatorDefaultValues.tsx
@@ -4,6 +4,7 @@ import {
   CostCalculatorSubmitButton,
   CostCalculatorResetButton,
 } from '@remoteoss/remote-flows';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { RemoteFlows } from './RemoteFlows';
 import './css/main.css';
 
@@ -23,6 +24,7 @@ export function BasicCostCalculatorWithDefaultValues() {
           currencySlug: 'eur-acf7d6b5-654a-449f-873f-aca61a280eba',
           salary: '50000',
         }}
+        options={COST_CALCULATOR_OPTIONS}
         render={(props) => {
           if (props.isLoading) {
             return <div>Loading...</div>;

--- a/example/src/BasicCostCalculatorLabels.tsx
+++ b/example/src/BasicCostCalculatorLabels.tsx
@@ -4,6 +4,7 @@ import {
   CostCalculatorSubmitButton,
   CostCalculatorResetButton,
 } from '@remoteoss/remote-flows';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { RemoteFlows } from './RemoteFlows';
 import './css/main.css';
 
@@ -41,6 +42,7 @@ export function BasicCostCalculatorLabels() {
           );
         }}
         options={{
+          ...COST_CALCULATOR_OPTIONS,
           jsfModify: {
             fields: {
               country: {

--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -75,6 +75,9 @@ const Input = ({ field, fieldData, fieldState }: FieldComponentProps) => {
       )}
 
       {renderDescription(fieldData.description, fieldData.transformHtml)}
+      {/* extra controls owned by the SDK, e.g. the salary currency conversion toggle
+          when the split_salary_description feature is enabled */}
+      {fieldData.descriptionSuffix}
       {fieldState.error && (
         <p className='error-message'>{fieldState.error.message}</p>
       )}

--- a/example/src/CostCalculatorWithExportPdf.tsx
+++ b/example/src/CostCalculatorWithExportPdf.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@remoteoss/remote-flows';
 import './css/main.css';
 import { useState } from 'react';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { RemoteFlows } from './RemoteFlows';
 import { downloadFile } from './utils';
 
@@ -50,6 +51,7 @@ function CostCalculatorFormDemo() {
     <>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
+        options={COST_CALCULATOR_OPTIONS}
         render={(props) => {
           if (props.isLoading) {
             return <div>Loading...</div>;

--- a/example/src/CostCalculatorWithPremiumBenefits.tsx
+++ b/example/src/CostCalculatorWithPremiumBenefits.tsx
@@ -32,6 +32,7 @@ import {
 import { ButtonHTMLAttributes, useState, isValidElement } from 'react';
 import { RemoteFlows } from './RemoteFlows';
 import { components } from './Components';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { downloadFile } from './utils';
 import { AlertError } from './AlertError';
 import 'react-flagpack/dist/style.css';
@@ -356,6 +357,7 @@ const AddEstimateForm = ({
       estimationOptions={{ ...estimationOptions, title: options.title }}
       defaultValues={defaultValues}
       options={{
+        ...COST_CALCULATOR_OPTIONS,
         onValidation: () => setErrorMessage(null),
         jsfModify: {
           fields: {

--- a/example/src/CostCalculatorWithReplaceableComponents.tsx
+++ b/example/src/CostCalculatorWithReplaceableComponents.tsx
@@ -24,6 +24,7 @@ export const CostCalculatorWithReplaceableComponents = () => {
     <RemoteFlows isClientToken components={components}>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
+        options={{ features: ['split_salary_description'] }}
         render={(props) => {
           if (props.isLoading) {
             return <div>Loading...</div>;

--- a/example/src/CostCalculatorWithReplaceableComponents.tsx
+++ b/example/src/CostCalculatorWithReplaceableComponents.tsx
@@ -5,6 +5,7 @@ import {
   CostCalculatorResetButton,
 } from '@remoteoss/remote-flows';
 import { components } from './Components';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { RemoteFlows } from './RemoteFlows';
 import './css/main.css';
 
@@ -24,7 +25,7 @@ export const CostCalculatorWithReplaceableComponents = () => {
     <RemoteFlows isClientToken components={components}>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
-        options={{ features: ['split_salary_description'] }}
+        options={COST_CALCULATOR_OPTIONS}
         render={(props) => {
           if (props.isLoading) {
             return <div>Loading...</div>;

--- a/example/src/CostCalculatorWithResults.tsx
+++ b/example/src/CostCalculatorWithResults.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@remoteoss/remote-flows';
 import Flag from 'react-flagpack';
 import { useState } from 'react';
+import { COST_CALCULATOR_OPTIONS } from './costCalculatorOptions';
 import { RemoteFlows } from './RemoteFlows';
 import './css/main.css';
 import 'react-flagpack/dist/style.css';
@@ -29,6 +30,7 @@ export function CostCalculatorWithResults() {
     <RemoteFlows isClientToken>
       <CostCalculatorFlow
         estimationOptions={estimationOptions}
+        options={COST_CALCULATOR_OPTIONS}
         render={(props) => {
           if (props.isLoading) {
             return <div>Loading...</div>;

--- a/example/src/costCalculatorOptions.ts
+++ b/example/src/costCalculatorOptions.ts
@@ -1,0 +1,11 @@
+import type { CostCalculatorFlowProps } from '@remoteoss/remote-flows';
+
+/**
+ * Options shared by every cost calculator demo, so feature flags only have to be
+ * flipped in one place. Spread it when a demo needs its own jsfModify/callbacks.
+ */
+export const COST_CALCULATOR_OPTIONS: NonNullable<
+  CostCalculatorFlowProps['options']
+> = {
+  features: ['split_salary_description'],
+};

--- a/example/tsconfig.e2e.tsbuildinfo
+++ b/example/tsconfig.e2e.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./e2e/add-estimation.spec.ts","./e2e/annual-gross-salary.spec.ts","./e2e/edit-estimation.spec.ts","./e2e/hiring-budget.spec.ts","./e2e/onboard-basic-employee.spec.ts","./e2e/helpers/estimation.ts","./e2e/helpers/general.ts","./e2e/helpers/onboarding.ts","./playwright.config.ts"],"version":"6.0.3"}

--- a/src/components/form/fields/CurrencyConversionField.tsx
+++ b/src/components/form/fields/CurrencyConversionField.tsx
@@ -18,20 +18,37 @@ import {
 type DescriptionWithConversionProps = {
   description: ReactNode;
   helpCenter: ReactNode;
+  toggle: ReactNode;
+  className: string;
+};
+
+const DescriptionWithConversion = ({
+  description,
+  helpCenter,
+  toggle,
+  className,
+}: DescriptionWithConversionProps) => (
+  <span className={className}>
+    <FormDescription as='span' helpCenter={helpCenter}>
+      {description}
+    </FormDescription>{' '}
+    {toggle}
+  </span>
+);
+
+type ConversionToggleProps = {
   showConversion: boolean;
   targetCurrency: string;
   className: string;
   onClick: (evt: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
-const DescriptionWithConversion = ({
-  description,
-  helpCenter,
+const ConversionToggle = ({
   showConversion,
   targetCurrency,
   className,
   onClick,
-}: DescriptionWithConversionProps) => {
+}: ConversionToggleProps) => {
   const { components } = useFormFields();
   const label = showConversion
     ? `Hide ${targetCurrency} conversion`
@@ -43,18 +60,9 @@ const DescriptionWithConversion = ({
   }
 
   return (
-    <span className={className}>
-      <FormDescription as='span' helpCenter={helpCenter}>
-        {description}
-      </FormDescription>{' '}
-      <CustomButton
-        className={`${className.replace('-description', '-button')}`}
-        data-type='inline'
-        onClick={onClick}
-      >
-        {label}
-      </CustomButton>
-    </span>
+    <CustomButton className={className} data-type='inline' onClick={onClick}>
+      {label}
+    </CustomButton>
   );
 };
 
@@ -73,6 +81,12 @@ export type CurrencyConversionFieldProps = JSFField & {
   meta?: {
     helpCenter?: HelpCenterDataProps;
   };
+  /**
+   * Enabled by the 'split_salary_description' feature flag. When on, the description, the help
+   * center link and the conversion toggle are handed to the text component as three separate
+   * slots instead of being packed into the description node.
+   */
+  splitDescription?: boolean;
 };
 
 export const CurrencyConversionField = ({
@@ -85,6 +99,7 @@ export const CurrencyConversionField = ({
   description,
   conversionType = 'spread',
   meta,
+  splitDescription = false,
   ...props
 }: CurrencyConversionFieldProps) => {
   const [showConversion, setShowConversion] = useState(false);
@@ -185,30 +200,44 @@ export const CurrencyConversionField = ({
     }
   };
 
-  // when we render the conversion toggle we also render the help center link ourselves,
-  // so it stays next to the description instead of being appended after the toggle.
-  // The link is then stripped from the meta we forward, to avoid rendering it twice.
-  const extraDescription = canShowConversion ? (
-    <DescriptionWithConversion
+  const conversionToggle = canShowConversion ? (
+    <ConversionToggle
       targetCurrency={targetCurrency}
-      description={description}
-      helpCenter={<HelpCenter helpCenter={meta?.helpCenter} />}
       showConversion={showConversion}
-      className={`${classNamePrefix}-description`}
+      className={`${classNamePrefix}-button`}
       onClick={toggleConversion}
     />
-  ) : (
-    description
-  );
+  ) : null;
+
+  // With the split_salary_description feature, the toggle is handed over as a separate slot so the
+  // text component stays free to render the description, the help center link and the toggle
+  // however it wants. Without it, we keep packing them into the description node: it's the only
+  // slot every text component is known to render, so the toggle can't get lost. The help center
+  // link is then rendered by us and stripped from the meta we forward, to avoid rendering it twice
+  // (FormDescription appends it after its children, which would put it after the toggle).
+  const descriptionProps = splitDescription
+    ? { meta, description, descriptionSuffix: conversionToggle }
+    : {
+        meta: conversionToggle ? omit(meta, 'helpCenter') : meta,
+        description: conversionToggle ? (
+          <DescriptionWithConversion
+            description={description}
+            helpCenter={<HelpCenter helpCenter={meta?.helpCenter} />}
+            toggle={conversionToggle}
+            className={`${classNamePrefix}-description`}
+          />
+        ) : (
+          description
+        ),
+      };
 
   return (
     <>
       <TextField
         {...props}
-        meta={canShowConversion ? omit(meta, 'helpCenter') : meta}
+        {...descriptionProps}
         name={mainFieldName || props.name}
         additionalProps={{ currency: sourceCurrency }}
-        description={extraDescription}
         type='text'
         inputMode='decimal'
         pattern='^[0-9.]*$'

--- a/src/components/form/fields/TextField.tsx
+++ b/src/components/form/fields/TextField.tsx
@@ -14,6 +14,7 @@ export type TextFieldProps = React.ComponentProps<'input'> & {
       component?: Components['text'];
       includeErrorMessage?: boolean;
       additionalProps?: Record<string, unknown>;
+      descriptionSuffix?: React.ReactNode;
     }
   >;
 
@@ -27,6 +28,7 @@ type CustomTextFieldProps = TextFieldDataProps & {
 export function TextField({
   name,
   description,
+  descriptionSuffix,
   label,
   type,
   onChange,
@@ -54,6 +56,7 @@ export function TextField({
         const customTextFieldProps: CustomTextFieldProps = {
           name,
           description,
+          descriptionSuffix,
           label,
           type,
           onChange,

--- a/src/components/form/fields/default/TextFieldDefault.tsx
+++ b/src/components/form/fields/default/TextFieldDefault.tsx
@@ -9,8 +9,14 @@ export function TextFieldDefault({
   fieldState,
   fieldData,
 }: TextFieldComponentProps) {
-  const { name, label, description, maxLength, includeErrorMessage } =
-    fieldData;
+  const {
+    name,
+    label,
+    description,
+    descriptionSuffix,
+    maxLength,
+    includeErrorMessage,
+  } = fieldData;
   return (
     <FormItem
       data-field={name}
@@ -38,6 +44,11 @@ export function TextFieldDefault({
         >
           {description}
         </FormDescription>
+      )}
+      {descriptionSuffix && (
+        <span className='RemoteFlows__TextField__DescriptionSuffix'>
+          {descriptionSuffix}
+        </span>
       )}
       {includeErrorMessage && fieldState.error && (
         <FormMessage className='RemoteFlows__TextField__Error' />

--- a/src/components/form/fields/default/TextFieldDefault.tsx
+++ b/src/components/form/fields/default/TextFieldDefault.tsx
@@ -17,6 +17,17 @@ export function TextFieldDefault({
     maxLength,
     includeErrorMessage,
   } = fieldData;
+
+  const descriptionNode = (description || fieldData.meta?.helpCenter) && (
+    <FormDescription
+      as={descriptionSuffix ? 'span' : 'p'}
+      className='RemoteFlows__TextField__Description'
+      helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
+    >
+      {description}
+    </FormDescription>
+  );
+
   return (
     <FormItem
       data-field={name}
@@ -37,18 +48,18 @@ export function TextFieldDefault({
           maxLength={maxLength}
         />
       </FormControl>
-      {(description || fieldData.meta?.helpCenter) && (
-        <FormDescription
-          className='RemoteFlows__TextField__Description'
-          helpCenter={<HelpCenter helpCenter={fieldData.meta?.helpCenter} />}
-        >
-          {description}
-        </FormDescription>
-      )}
-      {descriptionSuffix && (
-        <span className='RemoteFlows__TextField__DescriptionSuffix'>
-          {descriptionSuffix}
+      {descriptionSuffix ? (
+        // FormItem lays its children out in a grid, so the suffix has to share the description's
+        // cell to stay on the same line as it (and as the help center link), the way the salary
+        // description reads when the split_salary_description feature is off.
+        <span className='RemoteFlows__TextField__DescriptionGroup'>
+          {descriptionNode}{' '}
+          <span className='RemoteFlows__TextField__DescriptionSuffix'>
+            {descriptionSuffix}
+          </span>
         </span>
+      ) : (
+        descriptionNode
       )}
       {includeErrorMessage && fieldState.error && (
         <FormMessage className='RemoteFlows__TextField__Error' />

--- a/src/components/form/fields/tests/CurrencyConversionField.test.tsx
+++ b/src/components/form/fields/tests/CurrencyConversionField.test.tsx
@@ -17,6 +17,8 @@ import {
 import { useState } from 'react';
 import { TextFieldDefault } from '@/src/components/form/fields/default/TextFieldDefault';
 import { ButtonDefault } from '@/src/components/form/fields/default/ButtonDefault';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
+import { TextFieldComponentProps } from '@/src/types/fields';
 import { $TSFixMe } from '@/src/types/remoteFlows';
 
 vi.mock('@/src/components/shared/zendesk-drawer/ZendeskTriggerButton', () => ({
@@ -75,6 +77,36 @@ const renderWithFormContext = (props = defaultProps) => {
       <QueryClientProvider client={queryClient}>
         <FormFieldsProvider
           components={{ text: TextFieldDefault, button: ButtonDefault }}
+        >
+          <FormProvider {...methods}>
+            <CurrencyConversionField {...props} />
+          </FormProvider>
+        </FormFieldsProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  return render(<TestComponent />);
+};
+
+// Helper function to render with a custom text component
+const renderWithCustomTextComponent = (
+  CustomText: React.ComponentType<TextFieldComponentProps>,
+  props = defaultProps,
+) => {
+  const TestComponent = () => {
+    const methods = useForm({
+      defaultValues: {
+        [props.name]: '',
+        [props.conversionFieldName]: '',
+      },
+      mode: 'onChange',
+    });
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <FormFieldsProvider
+          components={{ text: CustomText, button: ButtonDefault }}
         >
           <FormProvider {...methods}>
             <CurrencyConversionField {...props} />
@@ -329,6 +361,20 @@ describe('CurrencyFieldWithConversion', () => {
     expect(screen.queryByText('Show USD conversion')).not.toBeInTheDocument();
   });
 
+  it('does not pass a description suffix to the text component', () => {
+    const CustomText = vi
+      .fn()
+      .mockImplementation(({ fieldData }: TextFieldComponentProps) => (
+        <input aria-label={fieldData.label} />
+      ));
+
+    renderWithCustomTextComponent(CustomText, propsWithHelpCenter);
+
+    expect(CustomText.mock.calls[0][0].fieldData.descriptionSuffix).toBe(
+      undefined,
+    );
+  });
+
   it('resets conversion field when source currency changes', async () => {
     const TestComponent = () => {
       const [sourceCurrency, setSourceCurrency] = useState('USD');
@@ -377,6 +423,62 @@ describe('CurrencyFieldWithConversion', () => {
 
     // The conversion field should be reset to empty
     expect(conversionInput).toHaveValue('');
+  });
+
+  describe('with the split_salary_description feature enabled', () => {
+    const propsWithSplitDescription: CurrencyConversionFieldProps = {
+      ...propsWithHelpCenter,
+      splitDescription: true,
+    };
+
+    it('renders the description with its help center link, then the toggle', () => {
+      renderWithFormContext(propsWithSplitDescription);
+
+      expect(screen.getAllByTestId('zendesk-button-12345')).toHaveLength(1);
+
+      const description = screen
+        .getByText(/Enter your test salary/i)
+        .closest('[data-slot="form-description"]');
+      expect(description).toContainElement(
+        screen.getByTestId('zendesk-button-12345'),
+      );
+      expect(description?.nextElementSibling).toHaveTextContent(
+        'Show EUR conversion',
+      );
+    });
+
+    it('lets a custom text component render the help center link without the description', () => {
+      const HelpCenterOnlyText = ({ fieldData }: TextFieldComponentProps) => (
+        <>
+          <label htmlFor={fieldData.name}>{fieldData.label}</label>
+          <input id={fieldData.name} name={fieldData.name} />
+          <HelpCenter helpCenter={fieldData.meta?.helpCenter} />
+          {fieldData.descriptionSuffix}
+        </>
+      );
+
+      renderWithCustomTextComponent(
+        HelpCenterOnlyText,
+        propsWithSplitDescription,
+      );
+
+      expect(screen.getByTestId('zendesk-button-12345')).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Enter your test salary/i),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Show EUR conversion')).toBeInTheDocument();
+    });
+
+    it('shows conversion field when toggle is clicked', async () => {
+      renderWithFormContext(propsWithSplitDescription);
+
+      const toggleButton = screen.getByText('Show EUR conversion');
+      fireEvent.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Conversion')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('with custom button component', () => {

--- a/src/components/form/fields/tests/CurrencyConversionField.test.tsx
+++ b/src/components/form/fields/tests/CurrencyConversionField.test.tsx
@@ -445,6 +445,10 @@ describe('CurrencyFieldWithConversion', () => {
       expect(description?.nextElementSibling).toHaveTextContent(
         'Show EUR conversion',
       );
+      // the toggle shares the description's grid cell, so it stays on the same line
+      expect(description?.parentElement).toHaveClass(
+        'RemoteFlows__TextField__DescriptionGroup',
+      );
     });
 
     it('lets a custom text component render the help center link without the description', () => {

--- a/src/flows/CostCalculator/components/SalaryField.tsx
+++ b/src/flows/CostCalculator/components/SalaryField.tsx
@@ -17,6 +17,7 @@ type SalaryFieldProps = JSFField & {
   conversionType?: 'spread' | 'no_spread';
   shouldSwapOrder: boolean;
   defaultValue?: string;
+  splitDescription?: boolean;
 };
 
 export const SalaryField = ({
@@ -25,6 +26,7 @@ export const SalaryField = ({
   salary_conversion_properties,
   conversionType = 'no_spread',
   defaultValue,
+  splitDescription,
   ...props
 }: SalaryFieldProps) => {
   const { setValue, getValues } = useFormContext();
@@ -84,6 +86,7 @@ export const SalaryField = ({
       conversionProperties={conversionProperties}
       classNamePrefix='RemoteFlows-Salary'
       conversionType={conversionType}
+      splitDescription={splitDescription}
     />
   );
 };

--- a/src/flows/CostCalculator/hooks.tsx
+++ b/src/flows/CostCalculator/hooks.tsx
@@ -192,6 +192,8 @@ export const useCostCalculator = (
 
   const showManagementField = estimationOptions.showManagementFee;
   const showEstimationTitleField = estimationOptions.includeEstimationTitle;
+  const useSplitSalaryDescription =
+    options?.features?.includes('split_salary_description') ?? false;
   const customFields = useMemo(() => {
     const { from, to, shouldSwapOrder } = getCurrencies();
     const salaryTitle = getSalaryTitle(salaryField, hiringBudget);
@@ -221,6 +223,7 @@ export const useCostCalculator = (
                     version === 'marketing' ? 'no_spread' : 'spread'
                   }
                   defaultValue={defaultSalary}
+                  splitDescription={useSplitSalaryDescription}
                 />
               );
             },
@@ -299,6 +302,7 @@ export const useCostCalculator = (
     showManagementField,
     showEstimationTitleField,
     defaultSalary,
+    useSplitSalaryDescription,
   ]);
 
   const fieldsJSONSchema = useStaticSchema({

--- a/src/flows/CostCalculator/types.ts
+++ b/src/flows/CostCalculator/types.ts
@@ -88,10 +88,20 @@ export type EstimationError =
   | PostV1CostCalculatorEstimationError
   | ValidationError;
 
+export type CostCalculatorFeatures = 'split_salary_description';
+
 export type UseCostCalculatorOptions = {
   jsfModify?: JSFModify;
   onCurrencyChange?: (currency: string) => void;
   onValidation?: (values: CostCalculatorEstimationFormValues) => void;
+  /**
+   * The features to enable for the cost calculator.
+   * - 'split_salary_description': Hand the salary description, its help center link and the currency
+   *   conversion toggle to the text component as three separate slots (`description`,
+   *   `meta.helpCenter`, `descriptionSuffix`) instead of packing them into `description`.
+   *   Custom text components must render `fieldData.descriptionSuffix` to keep the conversion toggle.
+   */
+  features?: CostCalculatorFeatures[];
 };
 
 export type CurrencyKey = keyof typeof BASE_RATES;

--- a/src/flows/Onboarding/components/AnnualGrossSalary.tsx
+++ b/src/flows/Onboarding/components/AnnualGrossSalary.tsx
@@ -8,12 +8,14 @@ type AnnualGrossSalaryProps = JSFField & {
     label?: string;
     description?: string;
   };
+  splitDescription?: boolean;
 };
 
 export const AnnualGrossSalary = ({
   currency,
   desiredCurrency,
   annual_gross_salary_conversion_properties,
+  splitDescription,
   ...props
 }: AnnualGrossSalaryProps) => {
   return (
@@ -21,6 +23,7 @@ export const AnnualGrossSalary = ({
       {...props}
       sourceCurrency={currency}
       targetCurrency={desiredCurrency}
+      splitDescription={splitDescription}
       conversionFieldName='annual_gross_salary_conversion'
       conversionProperties={{
         ...annual_gross_salary_conversion_properties,

--- a/src/flows/Onboarding/hooks.tsx
+++ b/src/flows/Onboarding/hooks.tsx
@@ -228,6 +228,8 @@ export const useOnboarding = ({
   ] = useState<boolean>(false);
 
   const useDynamicSteps = options?.features?.includes('dynamic_steps') ?? false;
+  const useSplitSalaryDescription =
+    options?.features?.includes('split_salary_description') ?? false;
   const useEAPreview = Boolean(
     options?.features?.includes('ea_preview') &&
     includeEmploymentAgreementPreview,
@@ -605,6 +607,7 @@ export const useOnboarding = ({
               return (
                 <AnnualGrossSalary
                   desiredCurrency={company?.desired_currency || ''}
+                  splitDescription={useSplitSalaryDescription}
                   {...props}
                 />
               );
@@ -640,6 +643,7 @@ export const useOnboarding = ({
       annualSalaryFieldPresentation,
       company?.desired_currency,
       equityCompensationField,
+      useSplitSalaryDescription,
     ],
   );
 

--- a/src/flows/Onboarding/types.ts
+++ b/src/flows/Onboarding/types.ts
@@ -63,7 +63,8 @@ type OnboardingFeatures =
   | 'onboarding_reserves'
   | 'dynamic_steps'
   | 'ea_preview'
-  | 'pre_onboarding_requirements';
+  | 'pre_onboarding_requirements'
+  | 'split_salary_description';
 
 /**
  * JSON schema version configuration for a specific country
@@ -163,6 +164,10 @@ export type OnboardingFlowProps = {
      * This is used to enable or disable features for the onboarding.
      * - 'onboarding_reserves': Enable onboarding reserves feature
      * - 'dynamic_steps': Enable dynamic step generation with visibility control (opt-in, will be default in next major version)
+     * - 'split_salary_description': Hand the annual gross salary description, its help center link and the
+     *   currency conversion toggle to the text component as three separate slots (`description`,
+     *   `meta.helpCenter`, `descriptionSuffix`) instead of packing them into `description`.
+     *   Custom text components must render `fieldData.descriptionSuffix` to keep the conversion toggle.
      */
     features?: OnboardingFeatures[];
   };

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -61,6 +61,13 @@ export type FieldDataProps = Partial<JSFField> & {
     helpCenter?: HelpCenterDataProps;
   };
   /**
+   * Optional node the SDK asks the field to render after the description and its help center
+   * link. Only some fields provide it: the salary field uses it for the currency conversion
+   * toggle when the flow enables the 'split_salary_description' feature. If your custom
+   * component doesn't render it, the toggle won't be available to your users.
+   */
+  descriptionSuffix?: React.ReactNode;
+  /**
    * Optional HTML transformer function passed from RemoteFlows context.
    * Use this in custom field components to transform HTML descriptions into React components.
    * @example


### PR DESCRIPTION
## What

The annual gross salary field packed three things into a single `description`
string: the description text, the help center link, and the currency conversion
toggle. Custom text components had no way to lay them out separately.

This PR hands them to the field as three independent slots — `description`,
`meta.helpCenter` and the new `fieldData.descriptionSuffix` (which carries the
conversion toggle).

## Behind a feature flag

Opt-in via `options={{ features: ['split_salary_description'] }}` on
`OnboardingFlow` and `CostCalculatorFlow`. Off by default: without the flag the
description keeps its current shape and `descriptionSuffix` stays empty, so
rendering is unchanged for every existing consumer.

## Note for custom components

A custom text component must render `fieldData.descriptionSuffix`, otherwise its
users lose the conversion toggle. Documented in `docs/COMPONENT_CUSTOMIZATION.md`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared form field plumbing and salary UX on onboarding and cost calculator flows; custom integrators must adopt `descriptionSuffix` when enabling the flag or lose the conversion toggle.
> 
> **Overview**
> **Adds an opt-in `split_salary_description` feature** on `OnboardingFlow` and `CostCalculatorFlow` so salary / annual gross salary fields can expose **description**, **help center** (`meta.helpCenter`), and the **currency conversion toggle** as separate `fieldData` slots instead of one bundled `description` node. The new slot is **`fieldData.descriptionSuffix`** (toggle only when conversion applies).
> 
> When the flag is **off**, behavior stays the same: the toggle and help link are still composed into `description`, and `descriptionSuffix` is empty. **`TextField`**, the default text UI, and **`CurrencyConversionField`** wire the split path; onboarding and cost calculator hooks pass `splitDescription` from `options.features`.
> 
> **Custom text components** must render `fieldData.descriptionSuffix` when using the flag, or users lose the conversion control—documented in `COMPONENT_CUSTOMIZATION.md`. Example cost calculator demos share `COST_CALCULATOR_OPTIONS` with the flag enabled; sample `Components` render the suffix. Tests cover both legacy and split layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e2d6bda386e91ab815f8c7076b363cd066cc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->