### PR TITLE
feat(contractors) - invoice schedule detail form JSON schema (FOUND-1726)

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -215,6 +215,7 @@ const MultiStepForm = ({
     ContractReviewButton,
     SaveDraftButton,
     ContractOriginStep,
+    InvoiceScheduleStep,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -504,6 +505,41 @@ const MultiStepForm = ({
         </div>
       );
 
+    case 'invoice_schedule':
+      return (
+        <div className='contractor-onboarding-form-layout'>
+          <InvoiceScheduleStep
+            components={{
+              radio: (props) => <ContractOriginRadio {...props} />,
+            }}
+            onSubmit={(payload) =>
+              console.log('invoice schedule payload', payload)
+            }
+            onSuccess={(response) =>
+              console.log('invoice schedule response', response)
+            }
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <AlertError errors={errors} />
+          <div className='contractor-onboarding-buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Back
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Continue
+            </SubmitButton>
+          </div>
+        </div>
+      );
+
     case 'eligibility_questionnaire':
       return (
         <div className='contractor-onboarding-form-layout'>
@@ -632,6 +668,7 @@ export const ContractorOnboardingWithProps = ({
             employmentId={employmentId}
             externalId={externalId}
             options={{
+              features: ['create_invoice_schedule'],
               jsonSchemaVersion: {
                 employment_basic_information: 1,
               },

--- a/src/common/api/contractor-contract-details.ts
+++ b/src/common/api/contractor-contract-details.ts
@@ -14,7 +14,7 @@ import {
 } from '@/src/flows/types';
 import { $TSFixMe } from '@/src/types/remoteFlows';
 
-const useContractorCurrencies = ({
+export const useContractorCurrencies = ({
   employmentId,
   options,
 }: {
@@ -86,17 +86,26 @@ const useContractorOnboardingDetailsSchema = ({
 
 /**
  * Get contractor onboarding details schema with currency options overridden
- * from the getIndexContractorCurrency endpoint
+ * from the getIndexContractorCurrency endpoint.
+ *
+ * `currencies` is fetched once by the caller (via useContractorCurrencies) and
+ * passed in, rather than fetched here, so that flows needing the same
+ * employment's currencies for more than one schema (e.g. ContractorOnboarding's
+ * contract_details and invoice_schedule steps) share a single query observer.
  */
 export const useContractorContractDetailsSchema = ({
   countryCode,
   employmentId,
   fieldValues,
+  currencies,
+  isLoadingCurrencies,
   options,
 }: {
   countryCode: string;
   fieldValues: FieldValues;
   employmentId: string;
+  currencies?: { code: string; source: string }[];
+  isLoadingCurrencies?: boolean;
   options?: FlowOptions & { queryOptions?: { enabled?: boolean } };
 }) => {
   const schemaQuery = useContractorOnboardingDetailsSchema({
@@ -105,14 +114,6 @@ export const useContractorContractDetailsSchema = ({
     fieldValues,
     options,
   });
-
-  const { data: currencies, isLoading: isLoadingCurrencies } =
-    useContractorCurrencies({
-      employmentId,
-      options: {
-        queryOptions: { enabled: options?.queryOptions?.enabled },
-      },
-    });
 
   const dataWithCurrencies = useMemo(() => {
     if (!schemaQuery.data || !currencies) {
@@ -153,6 +154,6 @@ export const useContractorContractDetailsSchema = ({
   return {
     ...schemaQuery,
     data: dataWithCurrencies as $TSFixMe,
-    isLoading: schemaQuery.isLoading || isLoadingCurrencies,
+    isLoading: schemaQuery.isLoading || Boolean(isLoadingCurrencies),
   };
 };

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -15,6 +15,7 @@ import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/component
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
+import { InvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/InvoiceScheduleStep';
 
 export const ContractorOnboardingFlow = ({
   render,
@@ -64,6 +65,7 @@ export const ContractorOnboardingFlow = ({
           PricingPlanStep: PricingPlanStep,
           EligibilityQuestionnaireStep: EligibilityQuestionnaireStep,
           ContractOriginStep: ContractOriginStep,
+          InvoiceScheduleStep: InvoiceScheduleStep,
           ContractDetailsStep: ContractDetailsStep,
           ContractPreviewStep: ContractPreviewStep,
           OnboardingInvite: OnboardingInvite,

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -22,6 +22,7 @@ import {
 import { useClient } from '@/src/context';
 import { signatureSchema } from '@/src/flows/ContractorOnboarding/json-schemas/signature';
 import { contractOriginSchema } from '@/src/flows/ContractorOnboarding/json-schemas/contractOrigin';
+import { invoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule';
 import { selectContractorSubscriptionStepSchema } from '@/src/flows/ContractorOnboarding/json-schemas/selectContractorSubscriptionStep';
 import {
   JSONSchemaFormResultWithFieldsets,
@@ -745,6 +746,24 @@ export const useGetContractOriginSchema = ({
     queryKey: ['contract-origin-schema', options?.jsfModify],
     queryFn: async () => {
       return createHeadlessForm(contractOriginSchema, fieldValues, {
+        jsfModify: options?.jsfModify,
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+  });
+};
+
+export const useGetInvoiceScheduleSchema = ({
+  fieldValues,
+  options,
+}: {
+  fieldValues: FieldValues;
+  options?: { queryOptions?: { enabled?: boolean }; jsfModify?: JSFModify };
+}) => {
+  return useQuery({
+    queryKey: ['invoice-schedule-schema', options?.jsfModify],
+    queryFn: async () => {
+      return createHeadlessForm(invoiceScheduleSchema, fieldValues, {
         jsfModify: options?.jsfModify,
       });
     },

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -753,14 +753,24 @@ export const useGetContractOriginSchema = ({
   });
 };
 
+/**
+ * `currencies` is fetched once by the caller (via useContractorCurrencies) and
+ * passed in, rather than fetched here, so that flows needing the same
+ * employment's currencies for more than one schema (e.g. this flow's
+ * contract_details and invoice_schedule steps) share a single query observer.
+ */
 export const useGetInvoiceScheduleSchema = ({
   fieldValues,
+  currencies,
+  isLoadingCurrencies,
   options,
 }: {
   fieldValues: FieldValues;
+  currencies?: { code: string; source: string }[];
+  isLoadingCurrencies?: boolean;
   options?: { queryOptions?: { enabled?: boolean }; jsfModify?: JSFModify };
 }) => {
-  return useQuery({
+  const schemaQuery = useQuery({
     queryKey: ['invoice-schedule-schema', options?.jsfModify],
     queryFn: async () => {
       return createHeadlessForm(invoiceScheduleSchema, fieldValues, {
@@ -769,6 +779,34 @@ export const useGetInvoiceScheduleSchema = ({
     },
     enabled: options?.queryOptions?.enabled,
   });
+
+  const dataWithCurrencies = useMemo(() => {
+    if (!schemaQuery.data || !currencies) {
+      return schemaQuery.data;
+    }
+
+    return {
+      ...schemaQuery.data,
+      fields: schemaQuery.data.fields.map((field: $TSFixMe) =>
+        field.name !== 'currency'
+          ? field
+          : {
+              ...field,
+              options: currencies.map((currency) => ({
+                label: currency.code,
+                value: currency.code,
+                meta: { source: currency.source },
+              })),
+            },
+      ),
+    };
+  }, [schemaQuery.data, currencies]);
+
+  return {
+    ...schemaQuery,
+    data: dataWithCurrencies as $TSFixMe,
+    isLoading: schemaQuery.isLoading || Boolean(isLoadingCurrencies),
+  };
 };
 
 export const useCountriesSchemaField = (

--- a/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
+++ b/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
@@ -4,6 +4,10 @@ import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding
 import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
 import { handleStepError } from '@/src/lib/utils';
 import { UseFormReturn } from 'react-hook-form';
+import {
+  InvoiceScheduleFormPayload,
+  InvoiceScheduleResponse,
+} from '@/src/flows/ContractorOnboarding/types';
 
 type InvoiceScheduleStepProps = {
   /**
@@ -13,15 +17,11 @@ type InvoiceScheduleStepProps = {
   /*
    * The function is called when the form is submitted. It receives the form values as an argument.
    */
-  onSubmit?: (payload: {
-    invoice_schedule_preference: string;
-  }) => void | Promise<void>;
+  onSubmit?: (payload: InvoiceScheduleFormPayload) => void | Promise<void>;
   /*
    * The function is called when the form submission is successful.
    */
-  onSuccess?: (data: {
-    invoiceSchedulePreference: string;
-  }) => void | Promise<void>;
+  onSuccess?: (data: InvoiceScheduleResponse) => void | Promise<void>;
   /*
    * The function is called when an error occurs during form submission.
    */
@@ -51,19 +51,11 @@ export function InvoiceScheduleStep({
     try {
       const parsedValues =
         await contractorOnboardingBag.parseFormValues(payload);
-      await onSubmit?.(
-        parsedValues as {
-          invoice_schedule_preference: string;
-        },
-      );
+      await onSubmit?.(parsedValues as InvoiceScheduleFormPayload);
       const response = await contractorOnboardingBag.onSubmit(payload);
 
       if (response?.data) {
-        await onSuccess?.(
-          response.data as {
-            invoiceSchedulePreference: string;
-          },
-        );
+        await onSuccess?.(response.data as InvoiceScheduleResponse);
         contractorOnboardingBag?.next();
         return;
       }

--- a/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
+++ b/src/flows/ContractorOnboarding/components/InvoiceScheduleStep.tsx
@@ -1,0 +1,91 @@
+import { $TSFixMe, Components } from '@/src/types/remoteFlows';
+import { NormalizedFieldError } from '@/src/lib/mutations';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+import { handleStepError } from '@/src/lib/utils';
+import { UseFormReturn } from 'react-hook-form';
+
+type InvoiceScheduleStepProps = {
+  /**
+   * Components to override the default field components used in the form.
+   */
+  components?: Components;
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: {
+    invoice_schedule_preference: string;
+  }) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: {
+    invoiceSchedulePreference: string;
+  }) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function InvoiceScheduleStep({
+  components,
+  onSubmit,
+  onSuccess,
+  onError,
+}: InvoiceScheduleStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const handleSubmit = async (
+    payload: $TSFixMe,
+    form: UseFormReturn<$TSFixMe>,
+  ) => {
+    try {
+      const parsedValues =
+        await contractorOnboardingBag.parseFormValues(payload);
+      await onSubmit?.(
+        parsedValues as {
+          invoice_schedule_preference: string;
+        },
+      );
+      const response = await contractorOnboardingBag.onSubmit(payload);
+
+      if (response?.data) {
+        await onSuccess?.(
+          response.data as {
+            invoiceSchedulePreference: string;
+          },
+        );
+        contractorOnboardingBag?.next();
+        return;
+      }
+    } catch (error: unknown) {
+      const structuredError = handleStepError(
+        error,
+        contractorOnboardingBag.meta?.fields?.invoice_schedule,
+        form,
+      );
+      onError?.(structuredError);
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.invoice_schedule ||
+    contractorOnboardingBag.initialValues.invoice_schedule;
+
+  return (
+    <ContractorOnboardingForm
+      components={components}
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -684,6 +684,9 @@ export const useContractorOnboarding = ({
   const { data: invoiceScheduleForm } = useGetInvoiceScheduleSchema({
     fieldValues: fieldValues,
     options: {
+      queryOptions: {
+        enabled: includeInvoiceSchedule,
+      },
       jsfModify: options?.jsfModify?.invoice_schedule,
     },
   });

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -32,6 +32,7 @@ import {
   useCompanyOpenTasks,
   useSetContractOrigin,
   useGetContractOriginSchema,
+  useGetInvoiceScheduleSchema,
 } from '@/src/flows/ContractorOnboarding/api';
 import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
@@ -86,6 +87,7 @@ const stepToFormSchemaMap: Record<StepKeys, JSONSchemaFormType | null> = {
   select_country: null,
   basic_information: 'employment_basic_information',
   contract_origin: null,
+  invoice_schedule: null,
   contract_details: null,
   eligibility_questionnaire: null,
   pricing_plan: null,
@@ -128,6 +130,7 @@ export const useContractorOnboarding = ({
     select_country: Meta;
     basic_information: Meta;
     contract_origin: Meta;
+    invoice_schedule: Meta;
     contract_details: Meta;
     contract_preview: Meta;
     pricing_plan: Meta;
@@ -136,6 +139,7 @@ export const useContractorOnboarding = ({
     select_country: {},
     basic_information: {},
     contract_origin: {},
+    invoice_schedule: {},
     contract_details: {},
     contract_preview: {},
     pricing_plan: {},
@@ -158,6 +162,9 @@ export const useContractorOnboarding = ({
   const [includeContractOrigin, setIncludeContractOrigin] =
     useState<boolean>(true);
 
+  const [includeInvoiceSchedule, setIncludeInvoiceSchedule] =
+    useState<boolean>(false);
+
   const [pendingNavigationStep, setPendingNavigationStep] =
     useState<StepKeys | null>(null);
 
@@ -166,12 +173,14 @@ export const useContractorOnboarding = ({
       buildSteps({
         includeSelectCountry: !skipSteps?.includes('select_country'),
         includeContractOrigin: includeContractOrigin,
+        includeInvoiceSchedule: includeInvoiceSchedule,
         includeEligibilityQuestionnaire: includeEligibilityQuestionnaire,
         includeContractDetails: includeContractDetails,
         includeContractPreview: includeContractPreview,
       }),
     [
       includeContractOrigin,
+      includeInvoiceSchedule,
       includeEligibilityQuestionnaire,
       includeContractDetails,
       includeContractPreview,
@@ -237,7 +246,7 @@ export const useContractorOnboarding = ({
   const createEmploymentMutation = useCreateEmployment();
   const updateEmploymentMutation = useUpdateEmployment(
     internalCountryCode as string,
-    options,
+    options as $TSFixMe, // TODO: done it as its shared between contractor and onboarding flows
   );
   const createContractorContractDocumentMutation =
     useCreateContractorContractDocument();
@@ -573,6 +582,12 @@ export const useContractorOnboarding = ({
     );
   }, [skipSteps, selectedPricingPlan]);
 
+  useEffect(() => {
+    setIncludeInvoiceSchedule(
+      options?.features?.includes('create_invoice_schedule') ?? false,
+    );
+  }, [options?.features]);
+
   const eligibilityFields = useMemo(() => {
     return {
       ...eligibilityAnswers,
@@ -666,6 +681,13 @@ export const useContractorOnboarding = ({
     },
   });
 
+  const { data: invoiceScheduleForm } = useGetInvoiceScheduleSchema({
+    fieldValues: fieldValues,
+    options: {
+      jsfModify: options?.jsfModify?.invoice_schedule,
+    },
+  });
+
   const {
     data: documentPreviewPdf,
     isLoading: isLoadingDocumentPreviewForm,
@@ -695,6 +717,7 @@ export const useContractorOnboarding = ({
       select_country: selectCountryForm?.fields || [],
       basic_information: basicInformationForm?.fields || [],
       contract_origin: contractOriginForm?.fields || [],
+      invoice_schedule: invoiceScheduleForm?.fields || [],
       pricing_plan: selectContractorSubscriptionForm?.fields || [],
       eligibility_questionnaire: eligibilityQuestionnaireForm?.fields || [],
       contract_details: contractorOnboardingDetailsForm?.fields || [],
@@ -705,6 +728,7 @@ export const useContractorOnboarding = ({
       selectCountryForm?.fields,
       basicInformationForm?.fields,
       contractOriginForm?.fields,
+      invoiceScheduleForm?.fields,
       selectContractorSubscriptionForm?.fields,
       contractorOnboardingDetailsForm?.fields,
       signatureSchemaForm?.fields,
@@ -719,6 +743,7 @@ export const useContractorOnboarding = ({
     select_country: null,
     basic_information: basicInformationForm?.meta['x-jsf-fieldsets'],
     contract_origin: null,
+    invoice_schedule: null,
     pricing_plan: null,
     contract_details: contractorOnboardingDetailsForm?.meta['x-jsf-fieldsets'],
     eligibility_questionnaire: null,
@@ -733,6 +758,7 @@ export const useContractorOnboarding = ({
     select_country: selectCountryForm?.meta?.['x-jsf-presentation'],
     basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
     contract_origin: contractOriginForm?.meta?.['x-jsf-presentation'],
+    invoice_schedule: invoiceScheduleForm?.meta?.['x-jsf-presentation'],
     pricing_plan:
       selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
     eligibility_questionnaire:
@@ -798,6 +824,13 @@ export const useContractorOnboarding = ({
     onboardingInitialValues,
     employment?.contract_details?.contract_origin,
   ]);
+
+  const invoiceScheduleInitialValues = useMemo(() => {
+    const initialValues = {
+      ...onboardingInitialValues,
+    };
+    return getInitialValues(stepFields.invoice_schedule, initialValues);
+  }, [stepFields.invoice_schedule, onboardingInitialValues]);
 
   const contractDetailsInitialValues = useMemo(() => {
     const hardcodedValues = {
@@ -868,6 +901,7 @@ export const useContractorOnboarding = ({
       select_country: selectCountryInitialValues,
       basic_information: basicInformationInitialValues,
       contract_origin: contractOriginInitialValues,
+      invoice_schedule: invoiceScheduleInitialValues,
       contract_details: contractDetailsInitialValues,
       contract_preview: contractPreviewInitialValues,
       pricing_plan: pricingPlanInitialValues,
@@ -877,6 +911,7 @@ export const useContractorOnboarding = ({
     selectCountryInitialValues,
     basicInformationInitialValues,
     contractOriginInitialValues,
+    invoiceScheduleInitialValues,
     contractDetailsInitialValues,
     contractPreviewInitialValues,
     pricingPlanInitialValues,
@@ -937,6 +972,7 @@ export const useContractorOnboarding = ({
           { skipMoneyConversion: true },
         ),
         contract_origin: {},
+        invoice_schedule: {},
         contract_details: prettifyFormValues(
           contractDetailsInitialValues,
           stepFields.contract_details,
@@ -963,6 +999,7 @@ export const useContractorOnboarding = ({
         select_country: selectCountryInitialValues,
         basic_information: basicInformationInitialValues,
         contract_origin: {},
+        invoice_schedule: {},
         contract_details: contractDetailsInitialValues,
         contract_preview: contractPreviewInitialValues,
         pricing_plan: pricingPlanInitialValues,
@@ -1060,6 +1097,15 @@ export const useContractorOnboarding = ({
       stepState.currentStep.name === 'contract_origin'
     ) {
       return await parseJSFToValidate(values, contractOriginForm?.fields, {
+        isPartialValidation: false,
+      });
+    }
+
+    if (
+      invoiceScheduleForm &&
+      stepState.currentStep.name === 'invoice_schedule'
+    ) {
+      return await parseJSFToValidate(values, invoiceScheduleForm?.fields, {
         isPartialValidation: false,
       });
     }
@@ -1347,6 +1393,14 @@ export const useContractorOnboarding = ({
         };
       }
 
+      case 'invoice_schedule': {
+        return {
+          data: {
+            invoiceSchedulePreference: values.invoice_schedule_preference,
+          },
+        };
+      }
+
       case 'eligibility_questionnaire': {
         try {
           const response = await createEligibilityQuestionnaireMutationAsync({
@@ -1559,6 +1613,18 @@ export const useContractorOnboarding = ({
           { isPartialValidation: false },
         );
         return contractOriginForm?.handleValidation(parsedValues);
+      }
+
+      if (
+        invoiceScheduleForm &&
+        stepState.currentStep.name === 'invoice_schedule'
+      ) {
+        const parsedValues = await parseJSFToValidate(
+          values,
+          invoiceScheduleForm?.fields,
+          { isPartialValidation: false },
+        );
+        return invoiceScheduleForm?.handleValidation(parsedValues);
       }
 
       return null;

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -34,7 +34,10 @@ import {
   useGetContractOriginSchema,
   useGetInvoiceScheduleSchema,
 } from '@/src/flows/ContractorOnboarding/api';
-import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
+import {
+  useContractorContractDetailsSchema,
+  useContractorCurrencies,
+} from '@/src/common/api/contractor-contract-details';
 import {
   ContractorOnboardingFlowProps,
   ContractorOnboardingHookOptions,
@@ -636,6 +639,26 @@ export const useContractorOnboarding = ({
     isEmploymentReadOnly,
   );
 
+  const isInvoiceScheduleEnabled =
+    includeInvoiceSchedule && Boolean(internalEmploymentId);
+
+  // Fetched once and shared: both contract_details and invoice_schedule need
+  // this employment's supported currencies, so a single query observer avoids
+  // mounting two competing fetches for the same data.
+  const {
+    data: contractorCurrencies,
+    isLoading: isLoadingContractorCurrencies,
+  } = useContractorCurrencies({
+    employmentId: internalEmploymentId as string,
+    options: {
+      queryOptions: {
+        enabled:
+          Boolean(internalEmploymentId) &&
+          (isContractorOnboardingDetailsEnabled || isInvoiceScheduleEnabled),
+      },
+    },
+  });
+
   const {
     data: contractorOnboardingDetailsForm,
     isLoading: isLoadingContractorOnboardingDetailsForm,
@@ -643,6 +666,8 @@ export const useContractorOnboarding = ({
     countryCode: internalCountryCode as string,
     fieldValues: fieldValues,
     employmentId: internalEmploymentId as string,
+    currencies: contractorCurrencies,
+    isLoadingCurrencies: isLoadingContractorCurrencies,
     options: {
       queryOptions: {
         enabled: isContractorOnboardingDetailsEnabled,
@@ -683,9 +708,11 @@ export const useContractorOnboarding = ({
 
   const { data: invoiceScheduleForm } = useGetInvoiceScheduleSchema({
     fieldValues: fieldValues,
+    currencies: contractorCurrencies,
+    isLoadingCurrencies: isLoadingContractorCurrencies,
     options: {
       queryOptions: {
-        enabled: includeInvoiceSchedule,
+        enabled: isInvoiceScheduleEnabled,
       },
       jsfModify: options?.jsfModify?.invoice_schedule,
     },

--- a/src/flows/ContractorOnboarding/index.ts
+++ b/src/flows/ContractorOnboarding/index.ts
@@ -10,6 +10,8 @@ export type {
   ContractPreviewResponse,
   EligibilityQuestionnaireFormPayload,
   EligibilityQuestionnaireResponse,
+  InvoiceScheduleFormPayload,
+  InvoiceScheduleResponse,
 } from './types';
 export type { ProductType } from './constants';
 export {

--- a/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
@@ -1,0 +1,30 @@
+export const invoiceScheduleSchema = {
+  type: 'object',
+  properties: {
+    invoice_schedule_preference: {
+      description:
+        'Set up a schedule to automatically create invoices on behalf of this contractor.',
+      oneOf: [
+        {
+          const: 'create_now',
+          description:
+            'Set up a schedule to create invoices for this contractor now.',
+          title: 'Create invoice schedule now',
+        },
+        {
+          const: 'skip',
+          description:
+            'You or your contractor can always set up an invoice schedule later.',
+          title: 'Skip for now',
+        },
+      ],
+      title: 'Invoice schedule',
+      type: 'string',
+      'x-jsf-presentation': {
+        direction: 'column',
+        inputType: 'radio',
+      },
+    },
+  },
+  required: ['invoice_schedule_preference'],
+};

--- a/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
@@ -1,3 +1,97 @@
+const INVOICE_ITEM_SLOTS = 10;
+
+const PERIODICITY_OPTIONS = [
+  { const: 'weekly', title: 'Weekly' },
+  { const: 'bi_weekly', title: 'Bi-weekly' },
+  { const: 'semi_monthly', title: 'Semi-monthly' },
+  { const: 'monthly', title: 'Monthly' },
+];
+
+function invoiceItemProperties() {
+  const properties: Record<string, object> = {};
+
+  for (let slot = 1; slot <= INVOICE_ITEM_SLOTS; slot++) {
+    properties[`item_${slot}_description`] = {
+      title: `Item ${slot} description`,
+      type: 'string',
+      'x-jsf-presentation': {
+        inputType: 'text',
+      },
+    };
+    properties[`item_${slot}_amount`] = {
+      title: `Item ${slot} amount`,
+      type: 'integer',
+      'x-jsf-presentation': {
+        inputType: 'money',
+      },
+      'x-jsf-logic-computedAttrs': {
+        currency: 'currency_selected',
+      },
+    };
+  }
+
+  return properties;
+}
+
+// Slot 1 is required whenever a schedule is created (see the base allOf below).
+// Slots 2..N are optional and only revealed once the previous slot has been filled in,
+// since the form-kit has no built-in "add another row" renderer for a true items array.
+function invoiceItemRevealConditionals() {
+  const conditionals = [];
+
+  for (let slot = 2; slot <= INVOICE_ITEM_SLOTS; slot++) {
+    const previousSlot = slot - 1;
+
+    conditionals.push({
+      if: {
+        properties: {
+          [`item_${previousSlot}_description`]: {
+            type: 'string',
+            minLength: 1,
+          },
+          [`item_${previousSlot}_amount`]: { type: 'integer', minimum: 1 },
+        },
+        required: [
+          `item_${previousSlot}_description`,
+          `item_${previousSlot}_amount`,
+        ],
+      },
+      then: {},
+      else: {
+        properties: {
+          [`item_${slot}_description`]: false,
+          [`item_${slot}_amount`]: false,
+        },
+      },
+    });
+  }
+
+  return conditionals;
+}
+
+function disabledDetailFieldProperties() {
+  const properties: Record<string, false> = {
+    currency: false,
+    periodicity: false,
+    start_date: false,
+    number: false,
+    note: false,
+    nr_occurrences: false,
+  };
+
+  for (let slot = 1; slot <= INVOICE_ITEM_SLOTS; slot++) {
+    properties[`item_${slot}_description`] = false;
+    properties[`item_${slot}_amount`] = false;
+  }
+
+  return properties;
+}
+
+const itemFieldOrder = Array.from(
+  { length: INVOICE_ITEM_SLOTS },
+  (_, index) => index + 1,
+).flatMap((slot) => [`item_${slot}_description`, `item_${slot}_amount`]);
+
 export const invoiceScheduleSchema = {
   type: 'object',
   properties: {
@@ -25,6 +119,101 @@ export const invoiceScheduleSchema = {
         inputType: 'radio',
       },
     },
+    currency: {
+      description: 'The currency this invoice schedule will be issued in.',
+      title: 'Invoice currency',
+      type: 'string',
+      // Replaced at runtime with the contractor's supported currencies
+      // (see useGetInvoiceScheduleSchema in ContractorOnboarding/api.ts).
+      oneOf: [{ const: 'placeholder', title: 'Loading currencies…' }],
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+    },
+    periodicity: {
+      description: 'How often invoices are generated for this schedule.',
+      title: 'Frequency',
+      type: 'string',
+      oneOf: PERIODICITY_OPTIONS,
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+    },
+    start_date: {
+      description: 'Date the first invoice will be generated.',
+      title: 'Start date',
+      type: 'string',
+      format: 'date',
+      'x-jsf-presentation': {
+        inputType: 'date',
+      },
+    },
+    ...invoiceItemProperties(),
+    number: {
+      description: 'Optional identifier shown on generated invoices.',
+      title: 'Invoice number',
+      type: 'string',
+      maxLength: 10,
+      'x-jsf-presentation': {
+        inputType: 'text',
+      },
+    },
+    note: {
+      description: 'Shown on generated invoices.',
+      title: 'Additional notes',
+      type: 'string',
+      'x-jsf-presentation': {
+        inputType: 'textarea',
+      },
+    },
+    nr_occurrences: {
+      description:
+        'Number of invoices to generate. Leave blank for the schedule to repeat indefinitely.',
+      title: 'Number of occurrences',
+      type: 'integer',
+      minimum: 1,
+      'x-jsf-presentation': {
+        inputType: 'number',
+      },
+    },
   },
   required: ['invoice_schedule_preference'],
+  'x-jsf-order': [
+    'invoice_schedule_preference',
+    'currency',
+    'periodicity',
+    'start_date',
+    ...itemFieldOrder,
+    'number',
+    'note',
+    'nr_occurrences',
+  ],
+  'x-jsf-logic': {
+    computedValues: {
+      currency_selected: {
+        rule: { var: 'currency' },
+      },
+    },
+  },
+  allOf: [
+    {
+      if: {
+        properties: { invoice_schedule_preference: { const: 'schedule' } },
+        required: ['invoice_schedule_preference'],
+      },
+      then: {
+        required: [
+          'currency',
+          'periodicity',
+          'start_date',
+          'item_1_description',
+          'item_1_amount',
+        ],
+      },
+      else: {
+        properties: disabledDetailFieldProperties(),
+      },
+    },
+    ...invoiceItemRevealConditionals(),
+  ],
 };

--- a/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule.ts
@@ -6,13 +6,13 @@ export const invoiceScheduleSchema = {
         'Set up a schedule to automatically create invoices on behalf of this contractor.',
       oneOf: [
         {
-          const: 'create_now',
+          const: 'schedule',
           description:
             'Set up a schedule to create invoices for this contractor now.',
           title: 'Create invoice schedule now',
         },
         {
-          const: 'skip',
+          const: 'manual',
           description:
             'You or your contractor can always set up an invoice schedule later.',
           title: 'Skip for now',

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -65,7 +65,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [4]: 'Contract Origin',
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
-  [7]: 'Review',
+  [7]: 'Invoice schedule',
+  [8]: 'Review',
 };
 
 function createMockRenderImplementation(

--- a/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
@@ -34,7 +34,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [4]: 'Eligibility Questionnaire',
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
-  [7]: 'Review',
+  [7]: 'Invoice schedule',
+  [8]: 'Review',
 };
 
 const mockSuccess = vi.fn();

--- a/src/flows/ContractorOnboarding/tests/invoiceScheduleSchema.test.ts
+++ b/src/flows/ContractorOnboarding/tests/invoiceScheduleSchema.test.ts
@@ -1,0 +1,72 @@
+import { createHeadlessForm } from '@/src/common/createHeadlessForm';
+import { invoiceScheduleSchema } from '../json-schemas/invoiceSchedule';
+
+function fieldByName(fields: Record<string, unknown>[], name: string) {
+  return fields.find((field) => field.name === name);
+}
+
+describe('invoiceScheduleSchema', () => {
+  it('hides every detail field when the user chooses to skip', () => {
+    const { fields } = createHeadlessForm(invoiceScheduleSchema, {
+      invoice_schedule_preference: 'manual',
+    });
+
+    [
+      'currency',
+      'periodicity',
+      'start_date',
+      'item_1_description',
+      'item_1_amount',
+    ].forEach((name) => {
+      const field = fieldByName(fields, name);
+      expect(field?.isVisible).toBe(false);
+      expect(field?.required).toBe(false);
+    });
+  });
+
+  it('requires the first item slot once the user opts to create a schedule', () => {
+    const { fields } = createHeadlessForm(invoiceScheduleSchema, {
+      invoice_schedule_preference: 'schedule',
+    });
+
+    [
+      'currency',
+      'periodicity',
+      'start_date',
+      'item_1_description',
+      'item_1_amount',
+    ].forEach((name) => {
+      const field = fieldByName(fields, name);
+      expect(field?.isVisible).toBe(true);
+      expect(field?.required).toBe(true);
+    });
+
+    const secondItemDescription = fieldByName(fields, 'item_2_description');
+    expect(secondItemDescription?.isVisible).toBe(false);
+  });
+
+  it('reveals the next item slot only once the previous one is filled in', () => {
+    const { fields } = createHeadlessForm(invoiceScheduleSchema, {
+      invoice_schedule_preference: 'schedule',
+      item_1_description: 'Consulting work',
+      item_1_amount: 100_00,
+    });
+
+    expect(fieldByName(fields, 'item_2_description')?.isVisible).toBe(true);
+    expect(fieldByName(fields, 'item_2_amount')?.isVisible).toBe(true);
+    expect(fieldByName(fields, 'item_2_description')?.required).toBe(false);
+    expect(fieldByName(fields, 'item_3_description')?.isVisible).toBe(false);
+  });
+
+  it('binds item amount fields to the currency computed from the currency field', () => {
+    const { fields } = createHeadlessForm(invoiceScheduleSchema, {
+      invoice_schedule_preference: 'schedule',
+      currency: 'BRL',
+    });
+
+    const itemAmount = fieldByName(fields, 'item_1_amount');
+    expect(itemAmount?.computedAttributes).toMatchObject({
+      currency: 'currency_selected',
+    });
+  });
+});

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -190,6 +190,33 @@ export type EligibilityQuestionnaireResponse = SuccessResponse;
 
 export type InvoiceScheduleFormPayload = {
   invoice_schedule_preference: string;
+  // The fields below are only present when invoice_schedule_preference is 'schedule'.
+  currency?: string;
+  periodicity?: string;
+  start_date?: string;
+  item_1_description?: string;
+  item_1_amount?: number;
+  item_2_description?: string;
+  item_2_amount?: number;
+  item_3_description?: string;
+  item_3_amount?: number;
+  item_4_description?: string;
+  item_4_amount?: number;
+  item_5_description?: string;
+  item_5_amount?: number;
+  item_6_description?: string;
+  item_6_amount?: number;
+  item_7_description?: string;
+  item_7_amount?: number;
+  item_8_description?: string;
+  item_8_amount?: number;
+  item_9_description?: string;
+  item_9_amount?: number;
+  item_10_description?: string;
+  item_10_amount?: number;
+  number?: string;
+  note?: string;
+  nr_occurrences?: number;
 };
 
 export type InvoiceScheduleResponse = {

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -187,3 +187,11 @@ export type EligibilityQuestionnaireFormPayload = {
 };
 
 export type EligibilityQuestionnaireResponse = SuccessResponse;
+
+export type InvoiceScheduleFormPayload = {
+  invoice_schedule_preference: string;
+};
+
+export type InvoiceScheduleResponse = {
+  invoiceSchedulePreference: string;
+};

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -16,6 +16,7 @@ import { OnboardingInvite } from '@/src/flows/ContractorOnboarding/components/On
 import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/components/ContractReviewButton';
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
 import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
+import { InvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/InvoiceScheduleStep';
 import { ProductType } from '@/src/flows/ContractorOnboarding/constants';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 
@@ -46,6 +47,7 @@ export type ContractorOnboardingRenderProps = {
     SubmitButton: typeof OnboardingSubmit;
     PricingPlanStep: typeof PricingPlanStep;
     ContractOriginStep: typeof ContractOriginStep;
+    InvoiceScheduleStep: typeof InvoiceScheduleStep;
     ContractDetailsStep: typeof ContractDetailsStep;
     ContractPreviewStep: typeof ContractPreviewStep;
     OnboardingInvite: typeof OnboardingInvite;
@@ -55,6 +57,8 @@ export type ContractorOnboardingRenderProps = {
   };
 };
 
+type ContractorOnboardingFeatures = 'create_invoice_schedule';
+
 type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
   /**
    * Products to exclude from the available options in pricing_plan step.
@@ -63,6 +67,11 @@ type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
    * @example excludeProducts: ['eor', 'cor'] // Hide both EOR and COR
    */
   excludeProducts?: ProductType[];
+  /**
+   * Features to enable for the contractor onboarding flow.
+   * - 'create_invoice_schedule': Enable the invoice schedule step
+   */
+  features?: ContractorOnboardingFeatures[];
   /**
    * The JSON schema modification to use for the onboarding.
    * This is used to modify the JSON schema for the onboarding.
@@ -76,6 +85,7 @@ type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
     eligibility_questionnaire?: JSFModify;
     pricing_plan?: JSFModify;
     contract_origin?: JSFModify;
+    invoice_schedule?: JSFModify;
   };
 };
 

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -13,6 +13,7 @@ export type StepKeys =
   | 'select_country'
   | 'basic_information'
   | 'contract_origin'
+  | 'invoice_schedule'
   | 'contract_details'
   | 'eligibility_questionnaire'
   | 'contract_preview'
@@ -22,6 +23,7 @@ export type StepKeys =
 type StepConfig = {
   includeSelectCountry?: boolean;
   includeContractOrigin?: boolean;
+  includeInvoiceSchedule?: boolean;
   includeEligibilityQuestionnaire?: boolean;
   includeContractDetails?: boolean;
   includeContractPreview?: boolean;
@@ -67,6 +69,11 @@ export function buildSteps(config: StepConfig = {}) {
       name: 'contract_preview',
       label: 'Contract Preview',
       visible: Boolean(config?.includeContractPreview),
+    },
+    {
+      name: 'invoice_schedule',
+      label: 'Invoice schedule',
+      visible: Boolean(config?.includeInvoiceSchedule),
     },
     {
       name: 'review',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,8 @@ export type {
   ContractPreviewResponse,
   EligibilityQuestionnaireFormPayload,
   EligibilityQuestionnaireResponse,
+  InvoiceScheduleFormPayload,
+  InvoiceScheduleResponse,
 } from '@/src/flows/ContractorOnboarding';
 
 export type { ContractPreviewStatementProps } from '@/src/flows/ContractorOnboarding/components/ContractPreviewStatement';


### PR DESCRIPTION
## Summary

Builds on #1249 (FOUND-1725). Extends the `invoice_schedule` step's `invoiceScheduleSchema` so that, once a user picks "Create invoice schedule now", a detail form appears matching the shape eor_web's existing `POST /api/eor/v1/contractor-invoice-schedules` endpoint already accepts:

- `currency`, `periodicity` (weekly/bi_weekly/semi_monthly/monthly), `start_date`
- Invoice items as 10 fixed, progressively-revealed slots (the form-kit has no built-in dynamic array-of-objects renderer; this mirrors the pattern Tiger's own legacy bulk-import schema uses, capped at the API's own `maxItems: 10`)
- `number`, `note`, `nr_occurrences` (optional; blank = repeats indefinitely)

Currency options (and the item money fields' displayed currency) come from the contractor's real supported currencies via `useContractorCurrencies`, not a hardcoded list — reused from the `contract_details` step rather than duplicated.

## Notable fix included

Originally wired `useContractorCurrencies` independently in both `useContractorContractDetailsSchema` and the new `useGetInvoiceScheduleSchema`. Two `useQuery` observers on the same cache key broke an existing test (`ContractorOnboarding.test.tsx`'s CSA-disclaimer test — contract_details' loading spinner stopped appearing). Fixed by fetching currencies once in `hooks.tsx` and passing the result into both hooks.

## Out of scope (left for a follow-up)

- Wiring the actual `POST` call into the submit handler (wrapping the payload as `{ contractor_invoice_schedules: [...] }`, converting item amounts to cents, handling the response/errors). The step still just returns the parsed form values from `onSubmit`, same as before this PR.
- FOUND-1723 (standalone SDK screen) and FOUND-1727/1728 (prefill + review-step display).

## Test plan

- [x] `invoiceScheduleSchema.test.ts` (new) — skip/create toggle, progressive item reveal, currency computed-attrs
- [x] `ContractorOnboarding.test.tsx` / `OnboardingInvite.test.tsx` — still passing (91 tests total), re-run 3x to confirm no flake
- [x] `tsc --noEmit`, `oxlint`, `oxfmt` clean
- [ ] Manual check in `example/src/ContractorOnboarding.tsx` with the `create_invoice_schedule` feature flag on