### PR TITLE
1.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,28 @@
 
 ### Minor Changes
 
-#### Chores
+#### Features
 
-- remove build files (#1211) [#1211](https://github.com/remoteoss/remote-flows/pull/1211)
-- replace endpoint (#1210) [#1210](https://github.com/remoteoss/remote-flows/pull/1210)
+- make employment readonly when shouldFreezeEmploymentData is true (#1213) [#1213](https://github.com/remoteoss/remote-flows/pull/1213)
+
+#### Fixes
+
 - add explicit waits for datepicker calendar popup in e2e tests (#1214) [#1214](https://github.com/remoteoss/remote-flows/pull/1214)
+
+#### Docs
+
+- replace endpoint (#1210) [#1210](https://github.com/remoteoss/remote-flows/pull/1210)
 - add test to make sure submission keeps working (#1206) [#1206](https://github.com/remoteoss/remote-flows/pull/1206)
 - add contract details changelog (#1215) [#1215](https://github.com/remoteoss/remote-flows/pull/1215)
+
+#### Chores
+
+- remove build files (#1211) [#1211](https://github.com/remoteoss/remote-flows/pull/1211)
 - update dependency html-react-parser to v6.1.5 (#1197) [#1197](https://github.com/remoteoss/remote-flows/pull/1197)
 - update dependency @tanstack/react-query to v5.101.4 (#1196) [#1196](https://github.com/remoteoss/remote-flows/pull/1196)
 - update dependency @arethetypeswrong/cli to v0.18.5 (#1128) [#1128](https://github.com/remoteoss/remote-flows/pull/1128)
 - update dependency @vitejs/plugin-react to v6.0.4 (#1217) [#1217](https://github.com/remoteoss/remote-flows/pull/1217)
 - update dependency postcss to v8.5.23 [security] (#1216) [#1216](https://github.com/remoteoss/remote-flows/pull/1216)
-- make employment readonly when shouldFreezeEmploymentData is true (#1213) [#1213](https://github.com/remoteoss/remote-flows/pull/1213)
 - update dependency @remoteoss/remote-json-schema-form-kit to v0.0.23 (#1218) [#1218](https://github.com/remoteoss/remote-flows/pull/1218)
 - update dependency @playwright/test to v1.62.0 (#1219) [#1219](https://github.com/remoteoss/remote-flows/pull/1219)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @remoteoss/remote-flows
 
+## 1.47.0
+
+### Minor Changes
+
+#### Chores
+
+- remove build files (#1211) [#1211](https://github.com/remoteoss/remote-flows/pull/1211)
+- replace endpoint (#1210) [#1210](https://github.com/remoteoss/remote-flows/pull/1210)
+- add explicit waits for datepicker calendar popup in e2e tests (#1214) [#1214](https://github.com/remoteoss/remote-flows/pull/1214)
+- add test to make sure submission keeps working (#1206) [#1206](https://github.com/remoteoss/remote-flows/pull/1206)
+- add contract details changelog (#1215) [#1215](https://github.com/remoteoss/remote-flows/pull/1215)
+- update dependency html-react-parser to v6.1.5 (#1197) [#1197](https://github.com/remoteoss/remote-flows/pull/1197)
+- update dependency @tanstack/react-query to v5.101.4 (#1196) [#1196](https://github.com/remoteoss/remote-flows/pull/1196)
+- update dependency @arethetypeswrong/cli to v0.18.5 (#1128) [#1128](https://github.com/remoteoss/remote-flows/pull/1128)
+- update dependency @vitejs/plugin-react to v6.0.4 (#1217) [#1217](https://github.com/remoteoss/remote-flows/pull/1217)
+- update dependency postcss to v8.5.23 [security] (#1216) [#1216](https://github.com/remoteoss/remote-flows/pull/1216)
+- make employment readonly when shouldFreezeEmploymentData is true (#1213) [#1213](https://github.com/remoteoss/remote-flows/pull/1213)
+- update dependency @remoteoss/remote-json-schema-form-kit to v0.0.23 (#1218) [#1218](https://github.com/remoteoss/remote-flows/pull/1218)
+- update dependency @playwright/test to v1.62.0 (#1219) [#1219](https://github.com/remoteoss/remote-flows/pull/1219)
+
 ## 1.46.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.46.0",
+      "version": "1.47.0",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.47.0

#### Features

- make employment readonly when shouldFreezeEmploymentData is true (#1213) [#1213](https://github.com/remoteoss/remote-flows/pull/1213)

#### Fixes

- add explicit waits for datepicker calendar popup in e2e tests (#1214) [#1214](https://github.com/remoteoss/remote-flows/pull/1214)

#### Docs

- replace endpoint (#1210) [#1210](https://github.com/remoteoss/remote-flows/pull/1210)
- add test to make sure submission keeps working (#1206) [#1206](https://github.com/remoteoss/remote-flows/pull/1206)
- add contract details changelog (#1215) [#1215](https://github.com/remoteoss/remote-flows/pull/1215)

#### Chores

- remove build files (#1211) [#1211](https://github.com/remoteoss/remote-flows/pull/1211)
- update dependency html-react-parser to v6.1.5 (#1197) [#1197](https://github.com/remoteoss/remote-flows/pull/1197)
- update dependency @tanstack/react-query to v5.101.4 (#1196) [#1196](https://github.com/remoteoss/remote-flows/pull/1196)
- update dependency @arethetypeswrong/cli to v0.18.5 (#1128) [#1128](https://github.com/remoteoss/remote-flows/pull/1128)
- update dependency @vitejs/plugin-react to v6.0.4 (#1217) [#1217](https://github.com/remoteoss/remote-flows/pull/1217)
- update dependency postcss to v8.5.23 [security] (#1216) [#1216](https://github.com/remoteoss/remote-flows/pull/1216)
- update dependency @remoteoss/remote-json-schema-form-kit to v0.0.23 (#1218) [#1218](https://github.com/remoteoss/remote-flows/pull/1218)
- update dependency @playwright/test to v1.62.0 (#1219) [#1219](https://github.com/remoteoss/remote-flows/pull/1219)


---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The freeze-employment read-only behavior can block edits and navigation during onboarding when requirements demand it. Dependency upgrades (especially json-schema-form-kit) may affect form rendering and validation across flows.
> 
> **Overview**
> **Release 1.47.0** bumps `@remoteoss/remote-flows` from **1.46.0** and records the aggregated changes from the merged PRs in `CHANGELOG.md`.
> 
> The main product change is **onboarding employment becomes read-only** when pre-onboarding requirements include `freeze_employment_data` (`shouldFreezeEmploymentData`), extending the existing review-step read-only rules in `src/flows/Onboarding/hooks.tsx`.
> 
> Other bundled work: **e2e stability** (explicit waits for datepicker popups), **docs** (endpoint replacement, submission regression test, contract-details changelog), **removal of build artifacts**, and **dependency updates** (React Query, Playwright, Vite React plugin, `remote-json-schema-form-kit`, and a **security** bump for `postcss`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262aef2f1fd4bed3b2efa1cf4ae947ac074c0645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->