### PR TITLE
1.47.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,25 @@
 
 ### Patch Changes
 
+#### Docs
+
+- add docs about v4 (#1231) [#1231](https://github.com/remoteoss/remote-flows/pull/1231)
+- fix field description (#1232) [#1232](https://github.com/remoteoss/remote-flows/pull/1232)
+- fix login field jsfModify (#1239) [#1239](https://github.com/remoteoss/remote-flows/pull/1239)
+- make force value a component that devs can override (#1238) [#1238](https://github.com/remoteoss/remote-flows/pull/1238)
+
+#### Chores
+
 - update dependency oxfmt to v0.61.0 (#1221) [#1221](https://github.com/remoteoss/remote-flows/pull/1221)
 - update dependency oxlint to v1.76.0 (#1223) [#1223](https://github.com/remoteoss/remote-flows/pull/1223)
 - update dependency vite to v8.1.5 (#1225) [#1225](https://github.com/remoteoss/remote-flows/pull/1225)
 - update dependency tsx to v4.23.1 (#1224) [#1224](https://github.com/remoteoss/remote-flows/pull/1224)
 - update dependency axios to v1.19.0
 - update schneegans/dynamic-badges-action action to v1.9.0 (#1229) [#1229](https://github.com/remoteoss/remote-flows/pull/1229)
-- add docs about v4 (#1231) [#1231](https://github.com/remoteoss/remote-flows/pull/1231)
 - update dependency @playwright/test to v1.62.1 (#1233) [#1233](https://github.com/remoteoss/remote-flows/pull/1233)
 - update dependency dompurify to v3.4.13 [security] (#1234) [#1234](https://github.com/remoteoss/remote-flows/pull/1234)
-- fix field description (#1232) [#1232](https://github.com/remoteoss/remote-flows/pull/1232)
 - update dependency @vitejs/plugin-react to v6.0.5 (#1235) [#1235](https://github.com/remoteoss/remote-flows/pull/1235)
 - update dependency tsx to v4.23.5 (#1236) [#1236](https://github.com/remoteoss/remote-flows/pull/1236)
-- fix login field jsfModify (#1239) [#1239](https://github.com/remoteoss/remote-flows/pull/1239)
-- make force value a component that devs can override (#1238) [#1238](https://github.com/remoteoss/remote-flows/pull/1238)
 
 ## 1.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @remoteoss/remote-flows
 
+## 1.47.1
+
+### Patch Changes
+
+- update dependency oxfmt to v0.61.0 (#1221) [#1221](https://github.com/remoteoss/remote-flows/pull/1221)
+- update dependency oxlint to v1.76.0 (#1223) [#1223](https://github.com/remoteoss/remote-flows/pull/1223)
+- update dependency vite to v8.1.5 (#1225) [#1225](https://github.com/remoteoss/remote-flows/pull/1225)
+- update dependency tsx to v4.23.1 (#1224) [#1224](https://github.com/remoteoss/remote-flows/pull/1224)
+- update dependency axios to v1.19.0
+- update schneegans/dynamic-badges-action action to v1.9.0 (#1229) [#1229](https://github.com/remoteoss/remote-flows/pull/1229)
+- add docs about v4 (#1231) [#1231](https://github.com/remoteoss/remote-flows/pull/1231)
+- update dependency @playwright/test to v1.62.1 (#1233) [#1233](https://github.com/remoteoss/remote-flows/pull/1233)
+- update dependency dompurify to v3.4.13 [security] (#1234) [#1234](https://github.com/remoteoss/remote-flows/pull/1234)
+- fix field description (#1232) [#1232](https://github.com/remoteoss/remote-flows/pull/1232)
+- update dependency @vitejs/plugin-react to v6.0.5 (#1235) [#1235](https://github.com/remoteoss/remote-flows/pull/1235)
+- update dependency tsx to v4.23.5 (#1236) [#1236](https://github.com/remoteoss/remote-flows/pull/1236)
+- fix login field jsfModify (#1239) [#1239](https://github.com/remoteoss/remote-flows/pull/1239)
+- make force value a component that devs can override (#1238) [#1238](https://github.com/remoteoss/remote-flows/pull/1238)
+
 ## 1.47.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.47.0",
+      "version": "1.47.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",
@@ -1764,9 +1764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1784,9 +1781,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1804,9 +1798,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1824,9 +1815,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1844,9 +1832,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,9 +1849,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1884,9 +1866,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1883,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2111,9 +2087,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2131,9 +2104,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2151,9 +2121,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2171,9 +2138,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,9 +2155,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2211,9 +2172,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2231,9 +2189,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2251,9 +2206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.47.1

### Patch Changes

#### Docs

- add docs about v4 (#1231) [#1231](https://github.com/remoteoss/remote-flows/pull/1231)
- fix field description (#1232) [#1232](https://github.com/remoteoss/remote-flows/pull/1232)
- fix login field jsfModify (#1239) [#1239](https://github.com/remoteoss/remote-flows/pull/1239)
- make force value a component that devs can override (#1238) [#1238](https://github.com/remoteoss/remote-flows/pull/1238)

#### Chores

- update dependency oxfmt to v0.61.0 (#1221) [#1221](https://github.com/remoteoss/remote-flows/pull/1221)
- update dependency oxlint to v1.76.0 (#1223) [#1223](https://github.com/remoteoss/remote-flows/pull/1223)
- update dependency vite to v8.1.5 (#1225) [#1225](https://github.com/remoteoss/remote-flows/pull/1225)
- update dependency tsx to v4.23.1 (#1224) [#1224](https://github.com/remoteoss/remote-flows/pull/1224)
- update dependency axios to v1.19.0
- update schneegans/dynamic-badges-action action to v1.9.0 (#1229) [#1229](https://github.com/remoteoss/remote-flows/pull/1229)
- update dependency @playwright/test to v1.62.1 (#1233) [#1233](https://github.com/remoteoss/remote-flows/pull/1233)
- update dependency dompurify to v3.4.13 [security] (#1234) [#1234](https://github.com/remoteoss/remote-flows/pull/1234)
- update dependency @vitejs/plugin-react to v6.0.5 (#1235) [#1235](https://github.com/remoteoss/remote-flows/pull/1235)
- update dependency tsx to v4.23.5 (#1236) [#1236](https://github.com/remoteoss/remote-flows/pull/1236)

---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and dependency lock refresh only; no application code changes in this PR.
> 
> **Overview**
> **Release 1.47.1** — bumps `@remoteoss/remote-flows` from **1.47.0** to **1.47.1** in `package.json` and `package-lock.json`, and adds the **1.47.1** changelog entry.
> 
> The changelog documents patch work already merged elsewhere: **docs** (v4 docs, field description, login field `jsfModify`, overridable force-value component) and **chores** (tooling bumps including Vite 8, Playwright, DOMPurify security update, oxfmt/oxlint, axios, CI action). The lockfile diff also drops `libc` metadata on several optional `@oxfmt` / `@oxlint` Linux binding packages—lockfile housekeeping, not application logic.
> 
> There is **no runtime source change** in this diff; it is a version-and-release-notes cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa9466d0eb2639c11155573c20d8638319ea487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->