### PR TITLE
feat(contractor-onboarding) - build next step to put the form in

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -228,6 +228,7 @@ const MultiStepForm = ({
     SaveDraftButton,
     ContractOriginStep,
     InvoiceScheduleStep,
+    CreateInvoiceScheduleStep,
   } = components;
   const [errors, setErrors] = useState<{
     apiError: string;
@@ -529,6 +530,38 @@ const MultiStepForm = ({
             }
             onSuccess={(response) =>
               console.log('invoice schedule response', response)
+            }
+            onError={({ error, fieldErrors }) =>
+              setErrors({ apiError: error.message, fieldErrors })
+            }
+          />
+          <AlertError errors={errors} />
+          <div className='contractor-onboarding-buttons-container'>
+            <BackButton
+              className='back-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Back
+            </BackButton>
+            <SubmitButton
+              className='submit-button'
+              onClick={() => setErrors({ apiError: '', fieldErrors: [] })}
+            >
+              Continue
+            </SubmitButton>
+          </div>
+        </div>
+      );
+
+    case 'create_invoice_schedule':
+      return (
+        <div className='contractor-onboarding-form-layout'>
+          <CreateInvoiceScheduleStep
+            onSubmit={(payload) =>
+              console.log('create invoice schedule payload', payload)
+            }
+            onSuccess={(response) =>
+              console.log('create invoice schedule response', response)
             }
             onError={({ error, fieldErrors }) =>
               setErrors({ apiError: error.message, fieldErrors })

--- a/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
+++ b/src/flows/ContractorOnboarding/ContractorOnboarding.tsx
@@ -16,6 +16,7 @@ import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/c
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
 import { InvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/InvoiceScheduleStep';
+import { CreateInvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/CreateInvoiceScheduleStep';
 
 export const ContractorOnboardingFlow = ({
   render,
@@ -66,6 +67,7 @@ export const ContractorOnboardingFlow = ({
           EligibilityQuestionnaireStep: EligibilityQuestionnaireStep,
           ContractOriginStep: ContractOriginStep,
           InvoiceScheduleStep: InvoiceScheduleStep,
+          CreateInvoiceScheduleStep: CreateInvoiceScheduleStep,
           ContractDetailsStep: ContractDetailsStep,
           ContractPreviewStep: ContractPreviewStep,
           OnboardingInvite: OnboardingInvite,

--- a/src/flows/ContractorOnboarding/components/CreateInvoiceScheduleStep.tsx
+++ b/src/flows/ContractorOnboarding/components/CreateInvoiceScheduleStep.tsx
@@ -1,0 +1,79 @@
+import { $TSFixMe, Components } from '@/src/types/remoteFlows';
+import { NormalizedFieldError } from '@/src/lib/mutations';
+import { useContractorOnboardingContext } from '@/src/flows/ContractorOnboarding/context';
+import { ContractorOnboardingForm } from '@/src/flows/ContractorOnboarding/components/ContractorOnboardingForm';
+import { handleStepError } from '@/src/lib/utils';
+import { UseFormReturn } from 'react-hook-form';
+
+type CreateInvoiceScheduleStepProps = {
+  /**
+   * Components to override the default field components used in the form.
+   */
+  components?: Components;
+  /*
+   * The function is called when the form is submitted. It receives the form values as an argument.
+   */
+  onSubmit?: (payload: $TSFixMe) => void | Promise<void>;
+  /*
+   * The function is called when the form submission is successful.
+   */
+  onSuccess?: (data: $TSFixMe) => void | Promise<void>;
+  /*
+   * The function is called when an error occurs during form submission.
+   */
+  onError?: ({
+    error,
+    rawError,
+    fieldErrors,
+  }: {
+    error: Error;
+    rawError: Record<string, unknown>;
+    fieldErrors: NormalizedFieldError[];
+  }) => void;
+};
+
+export function CreateInvoiceScheduleStep({
+  components,
+  onSubmit,
+  onSuccess,
+  onError,
+}: CreateInvoiceScheduleStepProps) {
+  const { contractorOnboardingBag } = useContractorOnboardingContext();
+
+  const handleSubmit = async (
+    payload: $TSFixMe,
+    form: UseFormReturn<$TSFixMe>,
+  ) => {
+    try {
+      const parsedValues =
+        await contractorOnboardingBag.parseFormValues(payload);
+      await onSubmit?.(parsedValues);
+      const response = await contractorOnboardingBag.onSubmit(payload);
+
+      if (response?.data) {
+        await onSuccess?.(response.data);
+        contractorOnboardingBag?.next();
+        return;
+      }
+    } catch (error: unknown) {
+      const structuredError = handleStepError(
+        error,
+        contractorOnboardingBag.meta?.fields?.create_invoice_schedule,
+        form,
+      );
+      onError?.(structuredError);
+    }
+  };
+
+  const initialValues =
+    contractorOnboardingBag.stepState.values?.create_invoice_schedule ||
+    contractorOnboardingBag.initialValues.create_invoice_schedule;
+
+  return (
+    <ContractorOnboardingForm
+      components={components}
+      defaultValues={initialValues}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -88,6 +88,7 @@ const stepToFormSchemaMap: Record<StepKeys, JSONSchemaFormType | null> = {
   basic_information: 'employment_basic_information',
   contract_origin: null,
   invoice_schedule: null,
+  create_invoice_schedule: null,
   contract_details: null,
   eligibility_questionnaire: null,
   pricing_plan: null,
@@ -131,6 +132,7 @@ export const useContractorOnboarding = ({
     basic_information: NestedMeta;
     contract_origin: NestedMeta;
     invoice_schedule: NestedMeta;
+    create_invoice_schedule: NestedMeta;
     contract_details: NestedMeta;
     contract_preview: NestedMeta;
     pricing_plan: NestedMeta;
@@ -140,6 +142,7 @@ export const useContractorOnboarding = ({
     basic_information: {},
     contract_origin: {},
     invoice_schedule: {},
+    create_invoice_schedule: {},
     contract_details: {},
     contract_preview: {},
     pricing_plan: {},
@@ -165,6 +168,9 @@ export const useContractorOnboarding = ({
   const [includeInvoiceSchedule, setIncludeInvoiceSchedule] =
     useState<boolean>(false);
 
+  const [includeCreateInvoiceSchedule, setIncludeCreateInvoiceSchedule] =
+    useState<boolean>(false);
+
   const [pendingNavigationStep, setPendingNavigationStep] =
     useState<StepKeys | null>(null);
 
@@ -174,6 +180,7 @@ export const useContractorOnboarding = ({
         includeSelectCountry: !skipSteps?.includes('select_country'),
         includeContractOrigin: includeContractOrigin,
         includeInvoiceSchedule: includeInvoiceSchedule,
+        includeCreateInvoiceSchedule: includeCreateInvoiceSchedule,
         includeEligibilityQuestionnaire: includeEligibilityQuestionnaire,
         includeContractDetails: includeContractDetails,
         includeContractPreview: includeContractPreview,
@@ -181,6 +188,7 @@ export const useContractorOnboarding = ({
     [
       includeContractOrigin,
       includeInvoiceSchedule,
+      includeCreateInvoiceSchedule,
       includeEligibilityQuestionnaire,
       includeContractDetails,
       includeContractPreview,
@@ -716,6 +724,7 @@ export const useContractorOnboarding = ({
       basic_information: basicInformationForm?.fields || [],
       contract_origin: contractOriginForm?.fields || [],
       invoice_schedule: invoiceScheduleForm?.fields || [],
+      create_invoice_schedule: [],
       pricing_plan: selectContractorSubscriptionForm?.fields || [],
       eligibility_questionnaire: eligibilityQuestionnaireForm?.fields || [],
       contract_details: contractorOnboardingDetailsForm?.fields || [],
@@ -742,6 +751,7 @@ export const useContractorOnboarding = ({
     basic_information: basicInformationForm?.meta['x-jsf-fieldsets'],
     contract_origin: null,
     invoice_schedule: null,
+    create_invoice_schedule: null,
     pricing_plan: null,
     contract_details: contractorOnboardingDetailsForm?.meta['x-jsf-fieldsets'],
     eligibility_questionnaire: null,
@@ -757,6 +767,7 @@ export const useContractorOnboarding = ({
     basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
     contract_origin: contractOriginForm?.meta?.['x-jsf-presentation'],
     invoice_schedule: invoiceScheduleForm?.meta?.['x-jsf-presentation'],
+    create_invoice_schedule: null,
     pricing_plan:
       selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
     eligibility_questionnaire:
@@ -830,6 +841,13 @@ export const useContractorOnboarding = ({
     return getInitialValues(stepFields.invoice_schedule, initialValues);
   }, [stepFields.invoice_schedule, onboardingInitialValues]);
 
+  const createInvoiceScheduleInitialValues = useMemo(() => {
+    const initialValues = {
+      ...onboardingInitialValues,
+    };
+    return getInitialValues(stepFields.create_invoice_schedule, initialValues);
+  }, [stepFields.create_invoice_schedule, onboardingInitialValues]);
+
   const contractDetailsInitialValues = useMemo(() => {
     const hardcodedValues = {
       service_duration: {
@@ -900,6 +918,7 @@ export const useContractorOnboarding = ({
       basic_information: basicInformationInitialValues,
       contract_origin: contractOriginInitialValues,
       invoice_schedule: invoiceScheduleInitialValues,
+      create_invoice_schedule: createInvoiceScheduleInitialValues,
       contract_details: contractDetailsInitialValues,
       contract_preview: contractPreviewInitialValues,
       pricing_plan: pricingPlanInitialValues,
@@ -910,6 +929,7 @@ export const useContractorOnboarding = ({
     basicInformationInitialValues,
     contractOriginInitialValues,
     invoiceScheduleInitialValues,
+    createInvoiceScheduleInitialValues,
     contractDetailsInitialValues,
     contractPreviewInitialValues,
     pricingPlanInitialValues,
@@ -971,6 +991,7 @@ export const useContractorOnboarding = ({
         ),
         contract_origin: {},
         invoice_schedule: {},
+        create_invoice_schedule: {},
         contract_details: prettifyFormValues(
           contractDetailsInitialValues,
           stepFields.contract_details,
@@ -998,6 +1019,7 @@ export const useContractorOnboarding = ({
         basic_information: basicInformationInitialValues,
         contract_origin: {},
         invoice_schedule: {},
+        create_invoice_schedule: {},
         contract_details: contractDetailsInitialValues,
         contract_preview: contractPreviewInitialValues,
         pricing_plan: pricingPlanInitialValues,
@@ -1392,10 +1414,23 @@ export const useContractorOnboarding = ({
       }
 
       case 'invoice_schedule': {
+        // Show create_invoice_schedule step only when user selects 'schedule'
+        const shouldShowCreateStep =
+          values.invoice_schedule_preference === 'schedule';
+        setIncludeCreateInvoiceSchedule(shouldShowCreateStep);
+
         return {
           data: {
             invoiceSchedulePreference: values.invoice_schedule_preference,
           },
+        };
+      }
+
+      case 'create_invoice_schedule': {
+        // TODO: Add form schema and API call when ready
+        // For now, just return empty data to allow progression
+        return {
+          data: {},
         };
       }
 

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -66,7 +66,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
   [7]: 'Invoice schedule',
-  [8]: 'Review',
+  [8]: 'Create Invoice Schedule',
+  [9]: 'Review',
 };
 
 function createMockRenderImplementation(

--- a/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/OnboardingInvite.test.tsx
@@ -35,7 +35,8 @@ const CONTRACTOR_ONBOARDING_STEPS: Record<number, string> = {
   [5]: 'Contract Details',
   [6]: 'Contract Preview',
   [7]: 'Invoice schedule',
-  [8]: 'Review',
+  [8]: 'Create Invoice Schedule',
+  [9]: 'Review',
 };
 
 const mockSuccess = vi.fn();

--- a/src/flows/ContractorOnboarding/types.ts
+++ b/src/flows/ContractorOnboarding/types.ts
@@ -17,6 +17,7 @@ import { ContractReviewButton } from '@/src/flows/ContractorOnboarding/component
 import { EligibilityQuestionnaireStep } from '@/src/flows/ContractorOnboarding/components/EligibilityQuestionnaireStep';
 import { ContractOriginStep } from '@/src/flows/ContractorOnboarding/components/ContractOriginStep';
 import { InvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/InvoiceScheduleStep';
+import { CreateInvoiceScheduleStep } from '@/src/flows/ContractorOnboarding/components/CreateInvoiceScheduleStep';
 import { ProductType } from '@/src/flows/ContractorOnboarding/constants';
 import { SaveDraftButton } from '@/src/flows/ContractorOnboarding/components/SaveDraftButton';
 
@@ -48,6 +49,7 @@ export type ContractorOnboardingRenderProps = {
     PricingPlanStep: typeof PricingPlanStep;
     ContractOriginStep: typeof ContractOriginStep;
     InvoiceScheduleStep: typeof InvoiceScheduleStep;
+    CreateInvoiceScheduleStep: typeof CreateInvoiceScheduleStep;
     ContractDetailsStep: typeof ContractDetailsStep;
     ContractPreviewStep: typeof ContractPreviewStep;
     OnboardingInvite: typeof OnboardingInvite;
@@ -86,6 +88,7 @@ type ContractorOnboardingFlowOptions = Omit<FlowOptions, 'jsfModify'> & {
     pricing_plan?: JSFModify;
     contract_origin?: JSFModify;
     invoice_schedule?: JSFModify;
+    create_invoice_schedule?: JSFModify;
   };
 };
 

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -14,6 +14,7 @@ export type StepKeys =
   | 'basic_information'
   | 'contract_origin'
   | 'invoice_schedule'
+  | 'create_invoice_schedule'
   | 'contract_details'
   | 'eligibility_questionnaire'
   | 'contract_preview'
@@ -24,6 +25,7 @@ type StepConfig = {
   includeSelectCountry?: boolean;
   includeContractOrigin?: boolean;
   includeInvoiceSchedule?: boolean;
+  includeCreateInvoiceSchedule?: boolean;
   includeEligibilityQuestionnaire?: boolean;
   includeContractDetails?: boolean;
   includeContractPreview?: boolean;
@@ -74,6 +76,11 @@ export function buildSteps(config: StepConfig = {}) {
       name: 'invoice_schedule',
       label: 'Invoice schedule',
       visible: Boolean(config?.includeInvoiceSchedule),
+    },
+    {
+      name: 'create_invoice_schedule',
+      label: 'Create Invoice Schedule',
+      visible: Boolean(config?.includeCreateInvoiceSchedule),
     },
     {
       name: 'review',


### PR DESCRIPTION
Just build the next that depends on the answer of the previous step

The cursor description sums up properly the change


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding only: no new API or validation for schedule creation yet, and progression is explicitly stubbed. Changes follow existing step patterns with limited blast radius.
> 
> **Overview**
> Adds a new **Create Invoice Schedule** onboarding step that appears only when the contractor onboarding feature flag includes `create_invoice_schedule` and the user chooses **Create invoice schedule now** (`invoice_schedule_preference === 'schedule'`) on the existing invoice schedule step.
> 
> The flow registers the step in `buildSteps`, wires `CreateInvoiceScheduleStep` through the flow render props and example app (with back/continue chrome), and toggles step visibility from the `invoice_schedule` submit handler. The new step component mirrors other step wrappers (`ContractorOnboardingForm`, parse/submit/error handling) but has **no JSON schema fields yet** (`create_invoice_schedule` fields are empty) and **`onSubmit` returns empty data** with a TODO for the real API—so users can advance without persisting schedule details yet. Types and `jsfModify` gain a `create_invoice_schedule` slot; tests update the expected step order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c37e28ef92bb5adcae1353b5e14681ce1ab890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->