### PR TITLE
fix(contractor-onboarding) - fix field description

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -19,6 +19,7 @@ import {
   corProductIdentifier,
   eorProductIdentifier,
   $TSFixMe,
+  JSFModifyField,
 } from '@remoteoss/remote-flows';
 import {
   Card,
@@ -644,7 +645,7 @@ export const ContractorOnboardingWithProps = ({
                   fields: {
                     // Use a function to modify a single option in place instead of
                     // hardcoding the full options list (labels/values you don't own).
-                    login_email: (field: $TSFixMe) => ({
+                    login_email: (field: JSFModifyField) => ({
                       'x-jsf-presentation': {
                         options: field['x-jsf-presentation']?.options?.map(
                           (option: { value: string }) =>

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -631,12 +631,31 @@ export const ContractorOnboardingWithProps = ({
             employmentId={employmentId}
             externalId={externalId}
             options={{
+              jsonSchemaVersion: {
+                employment_basic_information: 1,
+              },
               // Uncomment to hide specific products from the pricing selection:
               // excludeProducts: ['eor'] // Hide EOR option
               // excludeProducts: ['eor', 'cor'] // Hide both EOR and COR
               // excludeProducts: ['cm+'] // Hide Contractor Management Plus
               //excludeProducts: ['eor', 'cor', 'cm+', 'cm'], // Hide all products
               jsfModify: {
+                basic_information: {
+                  fields: {
+                    // Use a function to modify a single option in place instead of
+                    // hardcoding the full options list (labels/values you don't own).
+                    login_email: (field: $TSFixMe) => ({
+                      'x-jsf-presentation': {
+                        options: field['x-jsf-presentation']?.options?.map(
+                          (option: { value: string }) =>
+                            option.value === 'work'
+                              ? { ...option, description: 'Select...' }
+                              : option,
+                        ),
+                      },
+                    }),
+                  },
+                },
                 contract_details: {
                   fields: {
                     'payment_terms.payment_terms_type': {

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -130,7 +130,11 @@ export type GPStepCallbacks<TSuccess = unknown> = {
 };
 
 export type JSFModifyField = {
+  description?: string;
+  enum?: string[];
+  type?: string;
   'x-jsf-presentation'?: {
+    inputType?: string;
     options?: Array<{
       value: string;
       label?: string;

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -128,3 +128,13 @@ export type GPStepCallbacks<TSuccess = unknown> = {
     fieldErrors: NormalizedFieldError[];
   }) => void;
 };
+
+export type JSFModifyField = {
+  'x-jsf-presentation'?: {
+    options?: Array<{
+      value: string;
+      label?: string;
+      description?: string;
+    }>;
+  };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,6 +185,7 @@ export type {
 } from './client/types.gen';
 
 export type { $TSFixMe, JSFCustomComponentProps } from './types/remoteFlows';
+export type { JSFModifyField } from './flows/types';
 export type { FieldError, NormalizedFieldError } from './lib/mutations';
 export { zendeskArticles } from './components/shared/zendesk-drawer/utils';
 export { ZendeskTriggerButton } from './components/shared/zendesk-drawer/ZendeskTriggerButton';


### PR DESCRIPTION
Show a way on how to edit the description of the work radio input as asked in the weekly call


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Library type export plus example-only jsfModify usage; no runtime flow logic changes.
> 
> **Overview**
> Adds a public **`JSFModifyField`** type and re-exports it from the package so consumers can type **`jsfModify`** field callbacks safely.
> 
> The contractor onboarding **example** demonstrates the pattern: under **`basic_information`**, **`login_email`** is modified with a function that maps existing **`x-jsf-presentation.options`** and only overrides the **`work`** option’s **`description`** (e.g. to `Select...`) instead of replacing the whole options list. The example also pins **`jsonSchemaVersion.employment_basic_information`** to **`1`** so the demo runs against a fixed schema version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f340bab4e196985246479de43f0ae5344eadff74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->