### PR TITLE
fix(files) - preserve already-uploaded file references instead of re-encoding them

### DIFF
--- a/src/components/form/fields/FileUploadField.tsx
+++ b/src/components/form/fields/FileUploadField.tsx
@@ -6,17 +6,14 @@ import {
   useFormContext,
 } from 'react-hook-form';
 import { FormField } from '../../ui/form';
-import { FieldDataProps, UploadedFileReference } from '@/src/types/fields';
+import { FieldDataProps } from '@/src/types/fields';
 
-type FieldFile = File | UploadedFileReference;
-
-const validateFileSize = (
-  files: FieldFile[],
-  maxSize?: number,
-): string | null => {
+const validateFileSize = (files: File[], maxSize?: number): string | null => {
   if (!maxSize) return null;
 
   for (const file of files) {
+    // `file` may not be a real File at runtime (e.g. an already-uploaded reference mixed in
+    // via a multi-file field) even though the public type says otherwise — guard defensively.
     if (file instanceof File && file.size > maxSize) {
       const maxSizeMB = Math.round(maxSize / (1024 * 1024));
       const fileSizeMB = Math.round(file.size / (1024 * 1024));
@@ -33,7 +30,7 @@ export type FieldFileDataProps = FieldDataProps & {
 };
 
 export type FileUploadFieldProps = JSFField & {
-  onChange?: (value: FieldFile[]) => void;
+  onChange?: (value: File[]) => void;
   multiple?: boolean;
   component?: Components['file'];
   maxSize?: number;
@@ -56,7 +53,7 @@ export function FileUploadField({
   const transformHtml = useTransformer();
 
   const handleOnChange = async (
-    files: FieldFile[],
+    files: File[],
     field: ControllerRenderProps<FieldValues, string>,
   ) => {
     const sizeError = validateFileSize(files, maxSize);
@@ -96,8 +93,7 @@ export function FileUploadField({
             field={{
               ...field,
               value: field.value,
-              onChange: async (value: FieldFile[]) =>
-                handleOnChange(value, field),
+              onChange: async (value: File[]) => handleOnChange(value, field),
             }}
             fieldState={fieldState}
             fieldData={customFileUploadFieldProps}

--- a/src/components/form/fields/FileUploadField.tsx
+++ b/src/components/form/fields/FileUploadField.tsx
@@ -6,13 +6,18 @@ import {
   useFormContext,
 } from 'react-hook-form';
 import { FormField } from '../../ui/form';
-import { FieldDataProps } from '@/src/types/fields';
+import { FieldDataProps, UploadedFileReference } from '@/src/types/fields';
 
-const validateFileSize = (files: File[], maxSize?: number): string | null => {
+type FieldFile = File | UploadedFileReference;
+
+const validateFileSize = (
+  files: FieldFile[],
+  maxSize?: number,
+): string | null => {
   if (!maxSize) return null;
 
   for (const file of files) {
-    if (file.size > maxSize) {
+    if (file instanceof File && file.size > maxSize) {
       const maxSizeMB = Math.round(maxSize / (1024 * 1024));
       const fileSizeMB = Math.round(file.size / (1024 * 1024));
       return `File "${file.name}" exceeds maximum size of ${maxSizeMB}MB (file is ${fileSizeMB}MB)`;
@@ -28,7 +33,7 @@ export type FieldFileDataProps = FieldDataProps & {
 };
 
 export type FileUploadFieldProps = JSFField & {
-  onChange?: (value: File[]) => void;
+  onChange?: (value: FieldFile[]) => void;
   multiple?: boolean;
   component?: Components['file'];
   maxSize?: number;
@@ -51,7 +56,7 @@ export function FileUploadField({
   const transformHtml = useTransformer();
 
   const handleOnChange = async (
-    files: File[],
+    files: FieldFile[],
     field: ControllerRenderProps<FieldValues, string>,
   ) => {
     const sizeError = validateFileSize(files, maxSize);
@@ -91,7 +96,8 @@ export function FileUploadField({
             field={{
               ...field,
               value: field.value,
-              onChange: async (value: File[]) => handleOnChange(value, field),
+              onChange: async (value: FieldFile[]) =>
+                handleOnChange(value, field),
             }}
             fieldState={fieldState}
             fieldData={customFileUploadFieldProps}

--- a/src/components/form/utils.ts
+++ b/src/components/form/utils.ts
@@ -4,6 +4,7 @@ import { JSFFields } from '@/src/types/remoteFlows';
 import { convertFilesToBase64 } from '@/src/lib/files';
 import { addBusinessDays, isWeekend, nextMonday } from 'date-fns';
 import { getNestedValue } from '@/src/lib/utils';
+import { UploadedFileReference } from '@/src/types/fields';
 
 const textInputTypes = {
   TEXT: 'text',
@@ -278,13 +279,14 @@ export const fieldTypesTransformations: Record<string, $TSFixMe> = {
         : (option?.value ?? ''), // Fallback to '' in case user removes all options,
   },
   [supportedTypes.FILE]: {
-    transformValueToAPI: () => async (files: File[]) => {
-      if (!files) {
-        return null;
-      }
+    transformValueToAPI:
+      () => async (files: (File | UploadedFileReference)[]) => {
+        if (!files) {
+          return null;
+        }
 
-      return await convertFilesToBase64(files);
-    },
+        return await convertFilesToBase64(files);
+      },
   },
 };
 export async function parseFormValuesToAPI(

--- a/src/components/ui/file-uploader.tsx
+++ b/src/components/ui/file-uploader.tsx
@@ -2,9 +2,6 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/src/components/ui/button';
 import { Upload, X } from 'lucide-react';
 import { cn } from '@/src/lib/utils';
-import { UploadedFileReference } from '@/src/types/fields';
-
-type UploaderFile = File | UploadedFileReference;
 
 // Convert accept string to readable format (e.g., ".pdf, .doc" -> "PDF, DOC")
 const getAcceptedFormats = (accept?: string) => {
@@ -16,11 +13,11 @@ const getAcceptedFormats = (accept?: string) => {
 };
 
 type FileUploaderProps = {
-  onChange: (files: UploaderFile[]) => void;
+  onChange: (files: File[]) => void;
   className?: string;
   multiple?: boolean;
   accept?: string;
-  files?: UploaderFile[];
+  files?: File[];
   id?: string;
 };
 
@@ -32,9 +29,9 @@ export function FileUploader({
   files: externalFiles,
   id,
 }: FileUploaderProps) {
-  const syncedRef = useRef<UploaderFile[] | undefined>(undefined);
+  const syncedRef = useRef<File[] | undefined>(undefined);
 
-  const [files, setFiles] = useState<UploaderFile[]>(externalFiles || []);
+  const [files, setFiles] = useState<File[]>(externalFiles || []);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -54,13 +51,19 @@ export function FileUploader({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       const newFiles = Array.from(e.target.files);
+      // `multiple` unset keeps the historical accumulate-across-selections behavior. Only an
+      // explicit `multiple={false}` (as opposed to just not passing the prop) opts a field out
+      // of that and replaces its selection instead — see the discussion on why this can't be
+      // `!multiple` without reverting the field's own past "preserve existing files" fix.
+      const updatedFiles =
+        multiple === false ? newFiles : [...files, ...newFiles];
 
-      setFiles([...files, ...newFiles]);
-      onChange([...files, ...newFiles]);
+      setFiles(updatedFiles);
+      onChange(updatedFiles);
     }
   };
 
-  const onRemoveFile = (file: UploaderFile) => {
+  const onRemoveFile = (file: File) => {
     setFiles((prevFiles) => prevFiles.filter((f) => f.name !== file.name));
     onChange(files.filter((f) => f.name !== file.name));
   };

--- a/src/components/ui/file-uploader.tsx
+++ b/src/components/ui/file-uploader.tsx
@@ -2,6 +2,9 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/src/components/ui/button';
 import { Upload, X } from 'lucide-react';
 import { cn } from '@/src/lib/utils';
+import { UploadedFileReference } from '@/src/types/fields';
+
+type UploaderFile = File | UploadedFileReference;
 
 // Convert accept string to readable format (e.g., ".pdf, .doc" -> "PDF, DOC")
 const getAcceptedFormats = (accept?: string) => {
@@ -13,11 +16,11 @@ const getAcceptedFormats = (accept?: string) => {
 };
 
 type FileUploaderProps = {
-  onChange: (files: File[]) => void;
+  onChange: (files: UploaderFile[]) => void;
   className?: string;
   multiple?: boolean;
   accept?: string;
-  files?: File[];
+  files?: UploaderFile[];
   id?: string;
 };
 
@@ -29,9 +32,9 @@ export function FileUploader({
   files: externalFiles,
   id,
 }: FileUploaderProps) {
-  const syncedRef = useRef<File[] | undefined>(undefined);
+  const syncedRef = useRef<UploaderFile[] | undefined>(undefined);
 
-  const [files, setFiles] = useState<File[]>(externalFiles || []);
+  const [files, setFiles] = useState<UploaderFile[]>(externalFiles || []);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -57,7 +60,7 @@ export function FileUploader({
     }
   };
 
-  const onRemoveFile = (file: File) => {
+  const onRemoveFile = (file: UploaderFile) => {
     setFiles((prevFiles) => prevFiles.filter((f) => f.name !== file.name));
     onChange(files.filter((f) => f.name !== file.name));
   };
@@ -100,8 +103,8 @@ export function FileUploader({
       {files.length > 0 &&
         files.map((file, index) => (
           <div key={index} className='text-sm flex items-center gap-2'>
-            Selected file: <span className='font-medium'>{file.name}</span> (
-            {Math.round(file.size / 1024)} KB)
+            Selected file: <span className='font-medium'>{file.name}</span>
+            {'size' in file && ` (${Math.round(file.size / 1024)} KB)`}
             <Button
               type='button'
               variant='ghost'

--- a/src/components/ui/tests/file-uploader.test.tsx
+++ b/src/components/ui/tests/file-uploader.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { FileUploader } from '@/src/components/ui/file-uploader';
 
+// `FileUploader`'s public `files`/`onChange` types stay `File[]` to avoid a breaking change for
+// consumers, but at runtime a field pre-populated from the API can hand it an already-uploaded
+// reference object instead. These tests deliberately pass that shape past the declared type to
+// cover the defensive runtime handling.
 describe('FileUploader', () => {
   it('renders an already-uploaded file reference by name without crashing', () => {
     const uploadedFile = {
@@ -8,7 +12,12 @@ describe('FileUploader', () => {
       id: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
     };
 
-    render(<FileUploader onChange={vi.fn()} files={[uploadedFile]} />);
+    render(
+      <FileUploader
+        onChange={vi.fn()}
+        files={[uploadedFile] as unknown as File[]}
+      />,
+    );
 
     expect(screen.getByText('cba_document.pdf')).toBeInTheDocument();
     expect(screen.queryByText(/KB\)/)).not.toBeInTheDocument();
@@ -31,7 +40,7 @@ describe('FileUploader', () => {
     render(
       <FileUploader
         onChange={onChange}
-        files={[uploadedFile, file]}
+        files={[uploadedFile, file] as unknown as File[]}
         multiple
       />,
     );
@@ -41,5 +50,60 @@ describe('FileUploader', () => {
     fireEvent.click(removeButtons[0]);
 
     expect(onChange).toHaveBeenCalledWith([file]);
+  });
+
+  it('replaces the current selection instead of appending when multiple is false', () => {
+    const onChange = vi.fn();
+    const existingFile = new File(['old'], 'old.pdf', {
+      type: 'application/pdf',
+    });
+    const newFile = new File(['new'], 'new.pdf', { type: 'application/pdf' });
+
+    render(
+      <FileUploader
+        onChange={onChange}
+        files={[existingFile]}
+        multiple={false}
+      />,
+    );
+
+    const fileInput = screen.getByLabelText('File upload');
+    fireEvent.change(fileInput, { target: { files: [newFile] } });
+
+    expect(onChange).toHaveBeenCalledWith([newFile]);
+    expect(screen.queryByText('old.pdf')).not.toBeInTheDocument();
+    expect(screen.getByText('new.pdf')).toBeInTheDocument();
+  });
+
+  it('accumulates files instead of replacing when multiple is true', () => {
+    const onChange = vi.fn();
+    const existingFile = new File(['old'], 'old.pdf', {
+      type: 'application/pdf',
+    });
+    const newFile = new File(['new'], 'new.pdf', { type: 'application/pdf' });
+
+    render(
+      <FileUploader onChange={onChange} files={[existingFile]} multiple />,
+    );
+
+    const fileInput = screen.getByLabelText('File upload');
+    fireEvent.change(fileInput, { target: { files: [newFile] } });
+
+    expect(onChange).toHaveBeenCalledWith([existingFile, newFile]);
+  });
+
+  it('accumulates files when multiple is left unset, for backward compatibility', () => {
+    const onChange = vi.fn();
+    const existingFile = new File(['old'], 'old.pdf', {
+      type: 'application/pdf',
+    });
+    const newFile = new File(['new'], 'new.pdf', { type: 'application/pdf' });
+
+    render(<FileUploader onChange={onChange} files={[existingFile]} />);
+
+    const fileInput = screen.getByLabelText('File upload');
+    fireEvent.change(fileInput, { target: { files: [newFile] } });
+
+    expect(onChange).toHaveBeenCalledWith([existingFile, newFile]);
   });
 });

--- a/src/components/ui/tests/file-uploader.test.tsx
+++ b/src/components/ui/tests/file-uploader.test.tsx
@@ -5,7 +5,7 @@ describe('FileUploader', () => {
   it('renders an already-uploaded file reference by name without crashing', () => {
     const uploadedFile = {
       name: 'cba_document.pdf',
-      slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
+      id: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
     };
 
     render(<FileUploader onChange={vi.fn()} files={[uploadedFile]} />);
@@ -25,7 +25,7 @@ describe('FileUploader', () => {
 
   it('calls onChange with the remaining files when removing an uploaded reference', () => {
     const onChange = vi.fn();
-    const uploadedFile = { name: 'cba_document.pdf', slug: 'existing-slug' };
+    const uploadedFile = { name: 'cba_document.pdf', id: 'existing-id' };
     const file = new File(['content'], 'new.pdf', { type: 'application/pdf' });
 
     render(

--- a/src/components/ui/tests/file-uploader.test.tsx
+++ b/src/components/ui/tests/file-uploader.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FileUploader } from '@/src/components/ui/file-uploader';
+
+describe('FileUploader', () => {
+  it('renders an already-uploaded file reference by name without crashing', () => {
+    const uploadedFile = {
+      name: 'cba_document.pdf',
+      slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
+    };
+
+    render(<FileUploader onChange={vi.fn()} files={[uploadedFile]} />);
+
+    expect(screen.getByText('cba_document.pdf')).toBeInTheDocument();
+    expect(screen.queryByText(/KB\)/)).not.toBeInTheDocument();
+  });
+
+  it('still shows the size for a newly selected File', () => {
+    const file = new File(['content'], 'new.pdf', { type: 'application/pdf' });
+
+    render(<FileUploader onChange={vi.fn()} files={[file]} />);
+
+    expect(screen.getByText('new.pdf')).toBeInTheDocument();
+    expect(screen.getByText(/KB\)/)).toBeInTheDocument();
+  });
+
+  it('calls onChange with the remaining files when removing an uploaded reference', () => {
+    const onChange = vi.fn();
+    const uploadedFile = { name: 'cba_document.pdf', slug: 'existing-slug' };
+    const file = new File(['content'], 'new.pdf', { type: 'application/pdf' });
+
+    render(
+      <FileUploader
+        onChange={onChange}
+        files={[uploadedFile, file]}
+        multiple
+      />,
+    );
+
+    const removeButtons = screen.getAllByRole('button', { name: '' });
+    // One remove button per file, in the same order as `files`: uploadedFile, then file.
+    fireEvent.click(removeButtons[0]);
+
+    expect(onChange).toHaveBeenCalledWith([file]);
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -160,6 +160,7 @@ export type {
 export type {
   FieldComponentProps,
   FileComponentProps,
+  UploadedFileReference,
   CountryComponentProps,
   StatementComponentProps,
   ForcedValueComponentProps,

--- a/src/lib/__tests__/files.test.ts
+++ b/src/lib/__tests__/files.test.ts
@@ -29,7 +29,10 @@ describe('files lib', () => {
       const result = await convertFilesToBase64([uploadedFile]);
 
       expect(result).toEqual([
-        { name: 'cba_document.pdf', slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c' },
+        {
+          name: 'cba_document.pdf',
+          slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
+        },
       ]);
     });
 

--- a/src/lib/__tests__/files.test.ts
+++ b/src/lib/__tests__/files.test.ts
@@ -22,7 +22,7 @@ describe('files lib', () => {
     it('passes through an already-uploaded file by reference instead of re-encoding it', async () => {
       const uploadedFile = {
         name: 'cba_document.pdf',
-        slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
+        id: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
         sub_type: 'cba_document',
       };
 
@@ -31,7 +31,7 @@ describe('files lib', () => {
       expect(result).toEqual([
         {
           name: 'cba_document.pdf',
-          slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
+          id: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
         },
       ]);
     });
@@ -40,7 +40,7 @@ describe('files lib', () => {
       const newFile = new File(['content'], 'new.pdf', {
         type: 'application/pdf',
       });
-      const uploadedFile = { name: 'existing.pdf', slug: 'existing-slug' };
+      const uploadedFile = { name: 'existing.pdf', id: 'existing-id' };
 
       const result = await convertFilesToBase64([newFile, uploadedFile]);
 
@@ -51,7 +51,7 @@ describe('files lib', () => {
           type: 'application/pdf',
           content: expect.any(String),
         },
-        { name: 'existing.pdf', slug: 'existing-slug' },
+        { name: 'existing.pdf', id: 'existing-id' },
       ]);
     });
   });

--- a/src/lib/__tests__/files.test.ts
+++ b/src/lib/__tests__/files.test.ts
@@ -1,0 +1,55 @@
+import { convertFilesToBase64 } from '../files';
+
+describe('files lib', () => {
+  describe('convertFilesToBase64', () => {
+    it('base64-encodes a newly selected File', async () => {
+      const file = new File(['%PDF-1.4 fake pdf content'], 'cba_document.pdf', {
+        type: 'application/pdf',
+      });
+
+      const result = await convertFilesToBase64([file]);
+
+      expect(result).toEqual([
+        {
+          name: 'cba_document.pdf',
+          size: file.size,
+          type: 'application/pdf',
+          content: expect.any(String),
+        },
+      ]);
+    });
+
+    it('passes through an already-uploaded file by reference instead of re-encoding it', async () => {
+      const uploadedFile = {
+        name: 'cba_document.pdf',
+        slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c',
+        sub_type: 'cba_document',
+      };
+
+      const result = await convertFilesToBase64([uploadedFile]);
+
+      expect(result).toEqual([
+        { name: 'cba_document.pdf', slug: 'a1526614-e218-4f8f-a9d7-055a014ab42c' },
+      ]);
+    });
+
+    it('handles a mix of a new File and an already-uploaded reference', async () => {
+      const newFile = new File(['content'], 'new.pdf', {
+        type: 'application/pdf',
+      });
+      const uploadedFile = { name: 'existing.pdf', slug: 'existing-slug' };
+
+      const result = await convertFilesToBase64([newFile, uploadedFile]);
+
+      expect(result).toEqual([
+        {
+          name: 'new.pdf',
+          size: newFile.size,
+          type: 'application/pdf',
+          content: expect.any(String),
+        },
+        { name: 'existing.pdf', slug: 'existing-slug' },
+      ]);
+    });
+  });
+});

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,3 +1,5 @@
+import { UploadedFileReference } from '@/src/types/fields';
+
 const toBase64 = (file: File): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
@@ -7,12 +9,22 @@ const toBase64 = (file: File): Promise<string> => {
   });
 };
 
-export const convertFilesToBase64 = async (files: File[]) => {
+/**
+ * Base64-encodes newly selected files. Items that aren't a `File` (i.e. a reference to a file
+ * already uploaded, as returned by the API) are passed through by `name`/`slug` instead of being
+ * re-encoded — there's no binary content to read for those.
+ */
+export const convertFilesToBase64 = async (
+  files: (File | UploadedFileReference)[],
+) => {
   const base64Files = await Promise.all(
     files.map(async (file) => {
+      if (!(file instanceof File)) {
+        return { name: file.name, slug: file.slug };
+      }
+
       const base64 = await toBase64(file);
       return {
-        ...file,
         name: file.name,
         size: file.size,
         type: file.type,

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -20,7 +20,7 @@ export const convertFilesToBase64 = async (
   const base64Files = await Promise.all(
     files.map(async (file) => {
       if (!(file instanceof File)) {
-        return { name: file.name, slug: file.slug };
+        return { name: file.name, id: file.id };
       }
 
       const base64 = await toBase64(file);

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -95,6 +95,16 @@ export type FileComponentProps = FieldComponentProps & {
   fieldData: FieldFileDataProps;
 };
 
+/**
+ * Reference to a file already uploaded, as returned by the API on `GET` for `inputType: file`
+ * fields. Sent back unchanged on the next submit to keep the file instead of re-uploading it.
+ */
+export type UploadedFileReference = {
+  name: string;
+  slug: string;
+  sub_type?: string | null;
+};
+
 type FieldCountryDataProps = Omit<FieldDataProps, 'meta'> & {
   $meta: {
     regions: Record<string, string[]>;

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -101,7 +101,7 @@ export type FileComponentProps = FieldComponentProps & {
  */
 export type UploadedFileReference = {
   name: string;
-  slug: string;
+  id: string;
   sub_type?: string | null;
 };
 

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -91,6 +91,15 @@ export type FieldDataProps = Partial<JSFField> & {
   transformHtml?: (html: string) => React.ReactNode;
 };
 
+/**
+ * Props for a custom `inputType: file` component.
+ *
+ * `field.value` is typed as `File[]` for convenience, but for a field that already has a
+ * previously uploaded file (e.g. loaded from a `GET` response), an entry can be an
+ * {@link UploadedFileReference} instead of a real `File` — it only has `name` (and `id`), not
+ * `size`/`type`/any `Blob` method. Check `instanceof File` before relying on anything beyond
+ * `.name`.
+ */
 export type FileComponentProps = FieldComponentProps & {
   fieldData: FieldFileDataProps;
 };
@@ -98,6 +107,10 @@ export type FileComponentProps = FieldComponentProps & {
 /**
  * Reference to a file already uploaded, as returned by the API on `GET` for `inputType: file`
  * fields. Sent back unchanged on the next submit to keep the file instead of re-uploading it.
+ *
+ * A custom `inputType: file` component (see {@link FileComponentProps}) can receive one of these
+ * in place of a real `File` for a field that already had a file attached — it carries no binary
+ * content and doesn't implement the `Blob`/`File` interface.
  */
 export type UploadedFileReference = {
   name: string;


### PR DESCRIPTION
## Summary

- `inputType: file` fields get an already-uploaded file back from the API as a `{name, slug}` reference on `GET`, not the original binary. There's no `transformValueFromAPI` for file fields, so that reference flows straight into form state unchanged.
- On submit, `convertFilesToBase64` unconditionally ran every item in the field's array through `FileReader.readAsDataURL`, which needs a real `File`/`Blob`. Resubmitting a form without touching the file input passed the plain reference object in there instead, which doesn't produce useful output.
- `convertFilesToBase64` now checks `file instanceof File`: real files still get base64-encoded; anything else (an existing reference) is passed through as `{name, slug}` so the backend keeps the file instead of the request failing.
- Also fixed a cosmetic bug in `FileUploader` where an existing reference showed `(NaN KB)` since it has no `.size`.

Surfaced by [Tiger MR !90529](https://gitlab.com/remote-com/employ-starbase/tiger/-/merge_requests/90529) (CBA document upload on the public engagement agreement details endpoint), but the fix is generic to every `inputType: file` field, not specific to that one.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (no new warnings)
- [x] New tests: `src/lib/__tests__/files.test.ts` (new file encodes, existing reference passes through unchanged, mixed array), `src/components/ui/tests/file-uploader.test.tsx` (reference renders without the `NaN KB` bug, real file still shows size, removing one item from a mixed array leaves the other)
- [x] Existing `FileUploadField.test.tsx` suite still passes
- [x] Full suite passes (2 unrelated pre-existing timeouts in `OnboardingFlowFrance.test.tsx` under full-suite load, confirmed to pass in isolation with and without this change)
- [ ] Not yet verified against the real Tiger response shape end-to-end — `src/client/types.gen.ts` still reflects the pre-!90529 contract (`cba_document` as a free-form object) and needs regenerating once that MR merges and deploys