### PR TITLE
1.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @remoteoss/remote-flows
 
+## 1.48.0
+
+### Minor Changes
+
+- preserve already-uploaded file references instead of re-encoding them
+- fix formatting flagged by oxfmt in CI
+- use id instead of slug for the uploaded-file reference
+- avoid public API breaking change, fix multiple=false accumulating files
+- export UploadedFileReference and document the custom-component risk
+- add better examples on how to want partners want (#1242) [#1242](https://github.com/remoteoss/remote-flows/pull/1242)
+
 ## 1.47.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Minor Changes
 
-- preserve already-uploaded file references instead of re-encoding them
-- fix formatting flagged by oxfmt in CI
-- use id instead of slug for the uploaded-file reference
-- avoid public API breaking change, fix multiple=false accumulating files
-- export UploadedFileReference and document the custom-component risk
+#### Fixes
+
+- preserve already-uploaded file references instead of re-encoding them (#1241) [#1241](https://github.com/remoteoss/remote-flows/pull/1241)
+
+#### Docs
+
 - add better examples on how to want partners want (#1242) [#1242](https://github.com/remoteoss/remote-flows/pull/1242)
 
 ## 1.47.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.47.1",
+  "version": "1.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.47.1",
+      "version": "1.48.0",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.47.1",
+  "version": "1.48.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.48.0

### Minor Changes

#### Fixes

- preserve already-uploaded file references instead of re-encoding them (#1241) [#1241](https://github.com/remoteoss/remote-flows/pull/1241)

#### Docs

- add better examples on how to want partners want (#1242) [#1242](https://github.com/remoteoss/remote-flows/pull/1242)

---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only bumps version and changelog; runtime risk from the underlying file-upload fix is moderate for forms with pre-populated files but is not introduced by this release commit itself.
> 
> **Overview**
> **Release 1.48.0** bumps the package from **1.47.1** in `package.json`, `package-lock.json`, and documents the release in `CHANGELOG.md`.
> 
> The changelog entries reflect work shipped in prior PRs, not new logic in this diff:
> 
> **File upload fix (#1241):** Form submission no longer base64-re-encodes files that were already on the server. `convertFilesToBase64` passes through `UploadedFileReference` objects as `{ name, id }` instead of treating them like new `File` blobs. References use **`id`** (not slug), `multiple={false}` no longer accumulates stale files, and **`UploadedFileReference`** is exported with docs warning custom file components to use `instanceof File` before assuming blob APIs.
> 
> **Docs (#1242):** Example app / partner documentation gets clearer guidance on what partners typically want to customize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71167a60f11d5e43e29ac94144016f892ea85e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->