### PR TITLE
docs(bugbot) - make bugbot more intelligent

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -439,6 +439,7 @@ flows/[FlowName]/
 - Reimplementing existing UI components
 - Not using `cn()` helper for class merging
 - Missing `asChild` pattern for polymorphic components
+- Adding a new ad-hoc flag, condition, or check where an existing one nearby (in the same file, hook, or context) already covers the same case — prefer extending/reusing it over introducing a parallel mechanism
 
 ### 8. Testing Issues
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to Bugbot review rules; no runtime or package behavior.
> 
> **Overview**
> Updates **Bugbot** review guidance in `.cursor/BUGBOT.md` under **Component Composition Issues**.
> 
> Adds a rule to flag new ad-hoc flags, conditions, or checks when an existing one in the same file, hook, or context already covers the case — reviewers should prefer extending or reusing that mechanism instead of introducing a parallel one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb777e4d117d4562bc1b2a235125d2e843f07b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->