### PR TITLE
feat(create-invoice) - render form

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -556,6 +556,21 @@ const MultiStepForm = ({
     case 'create_invoice_schedule':
       return (
         <div className='contractor-onboarding-form-layout'>
+          {contractorOnboardingBag.meta.presentation?.title && (
+            <div className='flex flex-col gap-2 text-center mb-6'>
+              <h1 className='text-2xl font-bold text-[#000000]'>
+                {contractorOnboardingBag.meta.presentation.title as string}
+              </h1>
+              {contractorOnboardingBag.meta.presentation.description && (
+                <p className='text-sm text-[#71717A]'>
+                  {
+                    contractorOnboardingBag.meta.presentation
+                      .description as string
+                  }
+                </p>
+              )}
+            </div>
+          )}
           <CreateInvoiceScheduleStep
             onSubmit={(payload) =>
               console.log('create invoice schedule payload', payload)

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -554,19 +554,20 @@ const MultiStepForm = ({
       );
 
     case 'create_invoice_schedule':
+      const presentation = contractorOnboardingBag.meta.presentation as {
+        title: string;
+        description: string;
+      };
       return (
         <div className='contractor-onboarding-form-layout'>
-          {contractorOnboardingBag.meta.presentation?.title && (
+          {presentation?.title && (
             <div className='flex flex-col gap-2 text-center mb-6'>
               <h1 className='text-2xl font-bold text-[#000000]'>
-                {contractorOnboardingBag.meta.presentation.title as string}
+                {presentation.title}
               </h1>
-              {contractorOnboardingBag.meta.presentation.description && (
+              {presentation.description && (
                 <p className='text-sm text-[#71717A]'>
-                  {
-                    contractorOnboardingBag.meta.presentation
-                      .description as string
-                  }
+                  {presentation.description}
                 </p>
               )}
             </div>

--- a/src/common/api/contractor-contract-details.ts
+++ b/src/common/api/contractor-contract-details.ts
@@ -14,7 +14,7 @@ import {
 } from '@/src/flows/types';
 import { $TSFixMe } from '@/src/types/remoteFlows';
 
-const useContractorCurrencies = ({
+export const useContractorCurrencies = ({
   employmentId,
   options,
 }: {

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -23,6 +23,7 @@ import { useClient } from '@/src/context';
 import { signatureSchema } from '@/src/flows/ContractorOnboarding/json-schemas/signature';
 import { contractOriginSchema } from '@/src/flows/ContractorOnboarding/json-schemas/contractOrigin';
 import { invoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule';
+import { createInvoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule';
 import { selectContractorSubscriptionStepSchema } from '@/src/flows/ContractorOnboarding/json-schemas/selectContractorSubscriptionStep';
 import {
   JSONSchemaFormResultWithFieldsets,
@@ -764,6 +765,25 @@ export const useGetInvoiceScheduleSchema = ({
     if (!enabled) return null;
     return createHeadlessForm(
       invoiceScheduleSchema,
+      {},
+      {
+        jsfModify,
+      },
+    );
+  }, [enabled, jsfModify]);
+};
+
+export const useGetCreateInvoiceScheduleSchema = ({
+  enabled,
+  jsfModify,
+}: {
+  enabled?: boolean;
+  jsfModify?: JSFModify;
+}) => {
+  return useMemo(() => {
+    if (!enabled) return null;
+    return createHeadlessForm(
+      createInvoiceScheduleSchema,
       {},
       {
         jsfModify,

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -25,6 +25,7 @@ import { contractOriginSchema } from '@/src/flows/ContractorOnboarding/json-sche
 import { invoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/invoiceSchedule';
 import { createInvoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule';
 import { selectContractorSubscriptionStepSchema } from '@/src/flows/ContractorOnboarding/json-schemas/selectContractorSubscriptionStep';
+import { useContractorCurrencies } from '@/src/common/api/contractor-contract-details';
 import {
   JSONSchemaFormResultWithFieldsets,
   FlowOptions,
@@ -773,14 +774,27 @@ export const useGetInvoiceScheduleSchema = ({
   }, [enabled, jsfModify]);
 };
 
+/**
+ * Get the create invoice schedule schema with currency options from the contractor currencies endpoint.
+ * React Query caches the result, so multiple calls share the same data.
+ */
 export const useGetCreateInvoiceScheduleSchema = ({
   enabled,
+  employmentId,
   jsfModify,
 }: {
   enabled?: boolean;
+  employmentId?: string;
   jsfModify?: JSFModify;
-}) => {
-  return useMemo(() => {
+}): JSONSchemaFormResultWithFieldsets | null => {
+  const { data: currencies } = useContractorCurrencies({
+    employmentId: employmentId as string,
+    options: {
+      queryOptions: { enabled: enabled && Boolean(employmentId) },
+    },
+  });
+
+  const schemaQuery = useMemo(() => {
     if (!enabled) return null;
     return createHeadlessForm(
       createInvoiceScheduleSchema,
@@ -790,6 +804,32 @@ export const useGetCreateInvoiceScheduleSchema = ({
       },
     );
   }, [enabled, jsfModify]);
+
+  const dataWithCurrencies = useMemo(() => {
+    if (!schemaQuery || !currencies) {
+      return schemaQuery;
+    }
+
+    return {
+      ...schemaQuery,
+      fields: schemaQuery.fields.map((field: $TSFixMe) =>
+        field.name !== 'currency'
+          ? field
+          : {
+              ...field,
+              options: currencies.map(
+                (currency: { code: string; source: string }) => ({
+                  label: currency.code,
+                  value: currency.code,
+                  meta: { source: currency.source },
+                }),
+              ),
+            },
+      ),
+    };
+  }, [schemaQuery, currencies]);
+
+  return dataWithCurrencies;
 };
 
 export const useCountriesSchemaField = (

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import {
+  BulkContractorInvoiceScheduleCreateParams,
   CompanyAction,
   CreateContractDocument,
   getV1CompaniesCompanyIdActions,
@@ -9,6 +10,7 @@ import {
   postV1ContractorsEmploymentsEmploymentIdContractDocuments,
   postV1ContractorsEmploymentsEmploymentIdContractorPlusSubscription,
   postV1ContractorsEmploymentsEmploymentIdContractDocumentsContractDocumentIdSign,
+  postV1ContractorInvoiceSchedules,
   SignContractDocument,
   getV1EmploymentsEmploymentIdContractDocuments,
   EligibilityQuestionnaireJsonSchemaResponse,
@@ -794,42 +796,30 @@ export const useGetCreateInvoiceScheduleSchema = ({
     },
   });
 
-  const schemaQuery = useMemo(() => {
-    if (!enabled) return null;
-    return createHeadlessForm(
-      createInvoiceScheduleSchema,
-      {},
-      {
-        jsfModify,
+  const schemaWithCurrencies = useMemo(() => {
+    if (!enabled || !currencies) return null;
+
+    // Clone the schema and update the currency oneOf with actual currencies
+    const schema = {
+      ...createInvoiceScheduleSchema,
+      properties: {
+        ...createInvoiceScheduleSchema.properties,
+        currency: {
+          ...createInvoiceScheduleSchema.properties.currency,
+          oneOf: currencies.map(
+            (currency: { code: string; source: string }) => ({
+              const: currency.code,
+              title: currency.code,
+            }),
+          ),
+        },
       },
-    );
-  }, [enabled, jsfModify]);
-
-  const dataWithCurrencies = useMemo(() => {
-    if (!schemaQuery || !currencies) {
-      return schemaQuery;
-    }
-
-    return {
-      ...schemaQuery,
-      fields: schemaQuery.fields.map((field: $TSFixMe) =>
-        field.name !== 'currency'
-          ? field
-          : {
-              ...field,
-              options: currencies.map(
-                (currency: { code: string; source: string }) => ({
-                  label: currency.code,
-                  value: currency.code,
-                  meta: { source: currency.source },
-                }),
-              ),
-            },
-      ),
     };
-  }, [schemaQuery, currencies]);
 
-  return dataWithCurrencies;
+    return createHeadlessForm(schema, {}, { jsfModify });
+  }, [enabled, currencies, jsfModify]);
+
+  return schemaWithCurrencies;
 };
 
 export const useCountriesSchemaField = (
@@ -896,5 +886,59 @@ export const useCompanyOpenTasks = ({
       }),
     select: ({ data }) => data?.data?.actions ?? ([] as CompanyAction[]),
     enabled: (options?.queryOptions?.enabled ?? true) && !!companyId,
+  });
+};
+
+/**
+ * Creates contractor invoice schedules
+ * @param employmentId - The employment ID
+ * @param values - The form values containing invoice schedule data
+ * @returns The created invoice schedules
+ */
+export const useCreateInvoiceSchedule = () => {
+  const { client } = useClient();
+  return useMutation({
+    mutationFn: async ({
+      employmentId,
+      values,
+    }: {
+      employmentId: string;
+      values: FieldValues;
+    }) => {
+      // Collect invoice items from form fields (item_1 through item_10)
+      const items = [];
+      for (let i = 1; i <= 10; i++) {
+        const description = values[`item_${i}_description`];
+        const amount = values[`item_${i}_amount`];
+        if (description && amount) {
+          items.push({
+            description,
+            amount: Number(amount),
+          });
+        }
+      }
+
+      const payload: BulkContractorInvoiceScheduleCreateParams = {
+        contractor_invoice_schedules: [
+          {
+            employment_id: employmentId,
+            currency: values.currency,
+            periodicity: values.periodicity,
+            start_date: values.start_date,
+            items,
+            ...(values.number && { number: values.number }),
+            ...(values.note && { note: values.note }),
+            ...(values.nr_occurrences && {
+              nr_occurrences: Number(values.nr_occurrences),
+            }),
+          },
+        ],
+      };
+
+      return postV1ContractorInvoiceSchedules({
+        client: client as Client,
+        body: payload,
+      });
+    },
   });
 };

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -914,7 +914,7 @@ export const useCreateInvoiceSchedule = () => {
       for (let i = 1; i <= 10; i++) {
         const description = values[`item_${i}_description`];
         const amount = values[`item_${i}_amount`];
-        if (description && amount) {
+        if (description && amount != null) {
           items.push({
             description,
             amount: Number(amount),

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -788,13 +788,14 @@ export const useGetCreateInvoiceScheduleSchema = ({
   enabled?: boolean;
   employmentId?: string;
   jsfModify?: JSFModify;
-}): JSONSchemaFormResultWithFieldsets | null => {
-  const { data: currencies } = useContractorCurrencies({
-    employmentId: employmentId as string,
-    options: {
-      queryOptions: { enabled: enabled && Boolean(employmentId) },
-    },
-  });
+}): { data: JSONSchemaFormResultWithFieldsets | null; isLoading: boolean } => {
+  const { data: currencies, isLoading: isLoadingCurrencies } =
+    useContractorCurrencies({
+      employmentId: employmentId as string,
+      options: {
+        queryOptions: { enabled: enabled && Boolean(employmentId) },
+      },
+    });
 
   const schemaWithCurrencies = useMemo(() => {
     if (!enabled || !currencies) return null;
@@ -819,7 +820,10 @@ export const useGetCreateInvoiceScheduleSchema = ({
     return createHeadlessForm(schema, {}, { jsfModify });
   }, [enabled, currencies, jsfModify]);
 
-  return schemaWithCurrencies;
+  return {
+    data: schemaWithCurrencies,
+    isLoading: isLoadingCurrencies,
+  };
 };
 
 export const useCountriesSchemaField = (

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -700,7 +700,10 @@ export const useContractorOnboarding = ({
     jsfModify: options?.jsfModify?.invoice_schedule,
   });
 
-  const createInvoiceScheduleForm = useGetCreateInvoiceScheduleSchema({
+  const {
+    data: createInvoiceScheduleForm,
+    isLoading: isLoadingCreateInvoiceScheduleForm,
+  } = useGetCreateInvoiceScheduleSchema({
     enabled: includeInvoiceSchedule,
     employmentId: internalEmploymentId,
     jsfModify: options?.jsfModify?.create_invoice_schedule,
@@ -965,7 +968,8 @@ export const useContractorOnboarding = ({
     isLoadingDocumentPreviewForm ||
     isLoadingIR35File ||
     isLoadingContractDocuments ||
-    isLoadingEligibilityQuestionnaire;
+    isLoadingEligibilityQuestionnaire ||
+    isLoadingCreateInvoiceScheduleForm;
 
   const isNavigatingToReview = useMemo(() => {
     const isCor = employment?.contractor_type === 'cor';
@@ -1764,7 +1768,8 @@ export const useContractorOnboarding = ({
       createEligibilityQuestionnaireMutation.isPending ||
       manageContractorCorSubscriptionMutation.isPending ||
       deleteContractorCorSubscriptionMutation.isPending ||
-      setContractOriginMutation.isPending,
+      setContractOriginMutation.isPending ||
+      createInvoiceScheduleMutation.isPending,
 
     /**
      * Document preview PDF data

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1139,6 +1139,19 @@ export const useContractorOnboarding = ({
       });
     }
 
+    if (
+      createInvoiceScheduleForm &&
+      stepState.currentStep.name === 'create_invoice_schedule'
+    ) {
+      return await parseJSFToValidate(
+        values,
+        createInvoiceScheduleForm?.fields,
+        {
+          isPartialValidation: false,
+        },
+      );
+    }
+
     return {};
   };
 
@@ -1577,6 +1590,18 @@ export const useContractorOnboarding = ({
         return invoiceScheduleForm?.handleValidation(parsedValues);
       }
 
+      if (
+        createInvoiceScheduleForm &&
+        stepState.currentStep.name === 'create_invoice_schedule'
+      ) {
+        const parsedValues = await parseJSFToValidate(
+          values,
+          createInvoiceScheduleForm?.fields,
+          { isPartialValidation: false },
+        );
+        return createInvoiceScheduleForm?.handleValidation(parsedValues);
+      }
+
       return null;
     },
     [
@@ -1589,6 +1614,7 @@ export const useContractorOnboarding = ({
       eligibilityQuestionnaireForm,
       contractOriginForm,
       invoiceScheduleForm,
+      createInvoiceScheduleForm,
     ],
   );
 

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1462,10 +1462,48 @@ export const useContractorOnboarding = ({
       }
 
       case 'create_invoice_schedule': {
-        return createInvoiceScheduleMutationAsync({
+        const response = await createInvoiceScheduleMutationAsync({
           employmentId: internalEmploymentId as string,
           values: parsedValues,
         });
+
+        // Check for failures in the bulk response
+        const failures = response?.data?.failures;
+        if (failures && failures.length > 0) {
+          // Extract the first failure for error message
+          const firstFailure = failures[0];
+          const errorMessages: string[] = [];
+
+          // Collect all error messages from the failure
+          if (firstFailure.errors) {
+            Object.entries(firstFailure.errors).forEach(([, messages]) => {
+              if (Array.isArray(messages)) {
+                // Check if it's an array of strings or array of objects
+                messages.forEach((message) => {
+                  if (typeof message === 'string') {
+                    errorMessages.push(message);
+                  } else if (typeof message === 'object' && message !== null) {
+                    // Handle nested error objects (e.g., items array)
+                    Object.values(message).forEach((nestedMessages) => {
+                      if (Array.isArray(nestedMessages)) {
+                        errorMessages.push(...nestedMessages);
+                      }
+                    });
+                  }
+                });
+              }
+            });
+          }
+
+          const errorMessage =
+            errorMessages.length > 0
+              ? errorMessages.join(', ')
+              : 'Failed to create invoice schedule';
+
+          throw createStructuredError(errorMessage);
+        }
+
+        return response;
       }
 
       case 'eligibility_questionnaire': {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -33,6 +33,7 @@ import {
   useSetContractOrigin,
   useGetContractOriginSchema,
   useGetInvoiceScheduleSchema,
+  useGetCreateInvoiceScheduleSchema,
 } from '@/src/flows/ContractorOnboarding/api';
 import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
@@ -694,6 +695,11 @@ export const useContractorOnboarding = ({
     jsfModify: options?.jsfModify?.invoice_schedule,
   });
 
+  const createInvoiceScheduleForm = useGetCreateInvoiceScheduleSchema({
+    enabled: includeInvoiceSchedule,
+    jsfModify: options?.jsfModify?.create_invoice_schedule,
+  });
+
   const {
     data: documentPreviewPdf,
     isLoading: isLoadingDocumentPreviewForm,
@@ -724,7 +730,7 @@ export const useContractorOnboarding = ({
       basic_information: basicInformationForm?.fields || [],
       contract_origin: contractOriginForm?.fields || [],
       invoice_schedule: invoiceScheduleForm?.fields || [],
-      create_invoice_schedule: [],
+      create_invoice_schedule: createInvoiceScheduleForm?.fields || [],
       pricing_plan: selectContractorSubscriptionForm?.fields || [],
       eligibility_questionnaire: eligibilityQuestionnaireForm?.fields || [],
       contract_details: contractorOnboardingDetailsForm?.fields || [],
@@ -736,6 +742,7 @@ export const useContractorOnboarding = ({
       basicInformationForm?.fields,
       contractOriginForm?.fields,
       invoiceScheduleForm?.fields,
+      createInvoiceScheduleForm?.fields,
       selectContractorSubscriptionForm?.fields,
       contractorOnboardingDetailsForm?.fields,
       signatureSchemaForm?.fields,
@@ -767,7 +774,8 @@ export const useContractorOnboarding = ({
     basic_information: basicInformationForm?.meta?.['x-jsf-presentation'],
     contract_origin: contractOriginForm?.meta?.['x-jsf-presentation'],
     invoice_schedule: invoiceScheduleForm?.meta?.['x-jsf-presentation'],
-    create_invoice_schedule: null,
+    create_invoice_schedule:
+      createInvoiceScheduleForm?.meta?.['x-jsf-presentation'],
     pricing_plan:
       selectContractorSubscriptionForm?.meta?.['x-jsf-presentation'],
     eligibility_questionnaire:
@@ -1588,9 +1596,14 @@ export const useContractorOnboarding = ({
       setFieldValues(values);
       // new steps or refactor ones should rely on json-schema-form-mutability
       // instead of passing fieldValues
+      const stepsUsingHandleValidation = [
+        'invoice_schedule',
+        'create_invoice_schedule',
+      ];
+
       if (
         includeInvoiceSchedule &&
-        stepState.currentStep.name === 'invoice_schedule'
+        stepsUsingHandleValidation.includes(stepState.currentStep.name)
       ) {
         await handleValidation(values);
       }

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -34,6 +34,7 @@ import {
   useGetContractOriginSchema,
   useGetInvoiceScheduleSchema,
   useGetCreateInvoiceScheduleSchema,
+  useCreateInvoiceSchedule,
 } from '@/src/flows/ContractorOnboarding/api';
 import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
@@ -271,6 +272,7 @@ export const useContractorOnboarding = ({
   const manageContractorCorSubscriptionMutation =
     usePostManageContractorCorSubscription();
   const setContractOriginMutation = useSetContractOrigin();
+  const createInvoiceScheduleMutation = useCreateInvoiceSchedule();
 
   const { mutateAsyncOrThrow: updateEmploymentMutationAsync } =
     mutationToPromise(updateEmploymentMutation);
@@ -303,6 +305,9 @@ export const useContractorOnboarding = ({
 
   const { mutateAsyncOrThrow: setContractOriginMutationAsync } =
     mutationToPromise(setContractOriginMutation);
+
+  const { mutateAsyncOrThrow: createInvoiceScheduleMutationAsync } =
+    mutationToPromise(createInvoiceScheduleMutation);
 
   // if the employment is loaded, country code has not been set yet
   // we set the internal country code with the employment country code
@@ -1449,11 +1454,10 @@ export const useContractorOnboarding = ({
       }
 
       case 'create_invoice_schedule': {
-        // TODO: Add form schema and API call when ready
-        // For now, just return empty data to allow progression
-        return {
-          data: {},
-        };
+        return createInvoiceScheduleMutationAsync({
+          employmentId: internalEmploymentId as string,
+          values: parsedValues,
+        });
       }
 
       case 'eligibility_questionnaire': {

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1470,37 +1470,7 @@ export const useContractorOnboarding = ({
         // Check for failures in the bulk response
         const failures = response?.data?.failures;
         if (failures && failures.length > 0) {
-          // Extract the first failure for error message
-          const firstFailure = failures[0];
-          const errorMessages: string[] = [];
-
-          // Collect all error messages from the failure
-          if (firstFailure.errors) {
-            Object.entries(firstFailure.errors).forEach(([, messages]) => {
-              if (Array.isArray(messages)) {
-                // Check if it's an array of strings or array of objects
-                messages.forEach((message) => {
-                  if (typeof message === 'string') {
-                    errorMessages.push(message);
-                  } else if (typeof message === 'object' && message !== null) {
-                    // Handle nested error objects (e.g., items array)
-                    Object.values(message).forEach((nestedMessages) => {
-                      if (Array.isArray(nestedMessages)) {
-                        errorMessages.push(...nestedMessages);
-                      }
-                    });
-                  }
-                });
-              }
-            });
-          }
-
-          const errorMessage =
-            errorMessages.length > 0
-              ? errorMessages.join(', ')
-              : 'Failed to create invoice schedule';
-
-          throw createStructuredError(errorMessage);
+          throw createStructuredError('Failed to create invoice schedule');
         }
 
         return response;

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -696,7 +696,9 @@ export const useContractorOnboarding = ({
   });
 
   const invoiceScheduleForm = useGetInvoiceScheduleSchema({
-    enabled: includeInvoiceSchedule,
+    enabled:
+      includeInvoiceSchedule &&
+      stepState.currentStep.name === 'invoice_schedule',
     jsfModify: options?.jsfModify?.invoice_schedule,
   });
 
@@ -704,7 +706,9 @@ export const useContractorOnboarding = ({
     data: createInvoiceScheduleForm,
     isLoading: isLoadingCreateInvoiceScheduleForm,
   } = useGetCreateInvoiceScheduleSchema({
-    enabled: includeInvoiceSchedule,
+    enabled:
+      includeInvoiceSchedule &&
+      stepState.currentStep.name === 'create_invoice_schedule',
     employmentId: internalEmploymentId,
     jsfModify: options?.jsfModify?.create_invoice_schedule,
   });

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -697,6 +697,7 @@ export const useContractorOnboarding = ({
 
   const createInvoiceScheduleForm = useGetCreateInvoiceScheduleSchema({
     enabled: includeInvoiceSchedule,
+    employmentId: internalEmploymentId,
     jsfModify: options?.jsfModify?.create_invoice_schedule,
   });
 

--- a/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule.ts
@@ -1,0 +1,167 @@
+const INVOICE_ITEM_SLOTS = 10;
+
+const PERIODICITY_OPTIONS = [
+  { const: 'weekly', title: 'Weekly' },
+  { const: 'bi_weekly', title: 'Bi-weekly' },
+  { const: 'semi_monthly', title: 'Semi-monthly' },
+  { const: 'monthly', title: 'Monthly' },
+];
+
+function invoiceItemProperties() {
+  const properties: Record<string, object> = {};
+
+  for (let slot = 1; slot <= INVOICE_ITEM_SLOTS; slot++) {
+    properties[`item_${slot}_description`] = {
+      title: `Item ${slot} description`,
+      type: 'string',
+      'x-jsf-presentation': {
+        inputType: 'text',
+      },
+    };
+    properties[`item_${slot}_amount`] = {
+      title: `Item ${slot} amount`,
+      type: 'integer',
+      'x-jsf-presentation': {
+        inputType: 'money',
+      },
+      'x-jsf-logic-computedAttrs': {
+        currency: 'currency_selected',
+      },
+    };
+  }
+
+  return properties;
+}
+
+// Slot 1 is required (see the base required array below).
+// Slots 2..N are optional and only revealed once the previous slot has been filled in,
+// since the form-kit has no built-in "add another row" renderer for a true items array.
+function invoiceItemRevealConditionals() {
+  const conditionals = [];
+
+  for (let slot = 2; slot <= INVOICE_ITEM_SLOTS; slot++) {
+    const previousSlot = slot - 1;
+
+    conditionals.push({
+      if: {
+        properties: {
+          [`item_${previousSlot}_description`]: {
+            type: 'string',
+            minLength: 1,
+          },
+          [`item_${previousSlot}_amount`]: { type: 'integer', minimum: 1 },
+        },
+        required: [
+          `item_${previousSlot}_description`,
+          `item_${previousSlot}_amount`,
+        ],
+      },
+      then: {},
+      else: {
+        properties: {
+          [`item_${slot}_description`]: false,
+          [`item_${slot}_amount`]: false,
+        },
+      },
+    });
+  }
+
+  return conditionals;
+}
+
+const itemFieldOrder = Array.from(
+  { length: INVOICE_ITEM_SLOTS },
+  (_, index) => index + 1,
+).flatMap((slot) => [`item_${slot}_description`, `item_${slot}_amount`]);
+
+export const createInvoiceScheduleSchema = {
+  type: 'object',
+  'x-jsf-presentation': {
+    title: 'Create invoice schedule',
+    description:
+      'Fill out the invoice details and specify the recurrence options.',
+  },
+  properties: {
+    currency: {
+      description: 'The currency this invoice schedule will be issued in.',
+      title: 'Invoice currency',
+      type: 'string',
+      // Replaced at runtime with the contractor's supported currencies
+      // (see useGetCreateInvoiceScheduleSchema in ContractorOnboarding/api.ts).
+      oneOf: [{ const: 'placeholder', title: 'Loading currencies…' }],
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+    },
+    periodicity: {
+      description: 'How often invoices are generated for this schedule.',
+      title: 'Frequency',
+      type: 'string',
+      oneOf: PERIODICITY_OPTIONS,
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+    },
+    start_date: {
+      description: 'Date the first invoice will be generated.',
+      title: 'Start date',
+      type: 'string',
+      format: 'date',
+      'x-jsf-presentation': {
+        inputType: 'date',
+      },
+    },
+    ...invoiceItemProperties(),
+    number: {
+      description: 'Optional identifier shown on generated invoices.',
+      title: 'Invoice number',
+      type: 'string',
+      maxLength: 10,
+      'x-jsf-presentation': {
+        inputType: 'text',
+      },
+    },
+    note: {
+      description: 'Shown on generated invoices.',
+      title: 'Additional notes',
+      type: 'string',
+      'x-jsf-presentation': {
+        inputType: 'textarea',
+      },
+    },
+    nr_occurrences: {
+      description:
+        'Number of invoices to generate. Leave blank for the schedule to repeat indefinitely.',
+      title: 'Number of occurrences',
+      type: 'integer',
+      minimum: 1,
+      'x-jsf-presentation': {
+        inputType: 'number',
+      },
+    },
+  },
+  required: [
+    'currency',
+    'periodicity',
+    'start_date',
+    'item_1_description',
+    'item_1_amount',
+  ],
+  'x-jsf-order': [
+    'currency',
+    'periodicity',
+    'start_date',
+    ...itemFieldOrder,
+    'number',
+    'note',
+    'nr_occurrences',
+  ],
+  'x-jsf-logic': {
+    computedValues: {
+      currency_selected: {
+        rule: { var: 'currency' },
+      },
+    },
+  },
+  allOf: invoiceItemRevealConditionals(),
+};

--- a/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule.ts
@@ -25,7 +25,11 @@ function invoiceItemProperties() {
         inputType: 'money',
       },
       'x-jsf-logic-computedAttrs': {
-        currency: 'currency_selected',
+        'x-jsf-presentation': {
+          additionalProps: {
+            currency: 'currency_selected',
+          },
+        },
       },
     };
   }

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -1466,7 +1466,8 @@ describe('ContractorOnboardingFlow', () => {
 
     await screen.findByText(/Step: Contract Details/i);
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
+    // TODO: It seems we don't need it anymore but strange
+    // await waitForElementToBeRemoved(() => screen.getByTestId('spinner'));
 
     await waitFor(() => {
       const elements = screen.getAllByText(/Contractor Services Agreement/i);


### PR DESCRIPTION
It take's @cammellos [PR](https://github.com/remoteoss/remote-flows/pull/1251)  and integrates it on the new step

The submit is wired up with the API to create schedules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new write path for recurring invoice schedules (currency, amounts, dates) during onboarding; logic follows existing flow patterns but incorrect mapping or API handling could affect contractor billing setup.
> 
> **Overview**
> Adds a **create invoice schedule** step to contractor onboarding when the `create_invoice_schedule` feature is enabled and the user chooses to schedule invoices on the prior preference step.
> 
> The step renders a JSON Schema form (currency from contractor currencies, frequency, start date, progressively revealed line items, optional notes/occurrences) and **submits** via `postV1ContractorInvoiceSchedules`, mapping flat `item_N_*` fields into schedule items and surfacing bulk API failures as structured errors. Schema loading for invoice-related steps is scoped to the active step; the example app shows step presentation title/description around `CreateInvoiceScheduleStep`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe0b67ac3dc7372630dd32c30b5b954964e97e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->