### PR TITLE
docs(force-value) - make force value a component that devs can override

### DIFF
--- a/example/src/Components.tsx
+++ b/example/src/Components.tsx
@@ -4,6 +4,7 @@ import type {
   FieldComponentProps,
   FieldSetToggleComponentProps,
   FileComponentProps,
+  ForcedValueComponentProps,
   PDFPreviewComponentProps,
   TelFieldComponentProps,
   TimeFieldComponentProps,
@@ -324,6 +325,30 @@ const DatePickerInput = ({
   );
 };
 
+// Forced value fields render a non-editable value the SDK already set on the form (via
+// `const`). `title`/`description` come pre-resolved (statement overrides falling back to
+// label/description), so this component only needs to decide how to present them.
+const ForcedValue = ({ fieldData }: ForcedValueComponentProps) => {
+  const { title, description, transformHtml, meta } = fieldData;
+
+  return (
+    <div className='forced-value-container'>
+      {title && (
+        <p
+          className='forced-value-title'
+          dangerouslySetInnerHTML={{ __html: title }}
+        />
+      )}
+      {renderDescription(description, transformHtml)}
+      {meta?.helpCenter?.callToAction && (
+        <span className='forced-value-help-center'>
+          {meta.helpCenter.callToAction}
+        </span>
+      )}
+    </div>
+  );
+};
+
 const PDFPreview = ({ base64Data }: PDFPreviewComponentProps) => {
   return (
     <iframe
@@ -447,6 +472,7 @@ export const components: Components = {
   countries: Countries,
   fieldsetToggle: FieldsetToggle,
   file: FileUploadField,
+  forcedValue: ForcedValue,
   date: DatePickerInput,
   pdfViewer: PDFPreview,
   tel: TelField,

--- a/example/src/flows/Onboarding/Onboarding.tsx
+++ b/example/src/flows/Onboarding/Onboarding.tsx
@@ -27,6 +27,7 @@ import { ONBOARDING_OPTIONS } from './constants';
 import { StepsNavigation } from './StepsNavigation';
 import '../../css/main.css';
 import { PreviewEmploymentAgreementStep } from './PreviewEmploymentAgreementStep';
+import { components } from '../../Components';
 
 const BenefitsAboutSection = ({
   description,
@@ -399,6 +400,7 @@ const OnboardingWithProps = ({
   <RemoteFlows
     proxy={{ url: window.location.origin }}
     transformHtmlToComponents={transformHtmlToComponents}
+    components={components}
   >
     <OnboardingFlow
       companyId={companyId}

--- a/example/src/flows/Onboarding/Onboarding.tsx
+++ b/example/src/flows/Onboarding/Onboarding.tsx
@@ -27,7 +27,6 @@ import { ONBOARDING_OPTIONS } from './constants';
 import { StepsNavigation } from './StepsNavigation';
 import '../../css/main.css';
 import { PreviewEmploymentAgreementStep } from './PreviewEmploymentAgreementStep';
-import { components } from '../../Components';
 
 const BenefitsAboutSection = ({
   description,
@@ -400,7 +399,6 @@ const OnboardingWithProps = ({
   <RemoteFlows
     proxy={{ url: window.location.origin }}
     transformHtmlToComponents={transformHtmlToComponents}
-    components={components}
   >
     <OnboardingFlow
       companyId={companyId}

--- a/src/components/form/fields/ForcedValueField.tsx
+++ b/src/components/form/fields/ForcedValueField.tsx
@@ -1,9 +1,8 @@
 import { useFormContext } from 'react-hook-form';
-import { sanitizeHtml } from '@/src/lib/utils';
 import { useEffect } from 'react';
+import { useFormFields, useTransformer } from '@/src/context';
+import { sanitizeHtml } from '@/src/lib/utils';
 import { HelpCenterDataProps } from '@/src/types/fields';
-import { BaseFormDescription as Description } from '@/src/components/ui/form';
-import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
 
 export type ForcedValueFieldProps = {
   name: string;
@@ -26,53 +25,42 @@ export function ForcedValueField({
   helpCenter,
 }: ForcedValueFieldProps) {
   const { setValue } = useFormContext();
-  const forcedValueDescription = statement?.description || description;
-
-  const forcedValueTitle = statement?.title
-    ? sanitizeHtml(statement?.title)
-    : sanitizeHtml(label);
-
-  const titleId = `forced-value-${name}-title`;
-  const descriptionId = `forced-value-${name}-description`;
+  const { components } = useFormFields();
+  const transformHtml = useTransformer();
 
   useEffect(() => {
     setValue(name, value);
   }, [name, value, setValue]);
 
+  const forcedValueDescription = statement?.description || description;
+  const forcedValueTitle = statement?.title
+    ? sanitizeHtml(statement.title)
+    : sanitizeHtml(label);
+
+  // A forced value with no title and no description has nothing to show the user, so we
+  // skip rendering entirely (the value is still set on the form via the effect above).
   const isHiddenValue = !forcedValueDescription && !statement?.title;
 
   if (isHiddenValue) {
     return null;
   }
 
+  const Component = components?.forcedValue;
+
+  if (!Component) {
+    throw new Error(`Forced value component not found for field ${name}`);
+  }
+
   return (
-    <div
-      role='group'
-      aria-labelledby={forcedValueTitle ? titleId : undefined}
-      aria-describedby={forcedValueDescription ? descriptionId : undefined}
-    >
-      {forcedValueTitle && (
-        <p
-          id={titleId}
-          className={`text-sm RemoteFlows__ForcedValue__Title__${name}`}
-          dangerouslySetInnerHTML={{
-            __html: forcedValueTitle,
-          }}
-        />
-      )}
-      <Description
-        as='span'
-        id={descriptionId}
-        className={`text-xs RemoteFlows__ForcedValue__Description__${name}`}
-        helpCenter={
-          <HelpCenter
-            className='RemoteFlows__ForcedValue__HelpCenterLink'
-            helpCenter={helpCenter}
-          />
-        }
-      >
-        {forcedValueDescription}
-      </Description>
-    </div>
+    <Component
+      fieldData={{
+        name,
+        value,
+        title: forcedValueTitle,
+        description: forcedValueDescription,
+        meta: { helpCenter },
+        transformHtml,
+      }}
+    />
   );
 }

--- a/src/components/form/fields/default/ForcedValueFieldDefault.tsx
+++ b/src/components/form/fields/default/ForcedValueFieldDefault.tsx
@@ -1,0 +1,43 @@
+import { ForcedValueComponentProps } from '@/src/types/fields';
+import { BaseFormDescription as Description } from '@/src/components/ui/form';
+import { HelpCenter } from '@/src/components/shared/zendesk-drawer/HelpCenter';
+
+export function ForcedValueFieldDefault({
+  fieldData,
+}: ForcedValueComponentProps) {
+  const { name, title, description, meta } = fieldData;
+
+  const titleId = `forced-value-${name}-title`;
+  const descriptionId = `forced-value-${name}-description`;
+
+  return (
+    <div
+      role='group'
+      aria-labelledby={title ? titleId : undefined}
+      aria-describedby={description ? descriptionId : undefined}
+    >
+      {title && (
+        <p
+          id={titleId}
+          className={`text-sm RemoteFlows__ForcedValue__Title__${name}`}
+          dangerouslySetInnerHTML={{
+            __html: title,
+          }}
+        />
+      )}
+      <Description
+        as='span'
+        id={descriptionId}
+        className={`text-xs RemoteFlows__ForcedValue__Description__${name}`}
+        helpCenter={
+          <HelpCenter
+            className='RemoteFlows__ForcedValue__HelpCenterLink'
+            helpCenter={meta?.helpCenter}
+          />
+        }
+      >
+        {description}
+      </Description>
+    </div>
+  );
+}

--- a/src/components/form/fields/default/tests/ForcedValueFieldDefault.test.tsx
+++ b/src/components/form/fields/default/tests/ForcedValueFieldDefault.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { ForcedValueFieldDefault } from '../ForcedValueFieldDefault';
+import { ForcedValueDataProps } from '@/src/types/fields';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+
+vi.mock('@/src/components/shared/zendesk-drawer/ZendeskTriggerButton', () => ({
+  ZendeskTriggerButton: ({ zendeskId, children, className }: $TSFixMe) => (
+    <button className={className} data-testid={`zendesk-button-${zendeskId}`}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('ForcedValueFieldDefault Component', () => {
+  const defaultFieldData: ForcedValueDataProps = {
+    name: 'testField',
+    value: 'forced-value',
+    title: 'Test Label',
+    description: 'This is a test description',
+  };
+
+  it('renders the resolved title and description', () => {
+    render(<ForcedValueFieldDefault fieldData={defaultFieldData} />);
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('This is a test description')).toBeInTheDocument();
+  });
+
+  it('renders HTML content in the title using dangerouslySetInnerHTML', () => {
+    render(
+      <ForcedValueFieldDefault
+        fieldData={{
+          ...defaultFieldData,
+          title: '<strong>Bold Title</strong>',
+        }}
+      />,
+    );
+
+    const titleElement = screen.getByText('Bold Title');
+    expect(titleElement.tagName).toBe('STRONG');
+  });
+
+  it('renders the help center link from meta', () => {
+    render(
+      <ForcedValueFieldDefault
+        fieldData={{
+          ...defaultFieldData,
+          meta: {
+            helpCenter: {
+              callToAction: 'Learn more',
+              id: 12345,
+              content: '<p>Details</p>',
+              title: 'Details',
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Learn more')).toBeInTheDocument();
+  });
+});

--- a/src/components/form/fields/tests/ForcedValueField.test.tsx
+++ b/src/components/form/fields/tests/ForcedValueField.test.tsx
@@ -1,6 +1,17 @@
+import { useFormFields } from '@/src/context';
 import { render, screen } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ForcedValueField, ForcedValueFieldProps } from '../ForcedValueField';
+import { ForcedValueFieldDefault } from '@/src/components/form/fields/default/ForcedValueFieldDefault';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+
+vi.mock('@/src/context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/src/context')>();
+  return {
+    ...actual,
+    useFormFields: vi.fn(),
+  };
+});
 
 describe('ForcedValueField Component', () => {
   const defaultProps: ForcedValueFieldProps = {
@@ -10,10 +21,12 @@ describe('ForcedValueField Component', () => {
     label: 'Test Label',
   };
 
-  // Helper function to render the component with a form context
-  const renderWithFormContext = (props: ForcedValueFieldProps) => {
+  const renderWithFormContext = (
+    props: ForcedValueFieldProps,
+    setValue = vi.fn(),
+  ) => {
     const TestComponent = () => {
-      const methods = useForm();
+      const methods = { ...useForm(), setValue };
       return (
         <FormProvider {...methods}>
           <ForcedValueField {...props} />
@@ -21,261 +34,91 @@ describe('ForcedValueField Component', () => {
       );
     };
 
-    return render(<TestComponent />);
+    return { setValue, ...render(<TestComponent />) };
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('when statement is not provided', () => {
-    it('renders only the label and description', () => {
-      renderWithFormContext(defaultProps);
-
-      expect(
-        screen.getByText('This is a test description'),
-      ).toBeInTheDocument();
-      expect(screen.getByText('Test Label')).toBeInTheDocument();
+    (useFormFields as $TSFixMe).mockReturnValue({
+      components: { forcedValue: ForcedValueFieldDefault },
     });
   });
 
-  describe('when statement is provided with title', () => {
-    const propsWithStatement: ForcedValueFieldProps = {
+  it('sets the form value using setValue from useFormContext', () => {
+    const { setValue } = renderWithFormContext(defaultProps);
+
+    expect(setValue).toHaveBeenCalledWith('testField', 'forced-value');
+  });
+
+  it('renders the resolved label and description via the registered component', () => {
+    renderWithFormContext(defaultProps);
+
+    expect(screen.getByText('This is a test description')).toBeInTheDocument();
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+  });
+
+  it('falls back to label/description when statement fields are undefined', () => {
+    renderWithFormContext({
+      ...defaultProps,
+      statement: { title: undefined, description: undefined },
+    });
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('This is a test description')).toBeInTheDocument();
+  });
+
+  it('prioritizes statement title/description over label/description', () => {
+    renderWithFormContext({
       ...defaultProps,
       statement: {
         title: 'Statement Title',
         description: 'Statement Description',
       },
-    };
-
-    it('renders statement title and description', () => {
-      renderWithFormContext(propsWithStatement);
-
-      expect(screen.getByText('Statement Title')).toBeInTheDocument();
-      expect(screen.getByText('Statement Description')).toBeInTheDocument();
-      expect(
-        screen.queryByText('This is a test description'),
-      ).not.toBeInTheDocument();
     });
+
+    expect(screen.getByText('Statement Title')).toBeInTheDocument();
+    expect(screen.getByText('Statement Description')).toBeInTheDocument();
+    expect(
+      screen.queryByText('This is a test description'),
+    ).not.toBeInTheDocument();
   });
 
-  describe('when statement is provided but title is undefined', () => {
-    const propsWithStatementNoTitle: ForcedValueFieldProps = {
-      ...defaultProps,
-      statement: {
-        title: undefined,
-        description: 'Statement Description',
-      },
-    };
+  it('renders a custom forcedValue component when provided', () => {
+    const CustomForcedValue = vi
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid='custom-forced-value'>Custom Forced Value</div>
+      ));
 
-    it('falls back to label when statement.title is undefined', () => {
-      renderWithFormContext(propsWithStatementNoTitle);
-
-      expect(screen.getByText('Test Label')).toBeInTheDocument();
-      expect(screen.getByText('Statement Description')).toBeInTheDocument();
+    (useFormFields as $TSFixMe).mockReturnValue({
+      components: { forcedValue: CustomForcedValue },
     });
+
+    renderWithFormContext(defaultProps);
+
+    expect(CustomForcedValue).toHaveBeenCalled();
+    expect(screen.getByTestId('custom-forced-value')).toBeInTheDocument();
   });
 
-  describe('when statement is provided but title is empty string', () => {
-    const propsWithEmptyTitle: ForcedValueFieldProps = {
-      ...defaultProps,
-      statement: {
-        title: '',
-        description: 'Statement Description',
-      },
-    };
+  describe('when there is nothing to show', () => {
+    it('still sets the form value but renders nothing, without requiring a registered component', () => {
+      (useFormFields as $TSFixMe).mockReturnValue({ components: {} });
 
-    it('falls back to label when statement.title is empty string', () => {
-      renderWithFormContext(propsWithEmptyTitle);
-
-      expect(screen.getByText('Test Label')).toBeInTheDocument();
-      expect(screen.getByText('Statement Description')).toBeInTheDocument();
-    });
-  });
-
-  describe('when statement is provided but description is undefined', () => {
-    const propsWithUndefinedDescription: ForcedValueFieldProps = {
-      ...defaultProps,
-      statement: {
-        title: 'Test Label',
-        description: undefined,
-      },
-    };
-
-    it('falls back to description', () => {
-      renderWithFormContext(propsWithUndefinedDescription);
-
-      expect(screen.getByText('Test Label')).toBeInTheDocument();
-      expect(
-        screen.getByText('This is a test description'),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe('HTML content rendering', () => {
-    it('renders HTML content in statement title using dangerouslySetInnerHTML', () => {
-      const propsWithHtmlTitle: ForcedValueFieldProps = {
-        ...defaultProps,
-        statement: {
-          title: '<strong>Bold Title</strong>',
-          description: 'Statement Description',
-        },
-      };
-
-      renderWithFormContext(propsWithHtmlTitle);
-
-      const titleElement = screen.getByText('Bold Title');
-      expect(titleElement.tagName).toBe('STRONG');
-    });
-
-    it('renders HTML content in statement description using dangerouslySetInnerHTML', () => {
-      const propsWithHtmlDescription: ForcedValueFieldProps = {
-        ...defaultProps,
-        statement: {
-          title: 'Statement Title',
-          description: '<em>Italic Description</em>',
-        },
-      };
-
-      renderWithFormContext(propsWithHtmlDescription);
-
-      const descriptionElement = screen.getByText('Italic Description');
-      expect(descriptionElement.tagName).toBe('EM');
-    });
-
-    it('renders HTML content in fallback description using dangerouslySetInnerHTML', () => {
-      const propsWithHtmlFallbackDescription: ForcedValueFieldProps = {
-        ...defaultProps,
-        description: '<u>Underlined Description</u>',
-      };
-
-      renderWithFormContext(propsWithHtmlFallbackDescription);
-
-      const descriptionElement = screen.getByText('Underlined Description');
-      expect(descriptionElement.tagName).toBe('U');
-    });
-
-    it('renders HTML content in label fallback using dangerouslySetInnerHTML', () => {
-      const propsWithHtmlLabel: ForcedValueFieldProps = {
-        ...defaultProps,
-        label: '<span>Span Label</span>',
-        statement: {
-          title: '', // Empty title to trigger fallback
-          description: 'Statement Description',
-        },
-      };
-
-      renderWithFormContext(propsWithHtmlLabel);
-
-      const labelElement = screen.getByText('Span Label');
-      expect(labelElement.tagName).toBe('SPAN');
-    });
-  });
-
-  describe('form integration', () => {
-    it('sets the form value using setValue from useFormContext', () => {
-      const mockSetValue = vi.fn();
-
-      const TestComponent = () => {
-        const methods = {
-          ...useForm(),
-          setValue: mockSetValue,
-        };
-        return (
-          <FormProvider {...methods}>
-            <ForcedValueField {...defaultProps} />
-          </FormProvider>
-        );
-      };
-
-      render(<TestComponent />);
-
-      expect(mockSetValue).toHaveBeenCalledWith('testField', 'forced-value');
-    });
-
-    it('still sets form value even when field is hidden (no description and no title)', () => {
-      const mockSetValue = vi.fn();
-
-      const TestComponent = () => {
-        const methods = {
-          ...useForm(),
-          setValue: mockSetValue,
-        };
-        return (
-          <FormProvider {...methods}>
-            <ForcedValueField
-              name='testField'
-              value='forced-value'
-              description=''
-              label='Test Label'
-            />
-          </FormProvider>
-        );
-      };
-
-      render(<TestComponent />);
-
-      expect(mockSetValue).toHaveBeenCalledWith('testField', 'forced-value');
-    });
-  });
-
-  describe('edge cases for statement title fallback', () => {
-    it('handles statement with only description property', () => {
-      const propsWithDescriptionOnly: ForcedValueFieldProps = {
-        ...defaultProps,
-        statement: {
-          description: 'Only description provided',
-        },
-      };
-
-      renderWithFormContext(propsWithDescriptionOnly);
-
-      expect(screen.getByText('Test Label')).toBeInTheDocument();
-      expect(screen.getByText('Only description provided')).toBeInTheDocument();
-    });
-
-    it('prioritizes statement.title over label when title is truthy', () => {
-      const propsWithBothTitleAndLabel: ForcedValueFieldProps = {
-        ...defaultProps,
-        label: 'Should Not Appear',
-        statement: {
-          title: 'Should Appear',
-          description: 'Statement Description',
-        },
-      };
-
-      renderWithFormContext(propsWithBothTitleAndLabel);
-
-      expect(screen.getByText('Should Appear')).toBeInTheDocument();
-      expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('when component returns null (no rendering)', () => {
-    it('returns null when description is empty and no statement provided', () => {
-      const props: ForcedValueFieldProps = {
+      const { setValue, container } = renderWithFormContext({
         ...defaultProps,
         description: '',
-      };
+      });
 
-      const { container } = renderWithFormContext(props);
-
+      expect(setValue).toHaveBeenCalledWith('testField', 'forced-value');
       expect(container.firstChild).toBeNull();
     });
+  });
 
-    it('returns null when both descriptions are empty and statement.title is empty', () => {
-      const props: ForcedValueFieldProps = {
-        ...defaultProps,
-        description: '',
-        statement: {
-          title: '',
-          description: '',
-        },
-      };
+  it('throws when no forcedValue component is registered and there is content to show', () => {
+    (useFormFields as $TSFixMe).mockReturnValue({ components: {} });
 
-      const { container } = renderWithFormContext(props);
-
-      expect(container.firstChild).toBeNull();
-    });
+    expect(() => renderWithFormContext(defaultProps)).toThrow(
+      'Forced value component not found for field testField',
+    );
   });
 });

--- a/src/default-components.ts
+++ b/src/default-components.ts
@@ -1,5 +1,6 @@
 import { Components } from '@/src/types/remoteFlows';
 import { FileUploadFieldDefault } from '@/src/components/form/fields/default/FileUploadFieldDefault';
+import { ForcedValueFieldDefault } from '@/src/components/form/fields/default/ForcedValueFieldDefault';
 import { TextAreaFieldDefault } from '@/src/components/form/fields/default/TextAreaFieldDefault';
 import { SelectFieldDefault } from '@/src/components/form/fields/default/SelectFieldDefault';
 import { CountryFieldDefault } from '@/src/components/form/fields/default/CountryFieldDefault';
@@ -36,6 +37,7 @@ export const defaultComponents: Components = {
   email: EmailFieldDefault,
   fieldsetToggle: FieldsetToggleButtonDefault,
   file: FileUploadFieldDefault,
+  forcedValue: ForcedValueFieldDefault,
   // TODO: we have doubts multi-select, it's actually used
   'multi-select': MultiSelectFieldDefault,
   number: NumberFieldDefault,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -162,6 +162,7 @@ export type {
   FileComponentProps,
   CountryComponentProps,
   StatementComponentProps,
+  ForcedValueComponentProps,
   TextFieldComponentProps,
   DatePickerComponentProps,
   WorkScheduleComponentProps,

--- a/src/lazy-default-components.ts
+++ b/src/lazy-default-components.ts
@@ -60,6 +60,13 @@ export const lazyDefaultComponents: Components = {
       }),
     ),
   ),
+  forcedValue: lazy(() =>
+    import('./components/form/fields/default/ForcedValueFieldDefault').then(
+      (m) => ({
+        default: m.ForcedValueFieldDefault,
+      }),
+    ),
+  ),
   'multi-select': lazy(() =>
     import('./components/form/fields/default/MultiSelectFieldDefault').then(
       (m) => ({

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -148,6 +148,27 @@ export type StatementComponentProps = {
   };
 };
 
+/**
+ * Data passed to custom forced value components.
+ * Forced value fields display a non-editable value that is automatically set on the form
+ * (via `const`), typically rendered as informational text (e.g. a statement-like description).
+ *
+ * `title` and `description` are already resolved (statement overrides falling back to
+ * label/description) and sanitized where applicable, so custom components don't need to
+ * reimplement that fallback logic themselves.
+ */
+export type ForcedValueDataProps = FieldDataProps & {
+  value: string;
+  title?: string;
+};
+
+/**
+ * Props for custom forced value components.
+ */
+export type ForcedValueComponentProps = {
+  fieldData: ForcedValueDataProps;
+};
+
 export type PricingPlanDataProps = Omit<Partial<JSFField>, 'options'> & {
   metadata?: Record<string, unknown>;
   meta?: {

--- a/src/types/remoteFlows.ts
+++ b/src/types/remoteFlows.ts
@@ -10,6 +10,7 @@ import {
   DatePickerComponentProps,
   FieldComponentProps,
   FileComponentProps,
+  ForcedValueComponentProps,
   StatementComponentProps,
   TextFieldComponentProps,
   WorkScheduleComponentProps,
@@ -151,6 +152,7 @@ export type Components = {
   date?: React.ComponentType<DatePickerComponentProps>;
   countries?: React.ComponentType<CountryComponentProps>;
   statement?: React.ComponentType<StatementComponentProps>;
+  forcedValue?: React.ComponentType<ForcedValueComponentProps>;
   button?: React.ComponentType<ButtonComponentProps>;
   fieldsetToggle?: React.ComponentType<FieldSetToggleComponentProps>;
   zendeskDrawer?: React.ComponentType<ZendeskDrawerComponentProps>;


### PR DESCRIPTION
We're trying to do something with a previous feature called transformHTMLToComponents but the problem is partners don't have control about ForceValueField render

We make a refactor to be able to control what we render, we don't break current functionality as if they don't use the new forceValueField the default will be loaded



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-layer refactor with preserved form `setValue` behavior; risk is mainly integrators who override `components` without supplying `forcedValue` when visible forced-value fields exist.
> 
> **Overview**
> **Forced value fields** can now be customized through the SDK’s `components` map, matching other overridable field types.
> 
> `ForcedValueField` still writes the const value into react-hook-form and resolves title/description (statement overrides, sanitized HTML, help center meta, `transformHtml`). It no longer renders UI directly; when there is content to show it delegates to `components.forcedValue` and throws if none is registered. Hidden fields (no title/description) still set the value and render nothing without needing a component.
> 
> The previous default markup (ARIA group, title HTML, description + HelpCenter) lives in **`ForcedValueFieldDefault`**, wired into `defaultComponents`, lazy defaults, and the example app’s `ForcedValue` sample. **`ForcedValueComponentProps`** / **`ForcedValueDataProps`** are exported for integrators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f3c80c735b1a27df9b530e00268ffaa73c1d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->