### PR TITLE
feat(ai) - add cursor rules

### DIFF
--- a/.cursor/rules/check-existing-patterns.mdc
+++ b/.cursor/rules/check-existing-patterns.mdc
@@ -1,0 +1,124 @@
+---
+alwaysApply: true
+description: Always verify existing code patterns before proposing solutions
+---
+
+# Check Existing Patterns Rule
+
+## Philosophy: Verify Before You Code
+
+Before proposing or implementing any solution, **always** check the existing codebase patterns. Never make up functions, imports, or patterns that don't exist.
+
+## Critical Requirements
+
+### 1. Read Before You Write
+
+**ALWAYS** use the Read tool to check existing files before:
+
+- Creating new components
+- Adding new functions
+- Importing modules or utilities
+- Proposing architectural changes
+- Suggesting API calls or hooks
+
+### 2. Search for Similar Patterns
+
+When implementing something new, **first search** for similar implementations:
+
+```bash
+# Find similar components
+Glob: **/*StepComponent*.tsx
+
+# Find similar API hooks
+Grep: "export const use.*Options"
+
+# Find similar type definitions
+Grep: "export type.*FormPayload"
+```
+
+### 3. Follow Established Conventions
+
+After finding existing patterns:
+
+- ✅ **DO**: Follow the same structure, naming, and organization
+- ✅ **DO**: Import from the same utility locations
+- ✅ **DO**: Use the same helper functions
+- ❌ **DON'T**: Create new utilities when existing ones exist
+- ❌ **DON'T**: Invent new patterns without justification
+- ❌ **DON'T**: Make assumptions about function signatures
+
+## Examples
+
+### ❌ BAD: Making Up Functions
+
+```typescript
+// Proposing this without checking if normalizeErrors exists:
+import { normalizeErrors } from '@/src/lib/utils';
+
+const errors = normalizeErrors(response.errors);
+```
+
+### ✅ GOOD: Verify First, Then Use
+
+```typescript
+// After reading src/lib/mutations.ts and finding normalizeFieldErrors:
+import { normalizeFieldErrors } from '@/src/lib/mutations';
+
+const errors = normalizeFieldErrors(response.fieldErrors, fields);
+```
+
+### ❌ BAD: Assuming Hook Patterns
+
+```typescript
+// Proposing a custom hook without checking the React Query pattern:
+export const useCountries = () => {
+  return useQuery(['countries'], fetchCountries);
+};
+```
+
+### ✅ GOOD: Check Existing Patterns
+
+```typescript
+// After reading src/common/api/countries.ts and seeing the queryOptions pattern:
+export const countriesOptions = (client: Client) => {
+  return queryOptions({
+    queryKey: ['countries'] as const,
+    queryFn: () => getCountries(client),
+  });
+};
+```
+
+## Verification Checklist
+
+Before implementing any code, verify:
+
+- [ ] Similar components/functions exist
+- [ ] Import paths are correct and files exist
+- [ ] Utility functions are used correctly
+- [ ] Type definitions match the established pattern
+- [ ] API hooks follow the project's React Query pattern
+- [ ] Error handling matches the existing approach
+- [ ] File structure follows the established conventions
+
+## When Creating New Patterns
+
+If you genuinely need to create a new pattern (not just follow an existing one):
+
+1. **Explain why** existing patterns don't work
+2. **Show examples** of similar patterns in the codebase
+3. **Document the decision** clearly
+4. **Be consistent** with overall project architecture
+
+## Red Flags
+
+Stop and verify the codebase if you find yourself:
+
+- Creating utilities that "should" exist
+- Importing from paths you haven't read
+- Proposing function signatures you haven't verified
+- Suggesting "standard" approaches without checking the project's standards
+- Using libraries or APIs without confirming they're installed/available
+
+## Remember
+
+**The codebase is the source of truth.** Always verify patterns exist before using them. Reading files takes seconds; debugging non-existent imports wastes minutes or hours.

--- a/.cursor/rules/step-component-types.mdc
+++ b/.cursor/rules/step-component-types.mdc
@@ -1,0 +1,247 @@
+---
+alwaysApply: true
+description: Step component callback types must be exported from types.ts
+---
+
+# Step Component Types Rule
+
+## Philosophy: Export Public Types
+
+Step components are part of the public API. Their callback function types (`onSubmit`, `onSuccess`, `onError`) must be exported from `types.ts` so library consumers can use them.
+
+## Pattern to Follow
+
+### 1. Export Callback Types from types.ts
+
+Every step component must have its callback types exported from the flow's `types.ts` file:
+
+```typescript
+// src/flows/FlowName/types.ts
+
+// ✅ Export the form payload type (already standard practice)
+export type StepNameFormPayload = {
+  field1: string;
+  field2: number;
+};
+
+// ✅ Export the success response type
+export type StepNameSuccessResponse = SomeApiResponse;
+
+// ✅ NEW: Export the onSubmit callback type
+export type StepNameOnSubmit = (
+  payload: StepNameFormPayload,
+) => void | Promise<void>;
+
+// ✅ NEW: Export the onSuccess callback type
+export type StepNameOnSuccess = (
+  response: StepNameSuccessResponse,
+) => void | Promise<void>;
+
+// ✅ NEW: Export the onError callback type (if custom shape)
+export type StepNameOnError = (params: {
+  error: Error;
+  rawError: Record<string, unknown>;
+  fieldErrors: NormalizedFieldError[];
+}) => void;
+```
+
+### 2. Use Exported Types in Step Component
+
+```typescript
+// src/flows/FlowName/components/StepNameStep.tsx
+
+import {
+  StepNameFormPayload,
+  StepNameSuccessResponse,
+  StepNameOnSubmit,
+  StepNameOnSuccess,
+  StepNameOnError,
+} from '@/src/flows/FlowName/types';
+
+type StepNameStepProps = {
+  /** The function is called when the form is submitted. */
+  onSubmit?: StepNameOnSubmit;
+  /** The function is called when the form submission is successful. */
+  onSuccess?: StepNameOnSuccess;
+  /** The function is called when an error occurs during form submission. */
+  onError?: StepNameOnError;
+};
+
+export function StepNameStep({
+  onSubmit,
+  onSuccess,
+  onError,
+}: StepNameStepProps) {
+  // Component implementation
+}
+```
+
+### 3. Export from Flow's index.ts
+
+Make the callback types available through the flow's public API:
+
+```typescript
+// src/flows/FlowName/index.ts
+
+export { StepNameStep } from './components/StepNameStep';
+export type {
+  StepNameFormPayload,
+  StepNameSuccessResponse,
+  StepNameOnSubmit,
+  StepNameOnSuccess,
+  StepNameOnError,
+} from './types';
+```
+
+### 4. Re-export from Root index.tsx
+
+Ensure types are available to library consumers:
+
+```typescript
+// src/index.tsx
+
+export type {
+  StepNameFormPayload,
+  StepNameOnSubmit,
+  StepNameOnSuccess,
+  StepNameOnError,
+} from '@/src/flows/FlowName';
+```
+
+## Standard onError Type Pattern
+
+Most step components use the same `onError` shape. Consider creating a shared type:
+
+```typescript
+// src/flows/types.ts (or specific flow types.ts)
+
+import { NormalizedFieldError } from '@/src/lib/mutations';
+
+export type StepOnErrorParams = {
+  error: Error;
+  rawError: Record<string, unknown>;
+  fieldErrors: NormalizedFieldError[];
+};
+
+export type StepOnError = (params: StepOnErrorParams) => void;
+```
+
+Then use it in step components:
+
+```typescript
+import { StepOnError } from '@/src/flows/types';
+
+export type BasicInformationOnError = StepOnError;
+```
+
+## Why This Matters
+
+### For Library Consumers
+
+Users of `@remoteoss/remote-flows` need these types to:
+
+1. **Type their callbacks correctly:**
+
+```typescript
+import type {
+  BasicInformationOnSubmit,
+  BasicInformationOnSuccess,
+} from '@remoteoss/remote-flows';
+
+const handleSubmit: BasicInformationOnSubmit = async (payload) => {
+  console.log('Submitting:', payload);
+};
+
+const handleSuccess: BasicInformationOnSuccess = async (response) => {
+  console.log('Success:', response);
+};
+
+<BasicInformationStep onSubmit={handleSubmit} onSuccess={handleSuccess} />;
+```
+
+2. **Create wrapper components:**
+
+```typescript
+import type { BasicInformationOnSubmit } from '@remoteoss/remote-flows';
+
+type CustomStepProps = {
+  onSubmit: BasicInformationOnSubmit;
+  customProp: string;
+};
+
+export function CustomBasicInfoStep({ onSubmit, customProp }: CustomStepProps) {
+  // Custom implementation
+}
+```
+
+3. **Build derived types:**
+
+```typescript
+import type {
+  BasicInformationFormPayload,
+  BasicInformationOnSubmit,
+} from '@remoteoss/remote-flows';
+
+type ValidationFn = (payload: BasicInformationFormPayload) => boolean;
+```
+
+## Examples from Codebase
+
+### Current Pattern (❌ Not Exported)
+
+```typescript
+// BasicInformationStep.tsx
+type BasicInformationStepProps = {
+  onSubmit?: (payload: BasicInformationFormPayload) => void | Promise<void>;
+  onSuccess?: (data: EmploymentCreationResponse) => void | Promise<void>;
+  onError?: (params: {...}) => void;
+};
+```
+
+Users cannot import these callback types!
+
+### Correct Pattern (✅ Exported)
+
+```typescript
+// types.ts
+export type BasicInformationOnSubmit = (
+  payload: BasicInformationFormPayload,
+) => void | Promise<void>;
+
+export type BasicInformationOnSuccess = (
+  data: EmploymentCreationResponse,
+) => void | Promise<void>;
+
+export type BasicInformationOnError = StepOnError;
+
+// BasicInformationStep.tsx
+import type {
+  BasicInformationOnSubmit,
+  BasicInformationOnSuccess,
+  BasicInformationOnError,
+} from '@/src/flows/Onboarding/types';
+
+type BasicInformationStepProps = {
+  onSubmit?: BasicInformationOnSubmit;
+  onSuccess?: BasicInformationOnSuccess;
+  onError?: BasicInformationOnError;
+};
+```
+
+## Checklist for New Steps
+
+When creating a new step component:
+
+- [ ] Define `{StepName}FormPayload` in types.ts (if not exists)
+- [ ] Define `{StepName}OnSubmit` type in types.ts
+- [ ] Define `{StepName}OnSuccess` type in types.ts
+- [ ] Define or reuse `{StepName}OnError` type in types.ts
+- [ ] Export all types from types.ts
+- [ ] Use exported types in step component props
+- [ ] Export types from flow's index.ts
+- [ ] Re-export types from src/index.tsx
+- [ ] Add JSDoc comments to exported types
+
+## Remember
+
+**Step components are public API.** All callback prop types must be exported and documented for library consumers. Inline types are private implementation details—export them!


### PR DESCRIPTION
This is based on the work we're doing internally with AI

Basically the objectives are:

1. Detect when prompting doesn't help && why
2. Write a rule
3. In the future have a skill called pr-review or similar, which iterates all the rules and makes sure we follow them

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adds Cursor rule markdown files; no application code, APIs, or build behavior changes.
> 
> **Overview**
> Adds two **always-on** Cursor rules under `.cursor/rules/` to steer AI-assisted work on this library.
> 
> **`check-existing-patterns.mdc`** requires reading the repo and searching for similar code before proposing imports, hooks, or utilities—aligned with existing rules like `react-query-abstractions` (e.g. `queryOptions` vs custom hooks) and real paths such as `normalizeFieldErrors` in `mutations.ts`.
> 
> **`step-component-types.mdc`** documents exporting step callback types (`{Step}OnSubmit`, `OnSuccess`, `OnError`) from each flow’s `types.ts`, re-exporting through flow `index.ts` and `src/index.tsx`, and optionally sharing `StepOnError`—so `@remoteoss/remote-flows` consumers can type handlers and wrappers.
> 
> No runtime or package code changes; documentation for Cursor only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6923436bfa822864836056e7c6b21671aeb82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->