### PR TITLE
fix(e2e): add explicit waits for datepicker calendar popup in e2e tests

### DIFF
--- a/example/e2e/helpers/general.ts
+++ b/example/e2e/helpers/general.ts
@@ -160,19 +160,27 @@ export async function fillDatepicker(
   testId: string,
 ) {
   await page.getByTestId(testId).click();
+
+  // Wait for the calendar popup to be visible
+  await page
+    .locator('[role="dialog"]')
+    .waitFor({ state: 'visible', timeout: 5000 });
+
   if (value === 'auto') {
-    await page
+    const firstAvailableDate = page
       .locator('button[role="gridcell"]:not([disabled])')
-      .first()
-      .click();
+      .first();
+    await firstAvailableDate.waitFor({ state: 'visible' });
+    await firstAvailableDate.click();
   } else {
-    await page
+    const dateButton = page
       .getByRole('button', {
         name: value,
         exact: true,
       })
       .and(page.locator(':not([disabled])'))
-      .first()
-      .click();
+      .first();
+    await dateButton.waitFor({ state: 'visible' });
+    await dateButton.click();
   }
 }

--- a/example/e2e/helpers/general.ts
+++ b/example/e2e/helpers/general.ts
@@ -162,9 +162,7 @@ export async function fillDatepicker(
   await page.getByTestId(testId).click();
 
   // Wait for the calendar popup to be visible
-  await page
-    .locator('[role="dialog"]')
-    .waitFor({ state: 'visible', timeout: 5000 });
+  await page.locator('[role="dialog"]').waitFor({ state: 'visible' });
 
   if (value === 'auto') {
     const firstAvailableDate = page


### PR DESCRIPTION
The fillDatepicker helper was racing with the calendar popup rendering, causing tests to hang when trying to click dates that weren't visible yet.

This adds explicit waits for:
- The calendar dialog to appear after clicking the date picker button
- Individual date gridcells to be visible before clicking them

This makes the tests more robust against timing variations from validation changes, network conditions, or browser updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper changes with no production or auth/data impact.
> 
> **Overview**
> The `fillDatepicker` Playwright helper now waits for the calendar UI before selecting a date, instead of clicking grid cells immediately after opening the picker.
> 
> After the trigger click, it waits for `[role="dialog"]` to be visible. For both **auto** (first enabled day) and **named date** flows, it waits for the target `gridcell` / date button to be visible before clicking.
> 
> This targets flaky hangs caused by racing the popup render and should align with how other helpers in `general.ts` already wait for controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbd2e6361746ae502994d85262e84d58e704263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->