### PR TITLE
refactor(contractor-onboarding) - extract contract details schema hook to common/api

### DIFF
--- a/src/common/api/contractor-contract-details.ts
+++ b/src/common/api/contractor-contract-details.ts
@@ -1,0 +1,158 @@
+import { useMemo } from 'react';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FieldValues } from 'react-hook-form';
+import {
+  getV1CountriesCountryCodeContractorContractDetails,
+  getV1ContractorsEmploymentsEmploymentIdContractorCurrencies,
+} from '@/src/client';
+import { useClient } from '@/src/context';
+import { Client } from '@/src/client/client';
+import { createHeadlessForm } from '@/src/common/createHeadlessForm';
+import {
+  FlowOptions,
+  JSONSchemaFormResultWithFieldsets,
+} from '@/src/flows/types';
+import { $TSFixMe } from '@/src/types/remoteFlows';
+
+const useContractorCurrencies = ({
+  employmentId,
+  options,
+}: {
+  employmentId: string;
+  options?: { queryOptions?: { enabled?: boolean } };
+}) => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['contractor-currencies', employmentId],
+    queryFn: async () => {
+      return getV1ContractorsEmploymentsEmploymentIdContractorCurrencies({
+        client: client as Client,
+        path: { employment_id: employmentId },
+        query: {
+          restrict_to_guaranteed_pay_out_currencies: false,
+        },
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+    select: ({ data }) => {
+      return data?.data;
+    },
+  });
+};
+
+/**
+ * Get the contractor onboarding details schema for a given country
+ * @param countryCode - The country code
+ * @param fieldValues - The field values
+ * @param options - The options
+ * @returns The contractor onboarding details schema
+ */
+const useContractorOnboardingDetailsSchema = ({
+  countryCode,
+  employmentId,
+  fieldValues,
+  options,
+}: {
+  countryCode: string;
+  fieldValues: FieldValues;
+  employmentId: string;
+  options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
+}): UseQueryResult<JSONSchemaFormResultWithFieldsets> => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: [
+      'contractor-onboarding-details-schema',
+      countryCode,
+      employmentId,
+    ],
+    retry: false,
+    queryFn: async () => {
+      return getV1CountriesCountryCodeContractorContractDetails({
+        client: client as Client,
+        path: { country_code: countryCode },
+        query: {
+          json_schema_version: 1,
+          employment_id: employmentId,
+        },
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+    select: ({ data }) => {
+      const jsfSchema = data?.data?.schema || {};
+      return createHeadlessForm(jsfSchema, fieldValues, options);
+    },
+  });
+};
+
+/**
+ * Get contractor onboarding details schema with currency options overridden
+ * from the getIndexContractorCurrency endpoint
+ */
+export const useContractorContractDetailsSchema = ({
+  countryCode,
+  employmentId,
+  fieldValues,
+  options,
+}: {
+  countryCode: string;
+  fieldValues: FieldValues;
+  employmentId: string;
+  options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
+}) => {
+  const schemaQuery = useContractorOnboardingDetailsSchema({
+    countryCode,
+    employmentId,
+    fieldValues,
+    options,
+  });
+
+  const { data: currencies, isLoading: isLoadingCurrencies } =
+    useContractorCurrencies({
+      employmentId,
+      options: {
+        queryOptions: { enabled: options?.queryOptions?.enabled },
+      },
+    });
+
+  const dataWithCurrencies = useMemo(() => {
+    if (!schemaQuery.data || !currencies) {
+      return schemaQuery.data;
+    }
+
+    const form = {
+      ...schemaQuery.data,
+      fields: schemaQuery.data.fields.map((field) => {
+        if (field.name !== 'payment_terms') {
+          return field;
+        }
+
+        return {
+          ...field,
+          fields: (field.fields as $TSFixMe[])?.map((nestedField: $TSFixMe) => {
+            if (nestedField.name !== 'compensation_currency_code') {
+              return nestedField;
+            }
+
+            // Return a new object with overridden options
+            return {
+              ...nestedField,
+              options: currencies.map((currency) => ({
+                label: currency.code,
+                value: currency.code,
+                meta: { source: currency.source },
+              })),
+            };
+          }),
+        };
+      }),
+    };
+
+    return form;
+  }, [schemaQuery.data, currencies]);
+
+  return {
+    ...schemaQuery,
+    data: dataWithCurrencies as $TSFixMe,
+    isLoading: schemaQuery.isLoading || isLoadingCurrencies,
+  };
+};

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -4,7 +4,6 @@ import {
   CreateContractDocument,
   getV1CompaniesCompanyIdActions,
   getV1ContractorsEmploymentsEmploymentIdContractDocumentsId,
-  getV1CountriesCountryCodeContractorContractDetails,
   getV1ContractorsEmploymentsEmploymentIdContractorSubscriptions,
   ManageContractorPlusSubscriptionOperationsParams,
   postV1ContractorsEmploymentsEmploymentIdContractDocuments,
@@ -18,7 +17,6 @@ import {
   postV1ContractorsEligibilityQuestionnaire,
   postV1ContractorsEmploymentsEmploymentIdContractorCorSubscription,
   deleteV1ContractorsEmploymentsEmploymentIdContractorCorSubscription,
-  getV1ContractorsEmploymentsEmploymentIdContractorCurrencies,
   Country,
 } from '@/src/client';
 import { useClient } from '@/src/context';
@@ -33,7 +31,7 @@ import {
 import { clearBase64Data } from '@/src/lib/utils';
 import { Client } from '@/src/client/client';
 import { createHeadlessForm } from '@/src/common/createHeadlessForm';
-import { useMutation, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { FieldValues } from 'react-hook-form';
 import {
   contractorPlusProductIdentifier,
@@ -57,32 +55,6 @@ import { selectCountryStepSchema } from '@/src/flows/Onboarding/json-schemas/sel
 import { shouldIncludeProduct } from '@/src/flows/ContractorOnboarding/utils';
 import { useCompanyPricingPlans, hasCompany } from '@/src/common/api/companies';
 import { useIdentity } from '@/src/common/api/identity';
-
-const useContractorCurrencies = ({
-  employmentId,
-  options,
-}: {
-  employmentId: string;
-  options?: { queryOptions?: { enabled?: boolean } };
-}) => {
-  const { client } = useClient();
-  return useQuery({
-    queryKey: ['contractor-currencies', employmentId],
-    queryFn: async () => {
-      return getV1ContractorsEmploymentsEmploymentIdContractorCurrencies({
-        client: client as Client,
-        path: { employment_id: employmentId },
-        query: {
-          restrict_to_guaranteed_pay_out_currencies: false,
-        },
-      });
-    },
-    enabled: options?.queryOptions?.enabled,
-    select: ({ data }) => {
-      return data?.data;
-    },
-  });
-};
 
 /**
  * Get the contract document signature schema
@@ -290,51 +262,6 @@ export const useCreateContractorContractDocument = () => {
           employment_id: employmentId,
         },
       });
-    },
-  });
-};
-
-/**
- * Get the contractor onboarding details schema for a given country
- * @param countryCode - The country code
- * @param fieldValues - The field values
- * @param options - The options
- * @returns The contractor onboarding details schema
- */
-const useContractorOnboardingDetailsSchema = ({
-  countryCode,
-  employmentId,
-  fieldValues,
-  options,
-}: {
-  countryCode: string;
-  fieldValues: FieldValues;
-  employmentId: string;
-  options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
-  query?: Record<string, unknown>;
-}): UseQueryResult<JSONSchemaFormResultWithFieldsets> => {
-  const { client } = useClient();
-  return useQuery({
-    queryKey: [
-      'contractor-onboarding-details-schema',
-      countryCode,
-      employmentId,
-    ],
-    retry: false,
-    queryFn: async () => {
-      return getV1CountriesCountryCodeContractorContractDetails({
-        client: client as Client,
-        path: { country_code: countryCode },
-        query: {
-          json_schema_version: 1,
-          employment_id: employmentId,
-        },
-      });
-    },
-    enabled: options?.queryOptions?.enabled,
-    select: ({ data }) => {
-      const jsfSchema = data?.data?.schema || {};
-      return createHeadlessForm(jsfSchema, fieldValues, options);
     },
   });
 };
@@ -868,79 +795,6 @@ export const useCountriesSchemaField = (
     isLoading,
     selectCountryForm,
     countries,
-  };
-};
-
-/**
- * Get contractor onboarding details schema with currency options overridden
- * from the getIndexContractorCurrency endpoint
- */
-export const useContractorOnboardingDetailsSchemaWithCurrencies = ({
-  countryCode,
-  employmentId,
-  fieldValues,
-  options,
-}: {
-  countryCode: string;
-  fieldValues: FieldValues;
-  employmentId: string;
-  options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
-}) => {
-  const schemaQuery = useContractorOnboardingDetailsSchema({
-    countryCode,
-    employmentId,
-    fieldValues,
-    options,
-  });
-
-  const { data: currencies, isLoading: isLoadingCurrencies } =
-    useContractorCurrencies({
-      employmentId,
-      options: {
-        queryOptions: { enabled: options?.queryOptions?.enabled },
-      },
-    });
-
-  const dataWithCurrencies = useMemo(() => {
-    if (!schemaQuery.data || !currencies) {
-      return schemaQuery.data;
-    }
-
-    const form = {
-      ...schemaQuery.data,
-      fields: schemaQuery.data.fields.map((field) => {
-        if (field.name !== 'payment_terms') {
-          return field;
-        }
-
-        return {
-          ...field,
-          fields: (field.fields as $TSFixMe[])?.map((nestedField: $TSFixMe) => {
-            if (nestedField.name !== 'compensation_currency_code') {
-              return nestedField;
-            }
-
-            // Return a new object with overridden options
-            return {
-              ...nestedField,
-              options: currencies.map((currency) => ({
-                label: currency.code,
-                value: currency.code,
-                meta: { source: currency.source },
-              })),
-            };
-          }),
-        };
-      }),
-    };
-
-    return form;
-  }, [schemaQuery.data, currencies]);
-
-  return {
-    ...schemaQuery,
-    data: dataWithCurrencies as $TSFixMe,
-    isLoading: schemaQuery.isLoading || isLoadingCurrencies,
   };
 };
 

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -27,13 +27,13 @@ import {
   usePostManageContractorCorSubscription,
   useDeleteContractorCorSubscription,
   useCountriesSchemaField,
-  useContractorOnboardingDetailsSchemaWithCurrencies,
   CONTRACT_PRODUCT_TITLES,
   useHasCompanySignedContract,
   useCompanyOpenTasks,
   useSetContractOrigin,
   useGetContractOriginSchema,
 } from '@/src/flows/ContractorOnboarding/api';
+import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
   ContractorOnboardingFlowProps,
   ContractorOnboardingHookOptions,
@@ -624,7 +624,7 @@ export const useContractorOnboarding = ({
   const {
     data: contractorOnboardingDetailsForm,
     isLoading: isLoadingContractorOnboardingDetailsForm,
-  } = useContractorOnboardingDetailsSchemaWithCurrencies({
+  } = useContractorContractDetailsSchema({
     countryCode: internalCountryCode as string,
     fieldValues: fieldValues,
     employmentId: internalEmploymentId as string,


### PR DESCRIPTION
## Description

Move hook to a shared location to use in a next PR I am working on to reuse endpoints

## Summary
- Extracts `useContractorOnboardingDetailsSchemaWithCurrencies` (and its private `useContractorCurrencies` / `useContractorOnboardingDetailsSchema` helpers) out of `ContractorOnboarding/api.ts` into `src/common/api/contractor-contract-details.ts`, renamed to `useContractorContractDetailsSchema`.
- Updates `ContractorOnboarding/hooks.tsx` to import the hook from its new common location.

This is split out ahead of the upcoming ContractorContractCreation flow, which needs to reuse this same schema-fetching hook without duplicating it inside ContractorOnboarding.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with logic relocated unchanged; only import paths and hook naming change in contractor onboarding.
> 
> **Overview**
> Moves contractor **contract details** JSON-schema fetching (country schema + employment-scoped currency overrides for `payment_terms.compensation_currency_code`) out of `ContractorOnboarding/api.ts` into **`src/common/api/contractor-contract-details.ts`**, exported as **`useContractorContractDetailsSchema`** (replacing **`useContractorOnboardingDetailsSchemaWithCurrencies`**).
> 
> `ContractorOnboarding/hooks.tsx` now imports that hook from common API; onboarding API drops the related client imports and helper hooks. **No intended behavior change**—same React Query keys and currency override logic—so a future **ContractorContractCreation** flow can reuse the hook without duplicating onboarding API code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f7f244232905b36f41115e57459eead0010d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->