### PR TITLE
fix(onboarding-example) - fix login field jsfModify

### DIFF
--- a/example/src/flows/Onboarding/constants.ts
+++ b/example/src/flows/Onboarding/constants.ts
@@ -1,3 +1,5 @@
+import { JSFModifyField } from '@remoteoss/remote-flows';
+
 export const ONBOARDING_OPTIONS = {
   features: [
     'onboarding_reserves',
@@ -117,6 +119,24 @@ export const ONBOARDING_OPTIONS = {
     USA: {
       // United States
       contract_details: 3,
+    },
+  },
+  jsfModify: {
+    basic_information: {
+      fields: {
+        // Use a function to modify a single option in place instead of
+        // hardcoding the full options list (labels/values you don't own).
+        login_email: (field: JSFModifyField) => ({
+          'x-jsf-presentation': {
+            options: field['x-jsf-presentation']?.options?.map(
+              (option: { value: string }) =>
+                option.value === 'work'
+                  ? { ...option, description: 'Select...' }
+                  : option,
+            ),
+          },
+        }),
+      },
     },
   },
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Example-app presentation tweak only; no auth, API, or data-path changes.
> 
> **Overview**
> **Centralizes onboarding `login_email` JSF customization** in `ONBOARDING_OPTIONS` so every onboarding demo that spreads these options gets the same behavior.
> 
> Adds a **function-style `jsfModify`** on `basic_information.login_email` that maps existing presentation options and only overrides the **`work`** choice’s `description` to `Select...`, instead of replacing the full options list. Imports `JSFModifyField` from `@remoteoss/remote-flows` for typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5052dd36743df0f9dd1c70041e95179ec427bfb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->