### PR TITLE
feat(contractor-document-creation) - add new flow

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -44,6 +44,7 @@ import CostCalculatorWithReplaceableComponentsCode from './CostCalculatorWithRep
 import TerminationCode from './Termination?raw';
 import ContractAmendmentCode from './ContractAmendment?raw';
 import { ContractorOnboardingForm } from './ContractorOnboarding';
+import { ContractorContractCreationForm } from './ContractorContractCreation';
 import { CreateCompanyForm } from './CreateCompany';
 import { MagicLinkTest } from './MagicLinkTest';
 import { JsonSchemaComparisonDemo } from './JsonSchemaComparisonDemo';
@@ -52,6 +53,7 @@ import { SandboxPaymentApproval } from './SandboxPaymentApproval';
 import { PayrollAdminOnboardingForm } from './PayrollAdminOnboarding';
 import { PayrollEmployeeOnboardingForm } from './PayrollEmployeeOnboarding';
 import ContractorOnboardingCode from './ContractorOnboarding?raw';
+import ContractorContractCreationCode from './ContractorContractCreation?raw';
 import CreateCompanyCode from './CreateCompany?raw';
 import MagicLinkTestCode from './MagicLinkTest?raw';
 import JsonSchemaComparisonCode from './JsonSchemaComparisonDemo?raw';
@@ -159,6 +161,13 @@ const additionalDemos = [
     description: 'Onboarding flow of a new contractor',
     component: ContractorOnboardingForm,
     sourceCode: ContractorOnboardingCode,
+  },
+  {
+    id: 'contractor-contract-creation',
+    title: 'Contractor Contract Creation',
+    description: 'Create a contract for an existing contractor',
+    component: ContractorContractCreationForm,
+    sourceCode: ContractorContractCreationCode,
   },
   {
     id: 'create-company',

--- a/example/src/ContractorContractCreation.tsx
+++ b/example/src/ContractorContractCreation.tsx
@@ -1,0 +1,195 @@
+import React, { useState } from 'react';
+import {
+  ContractorContractCreationFlow,
+  ContractorContractCreationRenderProps,
+  ContractorContractCreationFormPayload,
+  ContractorContractCreationResponse,
+  NormalizedFieldError,
+} from '@remoteoss/remote-flows';
+import { Card } from '@remoteoss/remote-flows/internals';
+import { RemoteFlows } from './RemoteFlows';
+import { AlertError } from './AlertError';
+import './css/main.css';
+import './css/contractor-onboarding.css';
+
+type ContractorContractCreationFormProps = {
+  contractorContractCreationBag: ContractorContractCreationRenderProps['flowBag'];
+  components: ContractorContractCreationRenderProps['components'];
+};
+
+const ContractorContractCreationFormView = ({
+  contractorContractCreationBag,
+  components,
+}: ContractorContractCreationFormProps) => {
+  const { Form, SubmitButton } = components;
+  const [errors, setErrors] = useState<{
+    apiError: string;
+    fieldErrors: NormalizedFieldError[];
+  }>({
+    apiError: '',
+    fieldErrors: [],
+  });
+
+  return (
+    <>
+      <Header />
+      <Card className='px-0 py-0'>
+        {contractorContractCreationBag.isLoading ? (
+          <div className='contractor-onboarding-form-layout'>
+            <p>Loading...</p>
+          </div>
+        ) : (
+          <div className='contractor-onboarding-form-layout'>
+            <div className='mb-6'>
+              <h2 className='text-xl font-bold mb-2'>Contract Details</h2>
+              <p className='text-sm text-gray-600'>
+                Create a new contract for this contractor
+              </p>
+            </div>
+
+            <Form
+              defaultValues={contractorContractCreationBag.initialValues}
+              onSubmit={async (payload: ContractorContractCreationFormPayload) => {
+                // onSubmit callback is called before API call
+              }}
+            />
+
+            <AlertError errors={errors} />
+
+            {contractorContractCreationBag.canSkipAiValidation && (
+              <div className='bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4'>
+                <div className='flex'>
+                  <div className='flex-shrink-0'>
+                    <svg
+                      className='h-5 w-5 text-yellow-400'
+                      viewBox='0 0 20 20'
+                      fill='currentColor'
+                    >
+                      <path
+                        fillRule='evenodd'
+                        d='M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z'
+                        clipRule='evenodd'
+                      />
+                    </svg>
+                  </div>
+                  <div className='ml-3'>
+                    <p className='text-sm text-yellow-700'>
+                      AI validation detected potential compliance issues. You can
+                      edit the Services and Deliverables field above or continue at
+                      your own risk by clicking Submit again.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className='contractor-onboarding-buttons-container mt-6'>
+              <SubmitButton
+                className='submit-button'
+                onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+              >
+                {contractorContractCreationBag.canSkipAiValidation
+                  ? 'Continue Anyway'
+                  : 'Create Contract'}
+              </SubmitButton>
+            </div>
+          </div>
+        )}
+      </Card>
+    </>
+  );
+};
+
+const Header = () => {
+  return (
+    <div className='contractor-onboarding-header'>
+      <h1>Contractor Contract Creation</h1>
+      <p>Create a new contract for an existing contractor.</p>
+    </div>
+  );
+};
+
+type ContractorContractCreationFormData = {
+  employmentId?: string;
+};
+
+export const ContractorContractCreationWithProps = ({
+  employmentId,
+}: ContractorContractCreationFormData) => {
+  return (
+    <div className='contractor-onboarding-container'>
+      <RemoteFlows
+        authType='company-manager'
+        proxy={{ url: window.location.origin }}
+      >
+        <div className='contractor-onboarding-content'>
+          <ContractorContractCreationFlow
+            employmentId={employmentId || ''}
+            initialValues={{}}
+            onSubmit={(payload: ContractorContractCreationFormPayload) => {
+              console.log('onSubmit payload:', payload);
+            }}
+            onSuccess={(response: ContractorContractCreationResponse) => {
+              console.log('onSuccess response:', response);
+              alert('Contract created successfully!');
+            }}
+            onError={({ error, fieldErrors }) => {
+              console.error('onError:', error, fieldErrors);
+            }}
+            render={({ flowBag, components }) => (
+              <ContractorContractCreationFormView
+                contractorContractCreationBag={flowBag}
+                components={components}
+              />
+            )}
+          />
+        </div>
+      </RemoteFlows>
+    </div>
+  );
+};
+
+export const ContractorContractCreationForm = () => {
+  const [formData, setFormData] = useState<ContractorContractCreationFormData>({
+    employmentId:
+      import.meta.env.VITE_CONTRACTOR_MANAGEMENT_EMPLOYMENT_ID || '',
+  });
+  const [showForm, setShowForm] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.employmentId) {
+      alert('Please enter an employment ID');
+      return;
+    }
+    setShowForm(true);
+  };
+
+  if (showForm) {
+    return <ContractorContractCreationWithProps {...formData} />;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className='onboarding-form-container'>
+      <div className='onboarding-form-group'>
+        <label htmlFor='employmentId' className='onboarding-form-label'>
+          Employment ID:
+        </label>
+        <input
+          id='employmentId'
+          type='text'
+          value={formData.employmentId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, employmentId: e.target.value }))
+          }
+          placeholder='Enter contractor employment ID'
+          className='onboarding-form-input'
+          required
+        />
+      </div>
+      <button type='submit' className='onboarding-form-button'>
+        Create Contract
+      </button>
+    </form>
+  );
+};

--- a/src/common/api/contractor-contract-details.ts
+++ b/src/common/api/contractor-contract-details.ts
@@ -1,0 +1,157 @@
+import { useMemo } from 'react';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FieldValues } from 'react-hook-form';
+import { getV1CountriesCountryCodeContractorContractDetails, getV1ContractorsEmploymentsEmploymentIdContractorCurrencies } from '@/src/client';
+import { useClient } from '@/src/context';
+import { Client } from '@/src/client/client';
+import { createHeadlessForm } from '@/src/common/createHeadlessForm';
+import { FlowOptions, JSONSchemaFormResultWithFieldsets } from '@/src/flows/types';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+
+/**
+ * Fetches contractor currencies for a given employment
+ */
+const useContractorCurrencies = ({
+  employmentId,
+  options,
+}: {
+  employmentId: string;
+  options?: { queryOptions?: { enabled?: boolean } };
+}) => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['contractor-currencies', employmentId],
+    queryFn: async () => {
+      return getV1ContractorsEmploymentsEmploymentIdContractorCurrencies({
+        client: client as Client,
+        path: { employment_id: employmentId },
+        query: {
+          restrict_to_guaranteed_pay_out_currencies: false,
+        },
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+    select: ({ data }) => {
+      return data?.data;
+    },
+  });
+};
+
+/**
+ * Fetches the contractor contract details schema for a given country
+ */
+const useContractorOnboardingDetailsSchema = ({
+  countryCode,
+  employmentId,
+  fieldValues,
+  options,
+}: {
+  countryCode: string;
+  fieldValues: FieldValues;
+  employmentId: string;
+  options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
+}): UseQueryResult<JSONSchemaFormResultWithFieldsets> => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: [
+      'contractor-onboarding-details-schema',
+      countryCode,
+      employmentId,
+    ],
+    retry: false,
+    queryFn: async () => {
+      return getV1CountriesCountryCodeContractorContractDetails({
+        client: client as Client,
+        path: { country_code: countryCode },
+        query: {
+          json_schema_version: 1,
+          employment_id: employmentId,
+        },
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+    select: ({ data }) => {
+      const jsfSchema = data?.data?.schema || {};
+      return createHeadlessForm(jsfSchema, fieldValues, options);
+    },
+  });
+};
+
+/**
+ * Shared hook for fetching contractor contract details schema with currencies
+ * This hook combines the schema fetching with currency options injection
+ * 
+ * @param countryCode - The country code for the contractor
+ * @param employmentId - The employment ID
+ * @param fieldValues - Current form field values
+ * @param options - Flow options including jsfModify and query options
+ * @returns The contractor contract details schema with currency options injected
+ */
+export const useContractorContractDetailsSchema = ({
+  countryCode,
+  employmentId,
+  fieldValues,
+  options,
+}: {
+  countryCode: string;
+  fieldValues: FieldValues;
+  employmentId: string;
+  options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
+}) => {
+  const schemaQuery = useContractorOnboardingDetailsSchema({
+    countryCode,
+    employmentId,
+    fieldValues,
+    options,
+  });
+
+  const { data: currencies, isLoading: isLoadingCurrencies } =
+    useContractorCurrencies({
+      employmentId,
+      options: {
+        queryOptions: { enabled: options?.queryOptions?.enabled },
+      },
+    });
+
+  const dataWithCurrencies = useMemo(() => {
+    if (!schemaQuery.data || !currencies) {
+      return schemaQuery.data;
+    }
+
+    const form = {
+      ...schemaQuery.data,
+      fields: schemaQuery.data.fields.map((field) => {
+        if (field.name !== 'payment_terms') {
+          return field;
+        }
+
+        return {
+          ...field,
+          fields: (field.fields as $TSFixMe[])?.map((nestedField: $TSFixMe) => {
+            if (nestedField.name !== 'compensation_currency_code') {
+              return nestedField;
+            }
+
+            // Return a new object with overridden options
+            return {
+              ...nestedField,
+              options: currencies.map((currency) => ({
+                label: currency.code,
+                value: currency.code,
+                meta: { source: currency.source },
+              })),
+            };
+          }),
+        };
+      }),
+    };
+
+    return form;
+  }, [schemaQuery.data, currencies]);
+
+  return {
+    ...schemaQuery,
+    data: dataWithCurrencies as $TSFixMe,
+    isLoading: schemaQuery.isLoading || isLoadingCurrencies,
+  };
+};

--- a/src/flows/ContractorContractCreation/ContractorContractCreationFlow.tsx
+++ b/src/flows/ContractorContractCreation/ContractorContractCreationFlow.tsx
@@ -1,0 +1,44 @@
+import { useId } from 'react';
+import { ContractorContractCreationContext } from '@/src/flows/ContractorContractCreation/context';
+import { useContractorContractCreation } from '@/src/flows/ContractorContractCreation/hooks';
+import { ContractorContractCreationFlowProps } from '@/src/flows/ContractorContractCreation/types';
+import { ContractorContractCreationForm } from '@/src/flows/ContractorContractCreation/components/ContractorContractCreationForm';
+import { ContractorContractCreationSubmitButton } from '@/src/flows/ContractorContractCreation/components/ContractorContractCreationSubmitButton';
+
+/**
+ * ContractorContractCreationFlow component
+ *
+ * A single-step flow for creating contractor contracts directly from a contractor profile
+ * without going through the full onboarding process.
+ *
+ */
+export const ContractorContractCreationFlow = ({
+  render,
+  employmentId,
+  initialValues,
+  jsfModify,
+  jsonSchemaVersion,
+}: ContractorContractCreationFlowProps) => {
+  const formId = useId();
+
+  const contractorContractCreationBag = useContractorContractCreation({
+    employmentId,
+    initialValues,
+    jsfModify,
+    jsonSchemaVersion,
+  });
+
+  return (
+    <ContractorContractCreationContext.Provider
+      value={{ contractorContractCreationBag, formId }}
+    >
+      {render({
+        flowBag: contractorContractCreationBag,
+        components: {
+          Form: ContractorContractCreationForm,
+          SubmitButton: ContractorContractCreationSubmitButton,
+        },
+      })}
+    </ContractorContractCreationContext.Provider>
+  );
+};

--- a/src/flows/ContractorContractCreation/components/ContractorContractCreationForm.tsx
+++ b/src/flows/ContractorContractCreation/components/ContractorContractCreationForm.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { $TSFixMe, JSFFields } from '@/src/types/remoteFlows';
+import { JSONSchemaFormFields } from '@/src/components/form/JSONSchemaForm';
+import { Form } from '@/src/components/ui/form';
+import { Components } from '@/src/types/remoteFlows';
+import { useContractorContractCreationContext } from '@/src/flows/ContractorContractCreation/context';
+import { ContractorContractCreationFormPayload } from '@/src/flows/ContractorContractCreation/types';
+import { useJSONSchemaForm } from '@/src/components/form/useJSONSchemaForm';
+
+type ContractorContractCreationFormProps = {
+  onSubmit: (
+    payload: ContractorContractCreationFormPayload,
+    form: UseFormReturn<$TSFixMe>,
+  ) => Promise<void>;
+  components?: Components;
+  fields?: JSFFields;
+  defaultValues: Record<string, unknown>;
+};
+
+/**
+ * Form component for contractor contract creation
+ * Renders the contract details form fields using the JSON schema
+ */
+export function ContractorContractCreationForm({
+  defaultValues,
+  onSubmit,
+  components,
+}: ContractorContractCreationFormProps) {
+  const { formId, contractorContractCreationBag } =
+    useContractorContractCreationContext();
+
+  const form = useJSONSchemaForm({
+    handleValidation: contractorContractCreationBag.handleValidation,
+    defaultValues,
+    checkFieldUpdates: contractorContractCreationBag.checkFieldUpdates,
+  });
+
+  // Initialize field values
+  useEffect(() => {
+    if (contractorContractCreationBag.employment?.id) {
+      contractorContractCreationBag.checkFieldUpdates(form.getValues());
+    }
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSubmit = async (values: Record<string, unknown>) => {
+    await onSubmit(values as ContractorContractCreationFormPayload, form);
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        id={formId}
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className='space-y-4 RemoteFlows__ContractorContractCreationForm'
+      >
+        <JSONSchemaFormFields
+          components={components}
+          fields={contractorContractCreationBag.fields}
+          fieldsets={contractorContractCreationBag.meta.fieldsets}
+          fieldValues={contractorContractCreationBag.fieldValues}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/flows/ContractorContractCreation/components/ContractorContractCreationSubmitButton.tsx
+++ b/src/flows/ContractorContractCreation/components/ContractorContractCreationSubmitButton.tsx
@@ -1,0 +1,33 @@
+import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { useContractorContractCreationContext } from '@/src/flows/ContractorContractCreation/context';
+import { useFormFields } from '@/src/context';
+
+/**
+ * Submit button for contractor contract creation form
+ * Must be used within ContractorContractCreationFlow render prop
+ */
+export function ContractorContractCreationSubmitButton({
+  children,
+  ...props
+}: PropsWithChildren<
+  ButtonHTMLAttributes<HTMLButtonElement> & Record<string, unknown>
+>) {
+  const { formId, contractorContractCreationBag } =
+    useContractorContractCreationContext();
+  const { components } = useFormFields();
+
+  const CustomButton = components?.button;
+  if (!CustomButton) {
+    throw new Error(`Button component not found`);
+  }
+
+  return (
+    <CustomButton
+      {...props}
+      form={formId}
+      disabled={props.disabled || contractorContractCreationBag.isSubmitting}
+    >
+      {children}
+    </CustomButton>
+  );
+}

--- a/src/flows/ContractorContractCreation/context.ts
+++ b/src/flows/ContractorContractCreation/context.ts
@@ -1,0 +1,24 @@
+import type { ContractorContractCreationFlowBag } from '@/src/flows/ContractorContractCreation/types';
+import { createContext, useContext } from 'react';
+
+export const ContractorContractCreationContext = createContext<{
+  formId: string | undefined;
+  contractorContractCreationBag: ContractorContractCreationFlowBag | null;
+}>({
+  formId: undefined,
+  contractorContractCreationBag: null,
+});
+
+export const useContractorContractCreationContext = () => {
+  const context = useContext(ContractorContractCreationContext);
+  if (!context.formId || !context.contractorContractCreationBag) {
+    throw new Error(
+      'useContractorContractCreationContext must be used within a ContractorContractCreationFlow',
+    );
+  }
+
+  return {
+    formId: context.formId,
+    contractorContractCreationBag: context.contractorContractCreationBag,
+  } as const;
+};

--- a/src/flows/ContractorContractCreation/hooks.tsx
+++ b/src/flows/ContractorContractCreation/hooks.tsx
@@ -1,0 +1,228 @@
+import { useState, useMemo } from 'react';
+import { FieldValues } from 'react-hook-form';
+import { useEmploymentQuery } from '@/src/common/api/employment';
+import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
+import { useCreateContractorContractDocument } from '@/src/flows/ContractorOnboarding/api';
+import { buildContractDetailsJsfModify } from '@/src/flows/ContractorOnboarding/jsfModify';
+import {
+  calculateProvisionalStartDateDescription,
+  transformAiErrorResponse,
+} from '@/src/flows/ContractorOnboarding/utils';
+import { mutationToPromise, isMutationError } from '@/src/lib/mutations';
+import { parseJSFToValidate } from '@/src/components/form/utils';
+import { prettifyFormValues } from '@/src/lib/utils';
+import {
+  ContractorContractCreationHookProps,
+  ContractorContractCreationFlowBag,
+} from '@/src/flows/ContractorContractCreation/types';
+import { CreateContractDocument } from '@/src/client';
+
+// TODO: Possibly repeated code
+type AiValidationError = {
+  error: string[];
+  source: string;
+  skippable: boolean;
+};
+
+// TODO: Possibly repeated code
+const REMOTE_AI_ERROR_SOURCE = 'remote_ai';
+
+/**
+ * Extracts AI validation error from the error response
+ * TODO: Possibly repeated code
+ */
+const extractAiValidationError = (error: unknown): AiValidationError | null => {
+  if (!isMutationError(error)) {
+    return null;
+  }
+
+  const rawError = error.normalizedErrors.services_and_deliverables;
+
+  const servicesAndDeliverablesError = (
+    Array.isArray(rawError) ? rawError[0] : rawError
+  ) as
+    | {
+        error: string[];
+        source: string;
+        skippable: boolean;
+      }
+    | undefined;
+
+  if (servicesAndDeliverablesError?.source === REMOTE_AI_ERROR_SOURCE) {
+    return {
+      error: servicesAndDeliverablesError.error,
+      source: servicesAndDeliverablesError.source,
+      skippable: servicesAndDeliverablesError.skippable,
+    };
+  }
+  return null;
+};
+
+/**
+ * Headless hook for contractor contract creation flow
+ * This hook provides all the logic needed to create a contractor contract
+ * without being tied to any specific UI implementation
+ * TODO: Things missing on this hook:
+ * - Opportunity to use handleValidation to make the mutations instead of the old way...
+ */
+export const useContractorContractCreation = ({
+  employmentId,
+  initialValues: providedInitialValues = {},
+  jsfModify,
+  jsonSchemaVersion,
+}: ContractorContractCreationHookProps): ContractorContractCreationFlowBag => {
+  const [fieldValues, setFieldValues] = useState<FieldValues>({});
+
+  // Fetch employment data
+  const { data: employment, isLoading: isLoadingEmployment } =
+    useEmploymentQuery({
+      employmentId,
+      queryParams: { exclude_files: true },
+    });
+
+  // Derive country code from employment
+  const countryCode = employment?.country?.code;
+
+  // Get provisional start date from employment
+  const provisionalStartDate =
+    employment?.basic_information?.provisional_start_date;
+
+  // Calculate provisional start date description
+  const provisionalStartDateDescription = useMemo(() => {
+    // TODO: how to handle when we're loading the provisional start date?
+    return calculateProvisionalStartDateDescription(
+      provisionalStartDate,
+      fieldValues?.service_duration?.provisional_start_date,
+    );
+  }, [
+    provisionalStartDate,
+    fieldValues?.service_duration?.provisional_start_date,
+  ]);
+
+  // Build jsfModify with internal modifications
+  const mergedJsfModify = useMemo(() => {
+    return buildContractDetailsJsfModify(
+      jsfModify,
+      provisionalStartDateDescription,
+      undefined, // selectedPricingPlan - not applicable in standalone contract creation
+      fieldValues,
+      false, // isContractorOfRecord - not applicable in standalone contract creation
+    );
+  }, [jsfModify, provisionalStartDateDescription, fieldValues]);
+
+  // Fetch contractor schema
+  const { data: contractDetailsForm, isLoading: isLoadingSchema } =
+    useContractorContractDetailsSchema({
+      countryCode: countryCode as string,
+      employmentId,
+      fieldValues,
+      options: {
+        // TODO: We need to correct type...
+        jsonSchemaVersion,
+        jsfModify: mergedJsfModify,
+        queryOptions: { enabled: Boolean(countryCode) },
+      },
+    });
+
+  // Create contract document mutation
+  const createContractDocumentMutation = useCreateContractorContractDocument();
+  const { mutateAsyncOrThrow: createContractDocumentMutationAsync } =
+    mutationToPromise(createContractDocumentMutation);
+
+  // Initial values from contract details or provided values
+  const initialValues = useMemo(() => {
+    const employmentContractDetails = employment?.contract_details || {};
+    return {
+      ...employmentContractDetails,
+      ...providedInitialValues,
+    };
+  }, [employment?.contract_details, providedInitialValues]);
+
+  // Prettified values for display
+  const prettifiedValues = useMemo(() => {
+    return prettifyFormValues(fieldValues, contractDetailsForm?.fields || []);
+  }, [fieldValues, contractDetailsForm?.fields]);
+
+  // Parse form values
+  const parseFormValues = async (values: FieldValues) => {
+    if (contractDetailsForm) {
+      return await parseJSFToValidate(values, contractDetailsForm.fields, {
+        isPartialValidation: false,
+      });
+    }
+    return values;
+  };
+
+  // Handle validation
+  const handleValidation = async (values: FieldValues) => {
+    if (contractDetailsForm) {
+      const parsedValues = await parseJSFToValidate(
+        values,
+        contractDetailsForm.fields,
+        { isPartialValidation: false },
+      );
+      return contractDetailsForm.handleValidation(parsedValues);
+    }
+    return null;
+  };
+
+  // Submit handler
+  const onSubmit = async (values: FieldValues) => {
+    const parsedValues = await parseFormValues(values);
+
+    // Handle AI validation skipping
+    const shouldSkipAiChecks =
+      fieldValues.services_and_deliverables_error_skippable === true;
+
+    // Remove AI warning fields from submission
+    const {
+      services_and_deliverables_ai_warning: _aiWarning,
+      services_and_deliverables_error_skippable: _errorSkippable,
+      ...contractDetailsData
+    } = parsedValues;
+
+    const payload: CreateContractDocument = {
+      contract_document: contractDetailsData,
+      skip_ai_checks: shouldSkipAiChecks,
+    };
+
+    try {
+      const response = await createContractDocumentMutationAsync({
+        employmentId,
+        payload,
+      });
+      return response;
+    } catch (error) {
+      // Handle AI validation errors
+      const aiError = extractAiValidationError(error);
+      if (aiError) {
+        setFieldValues({
+          ...values,
+          services_and_deliverables_ai_warning: transformAiErrorResponse(false),
+          services_and_deliverables_error_skippable: aiError.skippable,
+        });
+      }
+      throw error;
+    }
+  };
+
+  return {
+    isLoading: isLoadingEmployment || isLoadingSchema,
+    fields: contractDetailsForm?.fields || [],
+    fieldValues,
+    checkFieldUpdates: setFieldValues,
+    handleValidation,
+    parseFormValues,
+    onSubmit,
+    initialValues,
+    employment,
+    canSkipAiValidation:
+      fieldValues.services_and_deliverables_error_skippable === true,
+    isSubmitting: createContractDocumentMutation.isPending,
+    meta: {
+      fields: prettifiedValues,
+      fieldsets: contractDetailsForm?.meta?.['x-jsf-fieldsets'],
+      presentation: contractDetailsForm?.meta?.['x-jsf-presentation'],
+    },
+  };
+};

--- a/src/flows/ContractorContractCreation/index.ts
+++ b/src/flows/ContractorContractCreation/index.ts
@@ -1,0 +1,1 @@
+export { ContractorContractCreationFlow } from './ContractorContractCreationFlow';

--- a/src/flows/ContractorContractCreation/tests/ContractorContractCreationFlow.test.tsx
+++ b/src/flows/ContractorContractCreation/tests/ContractorContractCreationFlow.test.tsx
@@ -1,0 +1,272 @@
+import { server } from '@/src/tests/server';
+import {
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+import { ContractorContractCreationFlow } from '@/src/flows/ContractorContractCreation/ContractorContractCreationFlow';
+import { ContractorContractCreationForm } from '@/src/flows/ContractorContractCreation/components/ContractorContractCreationForm';
+import { ContractorContractCreationSubmitButton } from '@/src/flows/ContractorContractCreation/components/ContractorContractCreationSubmitButton';
+import { mockContractorContractDetailsSchema, mockContractorEmploymentResponse } from '@/src/flows/ContractorOnboarding/tests/fixtures';
+import {
+  fillDatePickerByTestId,
+  fillSelect,
+  queryClient,
+  TestProviders,
+} from '@/src/tests/testHelpers';
+import { ContractorContractCreationRenderProps } from '@/src/flows/ContractorContractCreation/types';
+import { fireEvent } from '@testing-library/react';
+import { RemoteFlowContext } from '@/src/context';
+import { client as apiClient } from '@/src/client/client.gen';
+import { mockBaseResponse } from '@/src/common/api/fixtures/base';
+import { mockContractorCurrencies } from '@/src/common/api/fixtures/contractors';
+
+const mockOnSubmit = vi.fn();
+const mockOnSuccess = vi.fn();
+const mockOnError = vi.fn();
+
+function createMockRenderImplementation() {
+  return ({ flowBag }: ContractorContractCreationRenderProps) => {
+    if (flowBag.isLoading) {
+      return <div data-testid='spinner'>Loading...</div>;
+    }
+
+    return (
+      <>
+        <h1>Create Contract</h1>
+        <ContractorContractCreationForm
+          defaultValues={flowBag.initialValues}
+          onSubmit={async (payload, form) => {
+            try {
+              await mockOnSubmit(payload);
+              const response = await flowBag.onSubmit(payload);
+              await mockOnSuccess(response);
+            } catch (error: $TSFixMe) {
+              const structuredError = {
+                error: error as Error,
+                rawError: error as Record<string, unknown>,
+                fieldErrors: [],
+              };
+              mockOnError(structuredError);
+              form.setError('root', {
+                message: (error as Error).message,
+              });
+            }
+          }}
+        />
+        <ContractorContractCreationSubmitButton>
+          Create Contract
+        </ContractorContractCreationSubmitButton>
+      </>
+    );
+  };
+}
+
+describe('ContractorContractCreationFlow', () => {
+  const employmentId = 'emp_123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+
+    // Mock employment data
+    server.use(
+      http.get(
+        `*/v1/employments/${employmentId}`,
+        () => {
+          return HttpResponse.json(
+            mockBaseResponse(mockContractorEmploymentResponse),
+          );
+        },
+      ),
+    );
+
+    // Mock contract details schema
+    server.use(
+      http.get(
+        '*/v1/countries/:country_code/contractor-contract-details',
+        () => {
+          return HttpResponse.json(
+            mockBaseResponse({
+              schema: mockContractorContractDetailsSchema,
+            }),
+          );
+        },
+      ),
+    );
+
+    // Mock contractor currencies
+    server.use(
+      http.get(
+        `*/v1/contractors/employments/${employmentId}/contractor-currencies`,
+        () => {
+          return HttpResponse.json(mockBaseResponse(mockContractorCurrencies));
+        },
+      ),
+    );
+  });
+
+  it('renders loading state initially', () => {
+    render(
+      <TestProviders>
+        <RemoteFlowContext.Provider
+          value={{
+            client: apiClient,
+            auth: () => Promise.resolve({ accessToken: 'token', expiresIn: 3600 }),
+            environment: 'production',
+          }}
+        >
+          <ContractorContractCreationFlow
+            employmentId={employmentId}
+            render={createMockRenderImplementation()}
+          />
+        </RemoteFlowContext.Provider>
+      </TestProviders>,
+    );
+
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('renders contract creation form after loading', async () => {
+    render(
+      <TestProviders>
+        <RemoteFlowContext.Provider
+          value={{
+            client: apiClient,
+            auth: () => Promise.resolve({ accessToken: 'token', expiresIn: 3600 }),
+            environment: 'production',
+          }}
+        >
+          <ContractorContractCreationFlow
+            employmentId={employmentId}
+            render={createMockRenderImplementation()}
+          />
+        </RemoteFlowContext.Provider>
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Create Contract')).toBeInTheDocument();
+    });
+  });
+
+  it('successfully creates contract document', async () => {
+    const mockContractDocumentResponse = {
+      contract_document: {
+        id: 'contract_123',
+        status: 'pending',
+      },
+    };
+
+    server.use(
+      http.post(
+        `*/v1/contractors/employments/${employmentId}/contract-documents`,
+        () => {
+          return HttpResponse.json(
+            mockBaseResponse(mockContractDocumentResponse),
+          );
+        },
+      ),
+    );
+
+    render(
+      <TestProviders>
+        <RemoteFlowContext.Provider
+          value={{
+            client: apiClient,
+            auth: () => Promise.resolve({ accessToken: 'token', expiresIn: 3600 }),
+            environment: 'production',
+          }}
+        >
+          <ContractorContractCreationFlow
+            employmentId={employmentId}
+            onSuccess={mockOnSuccess}
+            render={createMockRenderImplementation()}
+          />
+        </RemoteFlowContext.Provider>
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Create Contract')).toBeInTheDocument();
+    });
+
+    // Fill in contract details
+    await fillDatePickerByTestId('service_duration.provisional_start_date', new Date('2024-01-01'));
+    
+    const positionField = screen.getByLabelText('Position');
+    fireEvent.change(positionField, { target: { value: 'Software Developer' } });
+
+    const servicesField = screen.getByLabelText('Services and deliverables');
+    fireEvent.change(servicesField, { target: { value: 'Software development services' } });
+
+    // Submit form
+    const submitButton = screen.getByText('Create Contract');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: mockContractDocumentResponse,
+        }),
+      );
+    });
+  });
+
+  it('handles AI validation errors', async () => {
+    const aiErrorResponse = {
+      errors: {
+        services_and_deliverables: {
+          error: ['This may be misclassified'],
+          source: 'remote_ai',
+          skippable: true,
+        },
+      },
+    };
+
+    server.use(
+      http.post(
+        `*/v1/contractors/employments/${employmentId}/contract-documents`,
+        () => {
+          return HttpResponse.json(aiErrorResponse, { status: 422 });
+        },
+      ),
+    );
+
+    render(
+      <TestProviders>
+        <RemoteFlowContext.Provider
+          value={{
+            client: apiClient,
+            auth: () => Promise.resolve({ accessToken: 'token', expiresIn: 3600 }),
+            environment: 'production',
+          }}
+        >
+          <ContractorContractCreationFlow
+            employmentId={employmentId}
+            onError={mockOnError}
+            render={createMockRenderImplementation()}
+          />
+        </RemoteFlowContext.Provider>
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Create Contract')).toBeInTheDocument();
+    });
+
+    // Fill in contract details
+    const servicesField = screen.getByLabelText('Services and deliverables');
+    fireEvent.change(servicesField, { target: { value: 'Test services' } });
+
+    // Submit form
+    const submitButton = screen.getByText('Create Contract');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockOnError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/flows/ContractorContractCreation/types.ts
+++ b/src/flows/ContractorContractCreation/types.ts
@@ -1,0 +1,182 @@
+import { ReactNode } from 'react';
+import { FieldValues } from 'react-hook-form';
+import { ValidationResult } from '@remoteoss/remote-json-schema-form-kit';
+import { Employment } from '@/src/client';
+import { JSFFields, NestedMeta } from '@/src/types/remoteFlows';
+import { JSFModify } from '@/src/flows/types';
+import { NormalizedFieldError } from '@/src/lib/mutations';
+import { ContractorContractCreationForm } from '@/src/flows/ContractorContractCreation/components/ContractorContractCreationForm';
+import { ContractorContractCreationSubmitButton } from '@/src/flows/ContractorContractCreation/components/ContractorContractCreationSubmitButton';
+
+/**
+ * Form payload for contractor contract creation
+ * TODO: Probably we need to correct the type
+ */
+export type ContractorContractCreationFormPayload = Record<string, unknown>;
+
+/**
+ * Response from contractor contract document creation
+ * TODO: Probably we need to correct type...
+ */
+export type ContractorContractCreationResponse = {
+  contract_document?: {
+    id: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+/**
+ * Props for the flow bag exposed to render prop
+ */
+export interface ContractorContractCreationFlowBag {
+  /**
+   * Loading state indicating if the flow is loading data
+   */
+  isLoading: boolean;
+
+  /**
+   * Current state of the form fields
+   */
+  fieldValues: FieldValues;
+
+  /**
+   * Array of form fields from the schema
+   */
+  fields: JSFFields;
+
+  /**
+   * Function to update the current form field values
+   * @param values - New form values to set
+   */
+  checkFieldUpdates: (values: FieldValues) => void;
+
+  /**
+   * Function to validate form values against the schema
+   * @param values - Form values to validate
+   * @returns Validation result or null if no schema is available
+   */
+  handleValidation: (values: FieldValues) => Promise<ValidationResult | null>;
+
+  /**
+   * Function to parse form values before submission
+   * @param values - Form values to parse
+   * @returns Parsed form values
+   */
+  parseFormValues: (values: FieldValues) => Promise<FieldValues>;
+
+  /**
+   * Function to handle form submission
+   * @param values - Form values to submit
+   * @returns Promise resolving to the mutation result
+   */
+  onSubmit: (values: FieldValues) => Promise<unknown>;
+
+  /**
+   * Initial form values
+   */
+  initialValues: Record<string, unknown>;
+
+  /**
+   * Employment data for the contractor
+   */
+  employment?: Employment;
+
+  /**
+   * Indicates whether AI validation errors can be skipped
+   */
+  canSkipAiValidation: boolean;
+
+  /**
+   * Loading state indicating if the mutation is in progress
+   */
+  isSubmitting: boolean;
+
+  /**
+   * Fields metadata
+   */
+  meta: {
+    fields: NestedMeta;
+    fieldsets: unknown;
+    presentation: Record<string, unknown> | null | undefined;
+  };
+}
+
+/**
+ * Props for render prop function
+ */
+export interface ContractorContractCreationRenderProps {
+  flowBag: ContractorContractCreationFlowBag;
+  components: {
+    Form: typeof ContractorContractCreationForm;
+    SubmitButton: typeof ContractorContractCreationSubmitButton;
+  };
+}
+
+/**
+ * Props for the ContractorContractCreationFlow component
+ */
+export interface ContractorContractCreationFlowProps {
+  /**
+   * Required: Contractor employment ID to create contract for
+   */
+  employmentId: string;
+
+  /**
+   * Optional: User-provided field overrides
+   * TODO: We need to correct type...
+   */
+  jsfModify?: JSFModify['contract_details'];
+
+  /**
+   * Optional: Initial values
+   */
+  initialValues?: Record<string, unknown>;
+
+  /**
+   * Optional: JSON schema version
+   */
+  jsonSchemaVersion?: number | 'latest';
+
+  /**
+   * Callback fired when form is submitted (before API call)
+   */
+  onSubmit?: (
+    payload: ContractorContractCreationFormPayload,
+  ) => void | Promise<void>;
+
+  /**
+   * Callback fired when contract creation is successful
+   */
+  onSuccess?: (
+    response: ContractorContractCreationResponse,
+  ) => void | Promise<void>;
+
+  /**
+   * Callback fired when an error occurs
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+
+  /**
+   * Render prop function
+   */
+  render: (props: ContractorContractCreationRenderProps) => ReactNode;
+}
+
+/**
+ * Props for the useContractorContractCreation hook
+ */
+export interface ContractorContractCreationHookProps {
+  employmentId: string;
+  initialValues?: Record<string, unknown>;
+  jsfModify?: JSFModify['contract_details'];
+  jsonSchemaVersion?: number | 'latest';
+}

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -27,13 +27,13 @@ import {
   usePostManageContractorCorSubscription,
   useDeleteContractorCorSubscription,
   useCountriesSchemaField,
-  useContractorOnboardingDetailsSchemaWithCurrencies,
   CONTRACT_PRODUCT_TITLES,
   useHasCompanySignedContract,
   useCompanyOpenTasks,
   useSetContractOrigin,
   useGetContractOriginSchema,
 } from '@/src/flows/ContractorOnboarding/api';
+import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
   ContractorOnboardingFlowProps,
   ContractorOnboardingHookOptions,
@@ -624,7 +624,7 @@ export const useContractorOnboarding = ({
   const {
     data: contractorOnboardingDetailsForm,
     isLoading: isLoadingContractorOnboardingDetailsForm,
-  } = useContractorOnboardingDetailsSchemaWithCurrencies({
+  } = useContractorContractDetailsSchema({
     countryCode: internalCountryCode as string,
     fieldValues: fieldValues,
     employmentId: internalEmploymentId as string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -91,6 +91,8 @@ export type {
 
 export type { ContractPreviewStatementProps } from '@/src/flows/ContractorOnboarding/components/ContractPreviewStatement';
 
+export { ContractorContractCreationFlow } from '@/src/flows/ContractorContractCreation';
+
 export {
   PayrollAdminOnboardingFlow,
   usePayrollAdminOnboarding,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches contract document creation and shared contract-details schema used by onboarding; behavior should stay aligned, but duplicate AI-validation logic and incomplete callback wiring in the flow component add integration risk.
> 
> **Overview**
> Adds **`ContractorContractCreationFlow`**, a single-step headless flow to create a contractor contract document for an **existing** employment (by `employmentId`), without full contractor onboarding.
> 
> The flow loads employment + country-scoped JSON schema (with **compensation currency** options), renders contract-details fields via the shared JSON-schema form, and submits through the same **create contract document** API used in onboarding. It reuses onboarding helpers for **jsfModify**, provisional start date messaging, and **skippable Remote AI** validation on services and deliverables (`canSkipAiValidation`, `skip_ai_checks`).
> 
> **Shared schema hook:** `useContractorContractDetailsSchema` in `contractor-contract-details.ts` centralizes schema + currency injection; **contractor onboarding**’s contract-details step now uses it instead of `useContractorOnboardingDetailsSchemaWithCurrencies`.
> 
> **Package surface:** exports `ContractorContractCreationFlow` from the main entry. The **example app** adds a demo (employment ID gate + form UI) alongside contractor onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd5cef07675735ba0d3d66a003a03e93b7049ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->