### PR TITLE
feat(contractors) - build intermeddiate step

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -20,6 +20,7 @@ import {
   eorProductIdentifier,
   $TSFixMe,
   JSFModifyField,
+  ZendeskTriggerButton,
 } from '@remoteoss/remote-flows';
 import {
   Card,
@@ -156,7 +157,18 @@ const ContractOriginRadio = ({
           </h1>
         )}
         {fieldData.description && (
-          <p className='text-sm text-[#71717A]'>{fieldData.description}</p>
+          <p className='text-sm text-[#71717A]'>
+            {fieldData.description}{' '}
+            {fieldData.meta?.helpCenter?.callToAction &&
+              fieldData.meta?.helpCenter?.id && (
+                <ZendeskTriggerButton
+                  zendeskId={fieldData.meta?.helpCenter?.id}
+                  external
+                >
+                  {fieldData.meta?.helpCenter?.callToAction}
+                </ZendeskTriggerButton>
+              )}
+          </p>
         )}
       </div>
       {fieldData.options?.map((option) => {

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -215,6 +215,7 @@ const MultiStepForm = ({
     ContractReviewButton,
     SaveDraftButton,
     ContractOriginStep,
+    InvoiceScheduleStep,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -504,6 +505,41 @@ const MultiStepForm = ({
         </div>
       );
 
+    case 'invoice_schedule':
+      return (
+        <div className='contractor-onboarding-form-layout'>
+          <InvoiceScheduleStep
+            components={{
+              radio: (props) => <ContractOriginRadio {...props} />,
+            }}
+            onSubmit={(payload) =>
+              console.log('invoice schedule payload', payload)
+            }
+            onSuccess={(response) =>
+              console.log('invoice schedule response', response)
+            }
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <AlertError errors={errors} />
+          <div className='contractor-onboarding-buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Back
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Continue
+            </SubmitButton>
+          </div>
+        </div>
+      );
+
     case 'eligibility_questionnaire':
       return (
         <div className='contractor-onboarding-form-layout'>
@@ -632,6 +668,7 @@ export const ContractorOnboardingWithProps = ({
             employmentId={employmentId}
             externalId={externalId}
             options={{
+              features: ['create_invoice_schedule'],
               jsonSchemaVersion: {
                 employment_basic_information: 1,
               },

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -15,6 +15,7 @@ import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/component
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
+import { InvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/InvoiceScheduleStep';
 
 export const ContractorOnboardingFlow = ({
   render,
@@ -64,6 +65,7 @@ export const ContractorOnboardingFlow = ({
           PricingPlanStep: PricingPlanStep,
           EligibilityQuestionnaireStep: EligibilityQuestionnaireStep,
           ContractOriginStep: ContractOriginStep,
+          InvoiceScheduleStep: InvoiceScheduleStep,
           ContractDetailsStep: ContractDetailsStep,
           ContractPreviewStep: ContractPreviewStep,
           OnboardingInvite: OnboardingInvite,

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -22,6 +22,7 @@ import {
 import { useClient } from '@/src/context';
 import { signatureSchema } from '@/src/flows/ContractorOnboarding/json-schemas/signature';
 import { contractOriginSchema } from '@/src/flows/ContractorOnboarding/json-schemas/contractOrigin';
+import { invoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule';
 import { selectContractorSubscriptionStepSchema } from '@/src/flows/ContractorOnboarding/json-schemas/selectContractorSubscriptionStep';
 import {
   JSONSchemaFormResultWithFieldsets,
@@ -745,6 +746,24 @@ export const useGetContractOriginSchema = ({
     queryKey: ['contract-origin-schema', options?.jsfModify],
     queryFn: async () => {
       return createHeadlessForm(contractOriginSchema, fieldValues, {
+        jsfModify: options?.jsfModify,
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+  });
+};
+
+export const useGetInvoiceScheduleSchema = ({
+  fieldValues,
+  options,
+}: {
+  fieldValues: FieldValues;
+  options?: { queryOptions?: { enabled?: boolean }; jsfModify?: JSFModify };
+}) => {
+  return useQuery({
+    queryKey: ['invoice-schedule-schema', options?.jsfModify],
+    queryFn: async () => {
+      return createHeadlessForm(invoiceScheduleSchema, fieldValues, {
         jsfModify: options?.jsfModify,
       });
     },

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -762,9 +762,13 @@ export const useGetInvoiceScheduleSchema = ({
 }) => {
   return useMemo(() => {
     if (!enabled) return null;
-    return createHeadlessForm(invoiceScheduleSchema, {}, {
-      jsfModify,
-    });
+    return createHeadlessForm(
+      invoiceScheduleSchema,
+      {},
+      {
+        jsfModify,
+      },
+    );
   }, [enabled, jsfModify]);
 };
 

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -754,21 +754,18 @@ export const useGetContractOriginSchema = ({
 };
 
 export const useGetInvoiceScheduleSchema = ({
-  fieldValues,
-  options,
+  enabled,
+  jsfModify,
 }: {
-  fieldValues: FieldValues;
-  options?: { queryOptions?: { enabled?: boolean }; jsfModify?: JSFModify };
+  enabled?: boolean;
+  jsfModify?: JSFModify;
 }) => {
-  return useQuery({
-    queryKey: ['invoice-schedule-schema', options?.jsfModify],
-    queryFn: async () => {
-      return createHeadlessForm(invoiceScheduleSchema, fieldValues, {
-        jsfModify: options?.jsfModify,
-      });
-    },
-    enabled: options?.queryOptions?.enabled,
-  });
+  return useMemo(() => {
+    if (!enabled) return null;
+    return createHeadlessForm(invoiceScheduleSchema, {}, {
+      jsfModify,
+    });
+  }, [enabled, jsfModify]);
 };
 
 export const useCountriesSchemaField = (

--- a/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
+++ b/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
@@ -4,6 +4,10 @@ import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding
 import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
 import { handleStepError } from '@/src/lib/utils';
 import { UseFormReturn } from 'react-hook-form';
+import {
+  InvoiceScheduleFormPayload,
+  InvoiceScheduleResponse,
+} from '@/src/flows/ContractorOnboarding/types';
 
 type InvoiceScheduleStepProps = {
   /**
@@ -13,15 +17,11 @@ type InvoiceScheduleStepProps = {
   /*
    * The function is called when the form is submitted. It receives the form values as an argument.
    */
-  onSubmit?: (payload: {
-    invoice_schedule_preference: string;
-  }) => void | Promise<void>;
+  onSubmit?: (payload: InvoiceScheduleFormPayload) => void | Promise<void>;
   /*
    * The function is called when the form submission is successful.
    */
-  onSuccess?: (data: {
-    invoiceSchedulePreference: string;
-  }) => void | Promise<void>;
+  onSuccess?: (data: InvoiceScheduleResponse) => void | Promise<void>;
   /*
    * The function is called when an error occurs during form submission.
    */
@@ -51,19 +51,11 @@ export function InvoiceScheduleStep({
     try {
       const parsedValues =
         await contractorOnboardingBag.parseFormValues(payload);
-      await onSubmit?.(
-        parsedValues as {
-          invoice_schedule_preference: string;
-        },
-      );
+      await onSubmit?.(parsedValues as InvoiceScheduleFormPayload);
       const response = await contractorOnboardingBag.onSubmit(payload);
 
       if (response?.data) {
-        await onSuccess?.(
-          response.data as {
-            invoiceSchedulePreference: string;
-          },
-        );
+        await onSuccess?.(response.data as InvoiceScheduleResponse);
         contractorOnboardingBag?.next();
         return;
       }

--- a/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
+++ b/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
@@ -1,0 +1,91 @@
+import { $TSFixMe, Components } from '@/src/types/remoteFlows';
+import { NormalizedFieldError } from '@/src/lib/mutations';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+import { handleStepError } from '@/src/lib/utils';
+import { UseFormReturn } from 'react-hook-form';
+
+type InvoiceScheduleStepProps = {
+  /**
+   * Components to override the default field components used in the form.
+   */
+  components?: Components;
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: {
+    invoice_schedule_preference: string;
+  }) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: {
+    invoiceSchedulePreference: string;
+  }) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function InvoiceScheduleStep({
+  components,
+  onSubmit,
+  onSuccess,
+  onError,
+}: InvoiceScheduleStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const handleSubmit = async (
+    payload: $TSFixMe,
+    form: UseFormReturn<$TSFixMe>,
+  ) => {
+    try {
+      const parsedValues =
+        await contractorOnboardingBag.parseFormValues(payload);
+      await onSubmit?.(
+        parsedValues as {
+          invoice_schedule_preference: string;
+        },
+      );
+      const response = await contractorOnboardingBag.onSubmit(payload);
+
+      if (response?.data) {
+        await onSuccess?.(
+          response.data as {
+            invoiceSchedulePreference: string;
+          },
+        );
+        contractorOnboardingBag?.next();
+        return;
+      }
+    } catch (error: unknown) {
+      const structuredError = handleStepError(
+        error,
+        contractorOnboardingBag.meta?.fields?.invoice_schedule,
+        form,
+      );
+      onError?.(structuredError);
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.invoice_schedule ||
+    contractorOnboardingBag.initialValues.invoice_schedule;
+
+  return (
+    <ContractorOnboardingForm
+      components={components}
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -684,6 +684,9 @@ export const useContractorOnboarding = ({
   const { data: invoiceScheduleForm } = useGetInvoiceScheduleSchema({
     fieldValues: fieldValues,
     options: {
+      queryOptions: {
+        enabled: includeInvoiceSchedule,
+      },
       jsfModify: options?.jsfModify?.invoice_schedule,
     },
   });

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -32,6 +32,7 @@ import {
   useCompanyOpenTasks,
   useSetContractOrigin,
   useGetContractOriginSchema,
+  useGetInvoiceScheduleSchema,
 } from '@/src/flows/ContractorOnboarding/api';
 import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
@@ -86,6 +87,7 @@ const stepToFormSchemaMap: Record<StepKeys, JSONSchemaFormType | null> = {
   select_country: null,
   basic_information: 'employment_basic_information',
   contract_origin: null,
+  invoice_schedule: null,
   contract_details: null,
   eligibility_questionnaire: null,
   pricing_plan: null,
@@ -128,6 +130,7 @@ export const useContractorOnboarding = ({
     select_country: Meta;
     basic_information: Meta;
     contract_origin: Meta;
+    invoice_schedule: Meta;
     contract_details: Meta;
     contract_preview: Meta;
     pricing_plan: Meta;
@@ -136,6 +139,7 @@ export const useContractorOnboarding = ({
     select_country: {},
     basic_information: {},
     contract_origin: {},
+    invoice_schedule: {},
     contract_details: {},
     contract_preview: {},
     pricing_plan: {},
@@ -158,6 +162,9 @@ export const useContractorOnboarding = ({
   const [includeContractOrigin, setIncludeContractOrigin] =
     useState<boolean>(true);
 
+  const [includeInvoiceSchedule, setIncludeInvoiceSchedule] =
+    useState<boolean>(false);
+
   const [pendingNavigationStep, setPendingNavigationStep] =
     useState<StepKeys | null>(null);
 
@@ -166,12 +173,14 @@ export const useContractorOnboarding = ({
       buildSteps({
         includeSelectCountry: !skipSteps?.includes('select_country'),
         includeContractOrigin: includeContractOrigin,
+        includeInvoiceSchedule: includeInvoiceSchedule,
         includeEligibilityQuestionnaire: includeEligibilityQuestionnaire,
         includeContractDetails: includeContractDetails,
         includeContractPreview: includeContractPreview,
       }),
     [
       includeContractOrigin,
+      includeInvoiceSchedule,
       includeEligibilityQuestionnaire,
       includeContractDetails,
       includeContractPreview,
@@ -237,7 +246,7 @@ export const useContractorOnboarding = ({
   const createEmploymentMutation = useCreateEmployment();
   const updateEmploymentMutation = useUpdateEmployment(
     internalCountryCode as string,
-    options,
+    options as $TSFixMe, // TODO: done it as its shared between contractor and onboarding flows
   );
   const createContractorContractDocumentMutation =
     useCreateContractorContractDocument();
@@ -573,6 +582,12 @@ export const useContractorOnboarding = ({
     );
   }, [skipSteps, selectedPricingPlan]);
 
+  useEffect(() => {
+    setIncludeInvoiceSchedule(
+      options?.features?.includes('create_invoice_schedule') ?? false,
+    );
+  }, [options?.features]);
+
   const eligibilityFields = useMemo(() => {
     return {
       ...eligibilityAnswers,
@@ -666,6 +681,13 @@ export const useContractorOnboarding = ({
     },
   });
 
+  const { data: invoiceScheduleForm } = useGetInvoiceScheduleSchema({
+    fieldValues: fieldValues,
+    options: {
+      jsfModify: options?.jsfModify?.invoice_schedule,
+    },
+  });
+
   const {
     data: documentPreviewPdf,
     isLoading: isLoadingDocumentPreviewForm,
@@ -695,6 +717,7 @@ export const useContractorOnboarding = ({
       select_country: selectCountryForm?.fields || [],
       basic_information: basicInformationForm?.fields || [],
       contract_origin: contractOriginForm?.fields || [],
+      invoice_schedule: invoiceScheduleForm?.fields || [],
       pricing_plan: selectContractorSubscriptionForm?.fields || [],
       eligibility_questionnaire: eligibilityQuestionnaireForm?.fields || [],
       contract_details: contractorOnboardingDetailsForm?.fields || [],
@@ -705,6 +728,7 @@ export const useContractorOnboarding = ({
       selectCountryForm?.fields,
       basicInformationForm?.fields,
       contractOriginForm?.fields,
+      invoiceScheduleForm?.fields,
       selectContractorSubscriptionForm?.fields,
       contractorOnboardingDetailsForm?.fields,
       signatureSchemaForm?.fields,
@@ -719,6 +743,7 @@ export const useContractorOnboarding = ({
     select_country: null,
     basic_information: basicInformationForm?.meta['x-jsf-fieldsets'],
     contract_origin: null,
+    invoice_schedule: null,
     pricing_plan: null,
     contract_details: contractorOnboardingDetailsForm?.meta['x-jsf-fieldsets'],
     eligibility_questionnaire: null,
@@ -733,6 +758,7 @@ export const useContractorOnboarding = ({
     select_country: selectCountryForm?.meta?.['x-jsf-presentation'],
     basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
     contract_origin: contractOriginForm?.meta?.['x-jsf-presentation'],
+    invoice_schedule: invoiceScheduleForm?.meta?.['x-jsf-presentation'],
     pricing_plan:
       selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
     eligibility_questionnaire:
@@ -798,6 +824,13 @@ export const useContractorOnboarding = ({
     onboardingInitialValues,
     employment?.contract_details?.contract_origin,
   ]);
+
+  const invoiceScheduleInitialValues = useMemo(() => {
+    const initialValues = {
+      ...onboardingInitialValues,
+    };
+    return getInitialValues(stepFields.invoice_schedule, initialValues);
+  }, [stepFields.invoice_schedule, onboardingInitialValues]);
 
   const contractDetailsInitialValues = useMemo(() => {
     const hardcodedValues = {
@@ -868,6 +901,7 @@ export const useContractorOnboarding = ({
       select_country: selectCountryInitialValues,
       basic_information: basicInformationInitialValues,
       contract_origin: contractOriginInitialValues,
+      invoice_schedule: invoiceScheduleInitialValues,
       contract_details: contractDetailsInitialValues,
       contract_preview: contractPreviewInitialValues,
       pricing_plan: pricingPlanInitialValues,
@@ -877,6 +911,7 @@ export const useContractorOnboarding = ({
     selectCountryInitialValues,
     basicInformationInitialValues,
     contractOriginInitialValues,
+    invoiceScheduleInitialValues,
     contractDetailsInitialValues,
     contractPreviewInitialValues,
     pricingPlanInitialValues,
@@ -937,6 +972,7 @@ export const useContractorOnboarding = ({
           { skipMoneyConversion: true },
         ),
         contract_origin: {},
+        invoice_schedule: {},
         contract_details: prettifyFormValues(
           contractDetailsInitialValues,
           stepFields.contract_details,
@@ -963,6 +999,7 @@ export const useContractorOnboarding = ({
         select_country: selectCountryInitialValues,
         basic_information: basicInformationInitialValues,
         contract_origin: {},
+        invoice_schedule: {},
         contract_details: contractDetailsInitialValues,
         contract_preview: contractPreviewInitialValues,
         pricing_plan: pricingPlanInitialValues,
@@ -1060,6 +1097,15 @@ export const useContractorOnboarding = ({
       stepState.currentStep.name === 'contract_origin'
     ) {
       return await parseJSFToValidate(values, contractOriginForm?.fields, {
+        isPartialValidation: false,
+      });
+    }
+
+    if (
+      invoiceScheduleForm &&
+      stepState.currentStep.name === 'invoice_schedule'
+    ) {
+      return await parseJSFToValidate(values, invoiceScheduleForm?.fields, {
         isPartialValidation: false,
       });
     }
@@ -1347,6 +1393,14 @@ export const useContractorOnboarding = ({
         };
       }
 
+      case 'invoice_schedule': {
+        return {
+          data: {
+            invoiceSchedulePreference: values.invoice_schedule_preference,
+          },
+        };
+      }
+
       case 'eligibility_questionnaire': {
         try {
           const response = await createEligibilityQuestionnaireMutationAsync({
@@ -1559,6 +1613,18 @@ export const useContractorOnboarding = ({
           { isPartialValidation: false },
         );
         return contractOriginForm?.handleValidation(parsedValues);
+      }
+
+      if (
+        invoiceScheduleForm &&
+        stepState.currentStep.name === 'invoice_schedule'
+      ) {
+        const parsedValues = await parseJSFToValidate(
+          values,
+          invoiceScheduleForm?.fields,
+          { isPartialValidation: false },
+        );
+        return invoiceScheduleForm?.handleValidation(parsedValues);
       }
 
       return null;

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import omit from 'lodash.omit';
-import { $TSFixMe, JSFFields } from '@/src/types/remoteFlows';
+import { $TSFixMe, JSFFields, NestedMeta } from '@/src/types/remoteFlows';
 import {
   CreateContractDocument,
   Employment,
@@ -56,7 +56,7 @@ import { FlowOptions, JSFModify, JSONSchemaFormType } from '@/src/flows/types';
 import { useStepState } from '@/src/flows/useStepState';
 import { mutationToPromise, isMutationError } from '@/src/lib/mutations';
 import { createStructuredError, prettifyFormValues } from '@/src/lib/utils';
-import { JSFFieldset, Meta } from '@/src/types/remoteFlows';
+import { JSFFieldset } from '@/src/types/remoteFlows';
 import {
   contractorStandardProductIdentifier,
   contractorPlusProductIdentifier,
@@ -127,14 +127,14 @@ export const useContractorOnboarding = ({
     string | undefined
   >(undefined);
   const fieldsMetaRef = useRef<{
-    select_country: Meta;
-    basic_information: Meta;
-    contract_origin: Meta;
-    invoice_schedule: Meta;
-    contract_details: Meta;
-    contract_preview: Meta;
-    pricing_plan: Meta;
-    eligibility_questionnaire: Meta;
+    select_country: NestedMeta;
+    basic_information: NestedMeta;
+    contract_origin: NestedMeta;
+    invoice_schedule: NestedMeta;
+    contract_details: NestedMeta;
+    contract_preview: NestedMeta;
+    pricing_plan: NestedMeta;
+    eligibility_questionnaire: NestedMeta;
   }>({
     select_country: {},
     basic_information: {},
@@ -681,14 +681,9 @@ export const useContractorOnboarding = ({
     },
   });
 
-  const { data: invoiceScheduleForm } = useGetInvoiceScheduleSchema({
-    fieldValues: fieldValues,
-    options: {
-      queryOptions: {
-        enabled: includeInvoiceSchedule,
-      },
-      jsfModify: options?.jsfModify?.invoice_schedule,
-    },
+  const invoiceScheduleForm = useGetInvoiceScheduleSchema({
+    enabled: includeInvoiceSchedule,
+    jsfModify: options?.jsfModify?.invoice_schedule,
   });
 
   const {
@@ -1448,100 +1443,8 @@ export const useContractorOnboarding = ({
     nextStep();
   };
 
-  const isLoading = initialLoading || shouldHandleReadOnlyEmployment;
-
-  return {
-    /**
-     * Loading state indicating if the flow is loading data
-     */
-    isLoading,
-
-    /**
-     * Current state of the form fields for the current step.
-     */
-    fieldValues,
-
-    /**
-     * Current step state containing the current step and total number of steps
-     */
-    stepState,
-
-    /**
-     * Function to update the current form field values
-     * @param values - New form values to set
-     */
-    checkFieldUpdates: setFieldValues,
-
-    /**
-     * Function to mark the contract as reviewed
-     * @param values - New form values to check
-     * @returns {boolean}
-     */
-    markContractAsReviewed,
-
-    /**
-     * Function to handle going back to the previous step
-     * @returns {void}
-     */
-    back: previousStep,
-
-    /**
-     * Function to handle going to the next step
-     * @returns {void}
-     */
-    next: handleNextStep,
-
-    /**
-     * Function to handle going to a specific step
-     * @param step The step to go to.
-     * @returns {void}
-     */
-    goTo: goTo,
-
-    /**
-     * Function to handle form submission
-     * @param values - Form values to submit
-     * @returns Promise resolving to the mutation result
-     */
-    onSubmit,
-
-    /**
-     * Array of form fields from the onboarding schema
-     */
-    fields: stepFields[stepState.currentStep.name],
-
-    /**
-     * Fields metadata for each step
-     */
-    meta: {
-      fields: fieldsMetaRef.current,
-      fieldsets: stepFieldsWithFlatFieldsets[stepState.currentStep.name],
-      presentation: stepPresentation[stepState.currentStep.name],
-    },
-
-    /**
-     * Function to parse form values before submission
-     * @param values - Form values to parse
-     * @returns Parsed form values
-     */
-    parseFormValues,
-
-    /**
-     * Indicates whether AI validation errors can be skipped (user can continue at their own risk).
-     * True when there's a skippable AI validation error on services_and_deliverables field.
-     * @returns {boolean}
-     */
-    canSkipAiValidation:
-      fieldValues.services_and_deliverables_error_skippable === true,
-
-    /**
-     * Function to validate form values against the onboarding schema
-     * @param values - Form values to validate
-     * @returns Validation result or null if no schema is available
-     */
-    handleValidation: async (
-      values: FieldValues,
-    ): Promise<ValidationResult | null> => {
+  const handleValidation = useCallback(
+    async (values: FieldValues): Promise<ValidationResult | null> => {
       if (stepState.currentStep.name === 'select_country') {
         return selectCountryForm.handleValidation(values);
       }
@@ -1632,6 +1535,124 @@ export const useContractorOnboarding = ({
 
       return null;
     },
+    [
+      stepState.currentStep.name,
+      selectCountryForm,
+      basicInformationForm,
+      contractorOnboardingDetailsForm,
+      signatureSchemaForm,
+      selectContractorSubscriptionForm,
+      eligibilityQuestionnaireForm,
+      contractOriginForm,
+      invoiceScheduleForm,
+    ],
+  );
+
+  const checkFieldUpdates = useCallback(
+    async (values: FieldValues) => {
+      setFieldValues(values);
+      if (
+        includeInvoiceSchedule &&
+        stepState.currentStep.name === 'invoice_schedule'
+      ) {
+        await handleValidation(values);
+      }
+    },
+    [setFieldValues, includeInvoiceSchedule, stepState, handleValidation],
+  );
+
+  const isLoading = initialLoading || shouldHandleReadOnlyEmployment;
+
+  return {
+    /**
+     * Loading state indicating if the flow is loading data
+     */
+    isLoading,
+
+    /**
+     * Current state of the form fields for the current step.
+     */
+    fieldValues,
+
+    /**
+     * Current step state containing the current step and total number of steps
+     */
+    stepState,
+
+    /**
+     * Function to update the current form field values
+     * @param values - New form values to set
+     */
+    checkFieldUpdates,
+
+    /**
+     * Function to mark the contract as reviewed
+     * @param values - New form values to check
+     * @returns {boolean}
+     */
+    markContractAsReviewed,
+
+    /**
+     * Function to handle going back to the previous step
+     * @returns {void}
+     */
+    back: previousStep,
+
+    /**
+     * Function to handle going to the next step
+     * @returns {void}
+     */
+    next: handleNextStep,
+
+    /**
+     * Function to handle going to a specific step
+     * @param step The step to go to.
+     * @returns {void}
+     */
+    goTo: goTo,
+
+    /**
+     * Function to handle form submission
+     * @param values - Form values to submit
+     * @returns Promise resolving to the mutation result
+     */
+    onSubmit,
+
+    /**
+     * Array of form fields from the onboarding schema
+     */
+    fields: stepFields[stepState.currentStep.name],
+
+    /**
+     * Fields metadata for each step
+     */
+    meta: {
+      fields: fieldsMetaRef.current,
+      fieldsets: stepFieldsWithFlatFieldsets[stepState.currentStep.name],
+      presentation: stepPresentation[stepState.currentStep.name],
+    },
+
+    /**
+     * Function to parse form values before submission
+     * @param values - Form values to parse
+     * @returns Parsed form values
+     */
+    parseFormValues,
+
+    /**
+     * Indicates whether AI validation errors can be skipped (user can continue at their own risk).
+     * True when there's a skippable AI validation error on services_and_deliverables field.
+     * @returns {boolean}
+     */
+    canSkipAiValidation:
+      fieldValues.services_and_deliverables_error_skippable === true,
+
+    /**
+     * Function to validate form values against the onboarding schema
+     * @param values - Form values to validate
+     * @returns Validation result or null if no schema is available
+     */
+    handleValidation,
 
     /**
      * Initial form values

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1551,6 +1551,8 @@ export const useContractorOnboarding = ({
   const checkFieldUpdates = useCallback(
     async (values: FieldValues) => {
       setFieldValues(values);
+      // new steps or refactor ones should rely on json-schema-form-mutability
+      // instead of passing fieldValues
       if (
         includeInvoiceSchedule &&
         stepState.currentStep.name === 'invoice_schedule'

--- a/src/flows/ContractorOnboarding/index.ts
+++ b/src/flows/ContractorOnboarding/index.ts
@@ -10,6 +10,8 @@ export type {
   ContractPreviewResponse,
   EligibilityQuestionnaireFormPayload,
   EligibilityQuestionnaireResponse,
+  InvoiceScheduleFormPayload,
+  InvoiceScheduleResponse,
 } from './types';
 export type { ProductType } from './constants';
 export {

--- a/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
@@ -23,6 +23,12 @@ export const invoiceScheduleSchema = {
       'x-jsf-presentation': {
         direction: 'column',
         inputType: 'radio',
+        meta: {
+          helpCenter: {
+            id: 13291039232141,
+            callToAction: 'Learn about invoice schedules',
+          },
+        },
       },
     },
   },

--- a/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
@@ -1,0 +1,30 @@
+export const invoiceScheduleSchema = {
+  type: 'object',
+  properties: {
+    invoice_schedule_preference: {
+      description:
+        'Set up a schedule to automatically create invoices on behalf of this contractor.',
+      oneOf: [
+        {
+          const: 'create_now',
+          description:
+            'Set up a schedule to create invoices for this contractor now.',
+          title: 'Create invoice schedule now',
+        },
+        {
+          const: 'skip',
+          description:
+            'You or your contractor can always set up an invoice schedule later.',
+          title: 'Skip for now',
+        },
+      ],
+      title: 'Invoice schedule',
+      type: 'string',
+      'x-jsf-presentation': {
+        direction: 'column',
+        inputType: 'radio',
+      },
+    },
+  },
+  required: ['invoice_schedule_preference'],
+};

--- a/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
@@ -6,13 +6,13 @@ export const invoiceScheduleSchema = {
         'Set up a schedule to automatically create invoices on behalf of this contractor.',
       oneOf: [
         {
-          const: 'create_now',
+          const: 'schedule',
           description:
             'Set up a schedule to create invoices for this contractor now.',
           title: 'Create invoice schedule now',
         },
         {
-          const: 'skip',
+          const: 'manual',
           description:
             'You or your contractor can always set up an invoice schedule later.',
           title: 'Skip for now',

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -65,7 +65,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [4]: 'Contract Origin',
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
-  [7]: 'Review',
+  [7]: 'Invoice schedule',
+  [8]: 'Review',
 };
 
 function createMockRenderImplementation(

--- a/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
@@ -34,7 +34,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [4]: 'Eligibility Questionnaire',
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
-  [7]: 'Review',
+  [7]: 'Invoice schedule',
+  [8]: 'Review',
 };
 
 const mockSuccess = vi.fn();

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -187,3 +187,11 @@ export type EligibilityQuestionnaireFormPayload = {
 };
 
 export type EligibilityQuestionnaireResponse = SuccessResponse;
+
+export type InvoiceScheduleFormPayload = {
+  invoice_schedule_preference: string;
+};
+
+export type InvoiceScheduleResponse = {
+  invoiceSchedulePreference: string;
+};

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -16,6 +16,7 @@ import { OnboardingInvite } from '@/src/flows/ContractorOnboarding/components/On
 import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/components/ContractReviewButton';
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
 import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
+import { InvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/InvoiceScheduleStep';
 import { ProductType } from '@/src/flows/ContractorOnboarding/constants';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 
@@ -46,6 +47,7 @@ export type ContractorOnboardingRenderProps = {
     SubmitButton: typeof OnboardingSubmit;
     PricingPlanStep: typeof PricingPlanStep;
     ContractOriginStep: typeof ContractOriginStep;
+    InvoiceScheduleStep: typeof InvoiceScheduleStep;
     ContractDetailsStep: typeof ContractDetailsStep;
     ContractPreviewStep: typeof ContractPreviewStep;
     OnboardingInvite: typeof OnboardingInvite;
@@ -55,6 +57,8 @@ export type ContractorOnboardingRenderProps = {
   };
 };
 
+type ContractorOnboardingFeatures = 'create_invoice_schedule';
+
 type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
   /**
    * Products to exclude from the available options in pricing_plan step.
@@ -63,6 +67,11 @@ type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
    * @example excludeProducts: ['eor', 'cor'] // Hide both EOR and COR
    */
   excludeProducts?: ProductType[];
+  /**
+   * Features to enable for the contractor onboarding flow.
+   * - 'create_invoice_schedule': Enable the invoice schedule step
+   */
+  features?: ContractorOnboardingFeatures[];
   /**
    * The JSON schema modification to use for the onboarding.
    * This is used to modify the JSON schema for the onboarding.
@@ -76,6 +85,7 @@ type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
     eligibility_questionnaire?: JSFModify;
     pricing_plan?: JSFModify;
     contract_origin?: JSFModify;
+    invoice_schedule?: JSFModify;
   };
 };
 

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -13,6 +13,7 @@ export type StepKeys =
   | 'select_country'
   | 'basic_information'
   | 'contract_origin'
+  | 'invoice_schedule'
   | 'contract_details'
   | 'eligibility_questionnaire'
   | 'contract_preview'
@@ -22,6 +23,7 @@ export type StepKeys =
 type StepConfig = {
   includeSelectCountry?: boolean;
   includeContractOrigin?: boolean;
+  includeInvoiceSchedule?: boolean;
   includeEligibilityQuestionnaire?: boolean;
   includeContractDetails?: boolean;
   includeContractPreview?: boolean;
@@ -67,6 +69,11 @@ export function buildSteps(config: StepConfig = {}) {
       name: 'contract_preview',
       label: 'Contract Preview',
       visible: Boolean(config?.includeContractPreview),
+    },
+    {
+      name: 'invoice_schedule',
+      label: 'Invoice schedule',
+      visible: Boolean(config?.includeInvoiceSchedule),
     },
     {
       name: 'review',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,8 @@ export type {
   ContractPreviewResponse,
   EligibilityQuestionnaireFormPayload,
   EligibilityQuestionnaireResponse,
+  InvoiceScheduleFormPayload,
+  InvoiceScheduleResponse,
 } from '@/src/flows/ContractorOnboarding';
 
 export type { ContractPreviewStatementProps } from '@/src/flows/ContractorOnboarding/components/ContractPreviewStatement';


### PR DESCRIPTION
Create infrastructure to create the new step to create invoices

The work is under a feature flag to prevent usage or break partners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are feature-flagged and the new step does not persist data to the API yet; risk is limited to step ordering and optional UI when the flag is enabled.
> 
> **Overview**
> Adds an optional **Invoice schedule** step to contractor onboarding, placed after contract preview and before review. The step is only included when `options.features` includes **`create_invoice_schedule`** (off by default so partners are unaffected).
> 
> The step uses a new JSON schema (`invoice_schedule_preference`: create schedule now vs skip) with **`InvoiceScheduleStep`**, schema hook **`useGetInvoiceScheduleSchema`**, and the same validation/parse/submit wiring as other JSF steps. Submit currently returns the preference in the response **without calling a backend API**—infrastructure for a follow-up.
> 
> The example app enables the feature flag and wires the step UI (reusing the contract-origin radio layout). **`ZendeskTriggerButton`** is added to **`ContractOriginRadio`** when field meta includes `helpCenter` (also used by the invoice schedule schema). **`handleValidation`** and **`checkFieldUpdates`** are refactored into shared callbacks, with validation on field updates for the invoice schedule step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3dc67ef99eb8b682a21421a5fe818efb7f4e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->