### PR TITLE
chore: prepare release v1.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,35 @@
 # @remoteoss/remote-flows
 
+## 1.46.0
+
+### Minor Changes
+
+#### Features
+
+- split description, help center and conversion toggle into separate slots, behind the `split_salary_description` feature flag on `OnboardingFlow` and `CostCalculatorFlow` (#1209) [#1209](https://github.com/remoteoss/remote-flows/pull/1209)
+
+#### Docs
+
+- share the cost calculator feature flags in a general constant in the example app (#1209) [#1209](https://github.com/remoteoss/remote-flows/pull/1209)
+
 ## 1.45.0
 
 ### Minor Changes
 
 #### Features
 
-- Italy APL and France SAS applies new contract details architecture
+- Italy APL and France SAS applies new contract details architecture (#1199, #1203) [#1199](https://github.com/remoteoss/remote-flows/pull/1199) [#1203](https://github.com/remoteoss/remote-flows/pull/1203)
 
 #### Fixes
 
 - always call the latest checkFieldUpdates (#1198) [#1198](https://github.com/remoteoss/remote-flows/pull/1198)
 - freeze basic information json schema (#1207) [#1207](https://github.com/remoteoss/remote-flows/pull/1207)
+- keep invisible values when revalidating a jsf v1 form (#1203) [#1203](https://github.com/remoteoss/remote-flows/pull/1203)
 
 #### Docs
 
 - fix france arch problems only on playground (#1195) [#1195](https://github.com/remoteoss/remote-flows/pull/1195)
+- add configurable schemas option with Italy APL example to the playground (#1190) [#1190](https://github.com/remoteoss/remote-flows/pull/1190)
 - add sandbox payment approval (#1200) [#1200](https://github.com/remoteoss/remote-flows/pull/1200)
 - example app demo for employee self-onboarding flow (PBYR-4044) (#1201) [#1201](https://github.com/remoteoss/remote-flows/pull/1201)
 - render help center link on text, select, tel, time and file fields

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.45.0",
+      "version": "1.46.0",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-only version and changelog updates with no runtime code changes in this diff.
> 
> **Overview**
> Prepares **v1.46.0** by syncing the package version in `package.json` and `package-lock.json` from `1.45.0` to `1.46.0`.
> 
> Adds a **1.46.0** section to `CHANGELOG.md` for work already merged via #1209: salary-field UI split behind `split_salary_description` on `OnboardingFlow` and `CostCalculatorFlow`, plus a shared cost-calculator feature-flag constant in the example app. The same changelog edit also tightens a few **1.45.0** entry links/wording (Italy/France architecture PR refs and related fix/docs bullets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d234bf8320be059872934008a0cf5acc020e3f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->