### PR TITLE
docs(usa) - add contract details changelog

### DIFF
--- a/docs/schema-changes/eor/contract-details/countries/README.md
+++ b/docs/schema-changes/eor/contract-details/countries/README.md
@@ -36,6 +36,7 @@ These countries have upgraded to different versions, check each guide to know ho
 - [Sweden (SWE)](./SWE.md)
 - [United Arab Emirates (ARE)](./ARE.md)
 - [United Kingdom (GBR)](./GBR.md)
+- [United States (USA)](./USA.md)
 
 ### Countries on Contract Details v1
 
@@ -45,7 +46,6 @@ These countries have upgraded to different versions, check each guide to know ho
 
 | Country              | Code | Contract Details | Last Updated |
 | -------------------- | ---- | ---------------- | ------------ |
-| United Arab Emirates | ARE  | v3               | March 2026   |
 | Belarus              | BLR  | v2               | March 2026   |
 | China                | CHN  | v3               | March 2026   |
 | Switzerland          | CHE  | v2               | March 2026   |
@@ -70,6 +70,8 @@ These countries have upgraded to different versions, check each guide to know ho
 | Serbia               | SRB  | v2               | March 2026   |
 | Sweden               | SWE  | v2               | March 2026   |
 | United Kingdom       | GBR  | v2               | March 2026   |
+| United Arab Emirates | ARE  | v3               | March 2026   |
+| United States        | USA  | v3               | August 2026  |
 
 ## How to Use
 

--- a/docs/schema-changes/eor/contract-details/countries/USA.md
+++ b/docs/schema-changes/eor/contract-details/countries/USA.md
@@ -1,6 +1,6 @@
-# Sweden (SWE)
+# United States (USA)
 
-Schema versions for employee onboarding in Sweden.
+Schema versions for employee onboarding in United States.
 
 ## Current Version
 

--- a/docs/schema-changes/eor/contract-details/countries/USA.md
+++ b/docs/schema-changes/eor/contract-details/countries/USA.md
@@ -1,0 +1,54 @@
+# Sweden (SWE)
+
+Schema versions for employee onboarding in Sweden.
+
+## Current Version
+
+**Contract Details:** v3
+
+## Contract Details
+
+### v3 - Current
+
+**What changed:**
+
+- Employee schedule added
+- Wage type field added
+
+**Migration:**
+
+```tsx
+<OnboardingFlow
+  options={{
+    jsonSchemaVersionByCountry: {
+      USA: { contract_details: 3 },
+    },
+  }}
+/>
+```
+
+---
+
+### v2
+
+**What changed:**
+
+- non compete fields migrated
+
+**Migration:**
+
+```tsx
+<OnboardingFlow
+  options={{
+    jsonSchemaVersionByCountry: {
+      USA: { contract_details: 2 },
+    },
+  }}
+/>
+```
+
+---
+
+### v1
+
+Initial version with basic contract details fields.

--- a/example/src/flows/Onboarding/constants.ts
+++ b/example/src/flows/Onboarding/constants.ts
@@ -113,5 +113,10 @@ export const ONBOARDING_OPTIONS = {
       // Sweden
       contract_details: 2,
     },
+
+    USA: {
+      // United States
+      contract_details: 3,
+    },
   },
 };

--- a/src/components/JsonSchemaComparison/promptTiger.txt
+++ b/src/components/JsonSchemaComparison/promptTiger.txt
@@ -5,7 +5,7 @@ For each country in apps/tiger/priv/json_schemas/contract_details/ (excluding ba
 3. Create an array of version objects from 1 to the total count
 Output format:
 ```typescript
-const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
+export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   COUNTRY_CODE: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },

--- a/src/components/JsonSchemaComparison/schemaVersions.ts
+++ b/src/components/JsonSchemaComparison/schemaVersions.ts
@@ -31,6 +31,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   AUT: [
     { value: 1, label: 'v1' },
@@ -75,6 +76,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   CAN: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   CHE: [
     { value: 1, label: 'v1' },
@@ -96,6 +98,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   COL: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   CRI: [
     { value: 1, label: 'v1' },
@@ -105,6 +108,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   CYP: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   CZE: [
     { value: 1, label: 'v1' },
@@ -153,6 +157,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   GEO: [
     { value: 1, label: 'v1' },
@@ -161,6 +166,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   GRC: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   GTM: [
     { value: 1, label: 'v1' },
@@ -171,7 +177,10 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
   ],
-  HND: [{ value: 1, label: 'v1' }],
+  HND: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   HRV: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
@@ -193,6 +202,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   ITA: [
     { value: 1, label: 'v1' },
@@ -239,6 +249,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
+    { value: 4, label: 'v4' },
   ],
   MAR: [
     { value: 1, label: 'v1' },
@@ -278,6 +289,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   NLD: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   NOR: [
     { value: 1, label: 'v1' },
@@ -297,9 +309,13 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   PAN: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   PER: [{ value: 1, label: 'v1' }],
-  PHL: [{ value: 1, label: 'v1' }],
+  PHL: [
+    { value: 1, label: 'v1' },
+    { value: 2, label: 'v2' },
+  ],
   POL: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
@@ -321,6 +337,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   ROU: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   SAU: [
     { value: 1, label: 'v1' },
@@ -336,6 +353,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
     { value: 2, label: 'v2' },
     { value: 3, label: 'v3' },
     { value: 4, label: 'v4' },
+    { value: 5, label: 'v5' },
   ],
   SVK: [
     { value: 1, label: 'v1' },
@@ -380,6 +398,7 @@ export const COUNTRY_CONTRACT_VERSIONS: Record<string, VersionOption[]> = {
   USA: [
     { value: 1, label: 'v1' },
     { value: 2, label: 'v2' },
+    { value: 3, label: 'v3' },
   ],
   VNM: [
     { value: 1, label: 'v1' },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and version-mapping updates for onboarding/schema comparison; no auth or runtime business-logic changes in app code beyond example constants.
> 
> **Overview**
> Documents **United States** contract-details schema history and sets **USA** to **contract details v3** in the example onboarding flow.
> 
> Adds `USA.md` (v3: employee schedule and wage type; v2: non-compete migration) and updates the countries README/version matrix. The example app’s `jsonSchemaVersionByCountry` now uses `USA: { contract_details: 3 }`.
> 
> `schemaVersions.ts` gains **v3** for USA and refreshes version lists for several other countries (e.g. AUS, CAN, GBR, SRB). The JsonSchema comparison prompt now expects an **`export`** on `COUNTRY_CONTRACT_VERSIONS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70348d8c41f379e22a98996a1a6aa4c88c31693f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->