### PR TITLE
feat(invoices) - edit a previous scheduled invoice

### DIFF
--- a/.cursor/rules/loading-state-aggregation.mdc
+++ b/.cursor/rules/loading-state-aggregation.mdc
@@ -1,0 +1,66 @@
+# Loading State Aggregation Pattern
+
+## Flow hooks.tsx Pattern
+
+When adding new queries to flow hooks (Onboarding, ContractorOnboarding, CreateCompany, etc.), **always** remember to:
+
+1. **Destructure the loading state** from the query hook:
+
+   ```typescript
+   const { data, isLoading: isLoadingSomething } = useSomeQuery({ ... });
+   ```
+
+2. **Add it to the `initialLoading` aggregation** (typically around line 966-976 in flow hooks):
+   
+   ```typescript
+   const initialLoading =
+     isLoadingCountries ||
+     isLoadingBasicInformationForm ||
+     // ... other loading states ...
+     isLoadingSomething;  // <-- Don't forget this!
+   ```
+
+3. **Why this matters:**
+   - The `initialLoading` is used to compute the final `isLoading` state returned from the flow
+   - Missing loading states can cause premature step transitions or missing loading indicators
+   - The loading state gates navigation in `isNavigatingToReview` logic
+
+## Quick Checklist
+
+When adding a new query to a flow:
+
+- [ ] Query hook returns `isLoading: isLoadingSomething`
+- [ ] `isLoadingSomething` is added to `initialLoading` aggregation
+- [ ] Query has proper `enabled` condition to prevent unnecessary calls
+
+## Example
+
+```typescript
+// 1. Add query with loading state
+const { data: invoiceSchedules, isLoading: isLoadingInvoiceSchedules } =
+  useGetInvoiceSchedules({
+    employmentId: internalEmploymentId as string,
+    options: {
+      queryOptions: {
+        enabled:
+          includeInvoiceSchedule &&
+          stepState.currentStep.name === 'invoice_schedule' &&
+          Boolean(internalEmploymentId),
+      },
+    },
+  });
+
+// 2. Add to initialLoading aggregation
+const initialLoading =
+  isLoadingCountries ||
+  isLoadingBasicInformationForm ||
+  isLoadingEmployment ||
+  isLoadingContractorOnboardingDetailsForm ||
+  isLoadingContractorSubscriptions ||
+  isLoadingDocumentPreviewForm ||
+  isLoadingIR35File ||
+  isLoadingContractDocuments ||
+  isLoadingEligibilityQuestionnaire ||
+  isLoadingCreateInvoiceScheduleForm ||
+  isLoadingInvoiceSchedules;  // <-- Added here
+```

--- a/.cursor/rules/submitting-state-aggregation.mdc
+++ b/.cursor/rules/submitting-state-aggregation.mdc
@@ -1,0 +1,207 @@
+# Submitting State Aggregation Pattern
+
+## Overview
+
+When adding mutations to flow hooks (Onboarding, ContractorOnboarding, CreateCompany, etc.), you must aggregate their `.isPending` states into `isSubmitting`. This prevents double submissions and provides consistent loading states.
+
+## The mutationToPromise Pattern
+
+Most flow mutations are wrapped with `mutationToPromise()` for structured error handling.
+
+### What it does
+
+`mutationToPromise()` (from `@/src/lib/mutations.ts`) wraps a React Query mutation and returns a `mutateAsyncOrThrow` function that:
+
+- Returns a promise resolving with unwrapped data (`response.data`)
+- Rejects with structured errors (`error`, `rawError`, `normalizedErrors`, `fieldErrors`, `response`)
+- Enables type-safe error handling with `isMutationError()` type guard
+
+### Usage Pattern
+
+```typescript
+// 1. Define mutation
+const createEmploymentMutation = useCreateEmployment();
+
+// 2. Wrap with mutationToPromise
+const { mutateAsyncOrThrow: createEmploymentMutationAsync } =
+  mutationToPromise(createEmploymentMutation);
+
+// 3. Call in handlers
+try {
+  const result = await createEmploymentMutationAsync(payload);
+} catch (error) {
+  if (isMutationError(error)) {
+    console.error(error.normalizedErrors);
+  }
+}
+```
+
+### Critical: Two Variables
+
+Wrapping creates TWO variables:
+
+1. **Original mutation** (`createEmploymentMutation`) - Has `.isPending`, `.isSuccess`, etc.
+2. **Wrapped function** (`createEmploymentMutationAsync`) - Only has the `mutateAsyncOrThrow` function
+
+**Always use the ORIGINAL mutation for `.isPending`** — the wrapped function doesn't have it!
+
+## Aggregating isSubmitting
+
+After defining (and optionally wrapping) your mutations, aggregate ALL their `.isPending` states:
+
+```typescript
+// Define mutations
+const createEmploymentMutation = useCreateEmployment();
+const updateEmploymentMutation = useUpdateEmployment();
+const signContractMutation = useSignContract();
+
+// Wrap with mutationToPromise (optional, for error handling)
+const { mutateAsyncOrThrow: createEmploymentMutationAsync } =
+  mutationToPromise(createEmploymentMutation);
+const { mutateAsyncOrThrow: updateEmploymentMutationAsync } =
+  mutationToPromise(updateEmploymentMutation);
+const { mutateAsyncOrThrow: signContractMutationAsync } =
+  mutationToPromise(signContractMutation);
+
+// Aggregate isSubmitting - use ORIGINAL mutations
+isSubmitting:
+  createEmploymentMutation.isPending ||  // ✅ Original mutation
+  updateEmploymentMutation.isPending ||   // ✅ Original mutation
+  signContractMutation.isPending,         // ✅ Original mutation
+```
+
+## Why This Matters
+
+- **Prevents double submissions** - Submit buttons are disabled during mutations
+- **Consistent UX** - Flow bag exposes `isSubmitting` for loading indicators
+- **Avoids race conditions** - Only one mutation at a time
+
+## Quick Checklist
+
+When adding a new mutation:
+
+- [ ] Define mutation using custom hook
+- [ ] Wrap with `mutationToPromise()` if you need structured error handling
+- [ ] Add **original mutation's** `.isPending` to `isSubmitting` aggregation
+- [ ] Use `mutateAsyncOrThrow` (from wrapped function) in handlers
+
+## Real Example: ContractorOnboarding
+
+```typescript
+import { mutationToPromise, isMutationError } from '@/src/lib/mutations';
+
+// Define all mutations
+const createEmploymentMutation = useCreateEmployment();
+const updateEmploymentMutation = useUpdateEmployment();
+const createContractDocumentMutation = useCreateContractorContractDocument();
+const signContractDocumentMutation = useSignContractDocument();
+const uploadFileMutation = useUploadFile();
+const createInvoiceScheduleMutation = useCreateInvoiceSchedule();
+const updateInvoiceScheduleMutation = useUpdateInvoiceSchedule();
+
+// Wrap with mutationToPromise for error handling
+const { mutateAsyncOrThrow: createEmploymentMutationAsync } =
+  mutationToPromise(createEmploymentMutation);
+const { mutateAsyncOrThrow: updateEmploymentMutationAsync } =
+  mutationToPromise(updateEmploymentMutation);
+const { mutateAsyncOrThrow: createContractDocumentMutationAsync } =
+  mutationToPromise(createContractDocumentMutation);
+const { mutateAsyncOrThrow: signContractDocumentMutationAsync } =
+  mutationToPromise(signContractDocumentMutation);
+const { mutateAsyncOrThrow: createInvoiceScheduleMutationAsync } =
+  mutationToPromise(createInvoiceScheduleMutation);
+const { mutateAsyncOrThrow: updateInvoiceScheduleMutationAsync } =
+  mutationToPromise(updateInvoiceScheduleMutation);
+
+// Aggregate isSubmitting - use ORIGINAL mutations
+return {
+  isSubmitting:
+    createEmploymentMutation.isPending ||
+    updateEmploymentMutation.isPending ||
+    createContractDocumentMutation.isPending ||
+    signContractDocumentMutation.isPending ||
+    uploadFileMutation.isPending ||
+    createInvoiceScheduleMutation.isPending ||
+    updateInvoiceScheduleMutation.isPending,
+};
+```
+
+## Common Mistakes
+
+### ❌ Using Wrapped Function for isPending
+
+```typescript
+const createEmploymentMutation = useCreateEmployment();
+const { mutateAsyncOrThrow: createEmploymentMutationAsync } =
+  mutationToPromise(createEmploymentMutation);
+
+// ❌ WRONG - wrapped function doesn't have isPending
+isSubmitting: createEmploymentMutationAsync.isPending;
+
+// ✅ CORRECT - use original mutation
+isSubmitting: createEmploymentMutation.isPending;
+```
+
+### ❌ Forgetting to Add New Mutation
+
+```typescript
+// Added new mutation
+const createInvoiceScheduleMutation = useCreateInvoiceSchedule();
+
+// But forgot to add to isSubmitting
+isSubmitting:
+  createEmploymentMutation.isPending ||
+  updateEmploymentMutation.isPending;
+  // ❌ Missing createInvoiceScheduleMutation.isPending
+```
+
+**Result:** Users can double-submit, causing duplicate API calls.
+
+### ❌ Using .isLoading Instead of .isPending
+
+```typescript
+// ❌ WRONG - mutations use .isPending
+isSubmitting: createEmploymentMutation.isLoading;
+
+// ✅ CORRECT
+isSubmitting: createEmploymentMutation.isPending;
+```
+
+## Integration with Submit Buttons
+
+```typescript
+<button disabled={flowBag.isSubmitting}>
+  {flowBag.isSubmitting ? 'Submitting...' : 'Submit'}
+</button>
+```
+
+## When to Add a Mutation
+
+**Add if:**
+
+- ✅ User-initiated action (form submit, button click)
+- ✅ Modifies server state (POST, PATCH, PUT, DELETE)
+- ✅ Should block concurrent submissions
+
+**Don't add if:**
+
+- ❌ Background operation that shouldn't block UI
+- ❌ Read operation (use `isLoading` aggregation instead)
+- ❌ Optimistic update that completes instantly
+
+## Testing
+
+```typescript
+// 1. Submit button disabled during mutation
+expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+
+// 2. isSubmitting is true
+expect(result.current.isSubmitting).toBe(true);
+
+// 3. Multiple submissions prevented
+expect(mockMutation).toHaveBeenCalledTimes(1);
+```
+
+## Remember
+
+**Every mutation that affects flow submission must be in the `isSubmitting` aggregation.** Missing even one mutation can cause double submissions and race conditions.

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -12,6 +12,8 @@ import {
   postV1ContractorsEmploymentsEmploymentIdContractorPlusSubscription,
   postV1ContractorsEmploymentsEmploymentIdContractDocumentsContractDocumentIdSign,
   postV1ContractorInvoiceSchedules,
+  patchV1ContractorInvoiceSchedulesId2,
+  UpdateScheduleContractorInvoiceParams,
   SignContractDocument,
   getV1EmploymentsEmploymentIdContractDocuments,
   EligibilityQuestionnaireJsonSchemaResponse,
@@ -29,6 +31,7 @@ import { invoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-sch
 import { createInvoiceScheduleSchema } from '@/src/flows/ContractorOnboarding/json-schemas/createInvoiceSchedule';
 import { selectContractorSubscriptionStepSchema } from '@/src/flows/ContractorOnboarding/json-schemas/selectContractorSubscriptionStep';
 import { useContractorCurrencies } from '@/src/common/api/contractor-contract-details';
+import { INVOICE_SCHEDULE_STATUS } from '@/src/flows/ContractorOnboarding/invoiceScheduleConstants';
 import {
   JSONSchemaFormResultWithFieldsets,
   FlowOptions,
@@ -37,7 +40,7 @@ import {
 import { clearBase64Data } from '@/src/lib/utils';
 import { Client } from '@/src/client/client';
 import { createHeadlessForm } from '@/src/common/createHeadlessForm';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, queryOptions } from '@tanstack/react-query';
 import { FieldValues } from 'react-hook-form';
 import {
   contractorPlusProductIdentifier,
@@ -828,12 +831,35 @@ export const useGetCreateInvoiceScheduleSchema = ({
 };
 
 /**
- * Get the invoice schedules for the given employment id
+ * Query options factory for fetching invoice schedules by employment id
+ * @param client - The API client
+ * @param employmentId - The employment ID
+ * @returns Query options for contractor invoice schedules
+ */
+export const invoiceSchedulesOptions = (
+  client: Client,
+  employmentId: string,
+) => {
+  return queryOptions({
+    queryKey: ['contractor-invoice-schedules', employmentId] as const,
+    queryFn: async () => {
+      return getV1ContractorInvoiceSchedules({
+        client,
+        query: { employment_id: employmentId },
+      });
+    },
+  });
+};
+
+/**
+ * Get the last invoice schedule for an employment that matches specific statuses.
+ * This is used to determine if a schedule was previously created during onboarding.
+ *
  * @param employmentId - The employment ID
  * @param options - Query options
- * @returns The invoice schedules for the employment
+ * @returns The last matching invoice schedule or undefined
  */
-export const useGetInvoiceSchedules = ({
+export const useGetLastInvoiceSchedule = ({
   employmentId,
   options,
 }: {
@@ -842,16 +868,17 @@ export const useGetInvoiceSchedules = ({
 }) => {
   const { client } = useClient();
   return useQuery({
-    queryKey: ['contractor-invoice-schedules', employmentId],
-    queryFn: async () => {
-      return getV1ContractorInvoiceSchedules({
-        client: client as Client,
-        query: { employment_id: employmentId },
-      });
-    },
+    ...invoiceSchedulesOptions(client as Client, employmentId),
     enabled: options?.queryOptions?.enabled,
-    select: ({ data }) => {
-      return data?.data?.contractor_invoice_schedules;
+    select: (response) => {
+      // Find the first invoice schedule that matches the editing criteria
+      return response.data?.data?.contractor_invoice_schedules?.find(
+        (invoice) =>
+          invoice.status ===
+            INVOICE_SCHEDULE_STATUS.PENDING_CONTRACTOR_ACTION ||
+          invoice.status === INVOICE_SCHEDULE_STATUS.PROCESSING ||
+          invoice.status === INVOICE_SCHEDULE_STATUS.PENDING_COMPANY_ACTION,
+      );
     },
   });
 };
@@ -971,6 +998,56 @@ export const useCreateInvoiceSchedule = () => {
 
       return postV1ContractorInvoiceSchedules({
         client: client as Client,
+        body: payload,
+      });
+    },
+  });
+};
+
+/**
+ * Updates an existing contractor invoice schedule
+ * @param scheduleId - The invoice schedule ID
+ * @param values - The form values containing invoice schedule data
+ * @returns The updated invoice schedule
+ */
+export const useUpdateInvoiceSchedule = () => {
+  const { client } = useClient();
+  return useMutation({
+    mutationFn: async ({
+      scheduleId,
+      values,
+    }: {
+      scheduleId: string;
+      values: FieldValues;
+    }) => {
+      // Collect invoice items from form fields (item_1 through item_10)
+      const items = [];
+      for (let i = 1; i <= 10; i++) {
+        const description = values[`item_${i}_description`];
+        const amount = values[`item_${i}_amount`];
+        if (description && amount) {
+          items.push({
+            description,
+            amount: Number(amount),
+          });
+        }
+      }
+
+      const payload: UpdateScheduleContractorInvoiceParams = {
+        currency: values.currency,
+        periodicity: values.periodicity,
+        start_date: values.start_date,
+        items,
+        ...(values.number && { number: values.number }),
+        ...(values.note && { note: values.note }),
+        ...(values.nr_occurrences && {
+          nr_occurrences: Number(values.nr_occurrences),
+        }),
+      };
+
+      return patchV1ContractorInvoiceSchedulesId2({
+        client: client as Client,
+        path: { id: scheduleId },
         body: payload,
       });
     },

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -23,6 +23,7 @@ import {
   postV1ContractorsEmploymentsEmploymentIdContractorCorSubscription,
   deleteV1ContractorsEmploymentsEmploymentIdContractorCorSubscription,
   Country,
+  ContractorInvoiceScheduleCreateParams,
 } from '@/src/client';
 import { useClient } from '@/src/context';
 import { signatureSchema } from '@/src/flows/ContractorOnboarding/json-schemas/signature';
@@ -61,7 +62,10 @@ import {
 import { convertFromCents } from '@/src/components/form/utils';
 import { countriesOptions } from '@/src/common/api/countries';
 import { selectCountryStepSchema } from '@/src/flows/Onboarding/json-schemas/selectCountryStep';
-import { shouldIncludeProduct } from '@/src/flows/ContractorOnboarding/utils';
+import {
+  shouldIncludeProduct,
+  buildInvoiceSchedulePayload,
+} from '@/src/flows/ContractorOnboarding/utils';
 import { useCompanyPricingPlans, hasCompany } from '@/src/common/api/companies';
 import { useIdentity } from '@/src/common/api/identity';
 
@@ -859,7 +863,7 @@ export const invoiceSchedulesOptions = (
  * @param options - Query options
  * @returns The last matching invoice schedule or undefined
  */
-export const useGetLastInvoiceSchedule = ({
+export const useGetExistingInvoiceSchedule = ({
   employmentId,
   options,
 }: {
@@ -966,33 +970,12 @@ export const useCreateInvoiceSchedule = () => {
       employmentId: string;
       values: FieldValues;
     }) => {
-      // Collect invoice items from form fields (item_1 through item_10)
-      const items = [];
-      for (let i = 1; i <= 10; i++) {
-        const description = values[`item_${i}_description`];
-        const amount = values[`item_${i}_amount`];
-        if (description && amount != null) {
-          items.push({
-            description,
-            amount: Number(amount),
-          });
-        }
-      }
-
       const payload: BulkContractorInvoiceScheduleCreateParams = {
         contractor_invoice_schedules: [
           {
             employment_id: employmentId,
-            currency: values.currency,
-            periodicity: values.periodicity,
-            start_date: values.start_date,
-            items,
-            ...(values.number && { number: values.number }),
-            ...(values.note && { note: values.note }),
-            ...(values.nr_occurrences && {
-              nr_occurrences: Number(values.nr_occurrences),
-            }),
-          },
+            ...buildInvoiceSchedulePayload(values),
+          } as ContractorInvoiceScheduleCreateParams,
         ],
       };
 
@@ -1020,30 +1003,8 @@ export const useUpdateInvoiceSchedule = () => {
       scheduleId: string;
       values: FieldValues;
     }) => {
-      // Collect invoice items from form fields (item_1 through item_10)
-      const items = [];
-      for (let i = 1; i <= 10; i++) {
-        const description = values[`item_${i}_description`];
-        const amount = values[`item_${i}_amount`];
-        if (description && amount) {
-          items.push({
-            description,
-            amount: Number(amount),
-          });
-        }
-      }
-
-      const payload: UpdateScheduleContractorInvoiceParams = {
-        currency: values.currency,
-        periodicity: values.periodicity,
-        start_date: values.start_date,
-        items,
-        ...(values.number && { number: values.number }),
-        ...(values.note && { note: values.note }),
-        ...(values.nr_occurrences && {
-          nr_occurrences: Number(values.nr_occurrences),
-        }),
-      };
+      const payload: UpdateScheduleContractorInvoiceParams =
+        buildInvoiceSchedulePayload(values);
 
       return patchV1ContractorInvoiceSchedulesId2({
         client: client as Client,

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -6,6 +6,7 @@ import {
   getV1CompaniesCompanyIdActions,
   getV1ContractorsEmploymentsEmploymentIdContractDocumentsId,
   getV1ContractorsEmploymentsEmploymentIdContractorSubscriptions,
+  getV1ContractorInvoiceSchedules,
   ManageContractorPlusSubscriptionOperationsParams,
   postV1ContractorsEmploymentsEmploymentIdContractDocuments,
   postV1ContractorsEmploymentsEmploymentIdContractorPlusSubscription,
@@ -824,6 +825,35 @@ export const useGetCreateInvoiceScheduleSchema = ({
     data: schemaWithCurrencies,
     isLoading: isLoadingCurrencies,
   };
+};
+
+/**
+ * Get the invoice schedules for the given employment id
+ * @param employmentId - The employment ID
+ * @param options - Query options
+ * @returns The invoice schedules for the employment
+ */
+export const useGetInvoiceSchedules = ({
+  employmentId,
+  options,
+}: {
+  employmentId: string;
+  options?: { queryOptions?: { enabled?: boolean } };
+}) => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['contractor-invoice-schedules', employmentId],
+    queryFn: async () => {
+      return getV1ContractorInvoiceSchedules({
+        client: client as Client,
+        query: { employment_id: employmentId },
+      });
+    },
+    enabled: options?.queryOptions?.enabled,
+    select: ({ data }) => {
+      return data?.data?.contractor_invoice_schedules;
+    },
+  });
 };
 
 export const useCountriesSchemaField = (

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -847,10 +847,16 @@ export const invoiceSchedulesOptions = (
   return queryOptions({
     queryKey: ['contractor-invoice-schedules', employmentId] as const,
     queryFn: async () => {
-      return getV1ContractorInvoiceSchedules({
+      const response = await getV1ContractorInvoiceSchedules({
         client,
         query: { employment_id: employmentId },
       });
+
+      if (response.error || !response.data) {
+        throw new Error('Failed to fetch invoice schedules');
+      }
+
+      return response;
     },
   });
 };

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -711,6 +711,7 @@ export const useContractorOnboarding = ({
   const {
     data: existingInvoiceSchedule,
     isLoading: isLoadingInvoiceSchedules,
+    refetch: refetchInvoiceSchedule,
   } = useGetLastInvoiceSchedule({
     employmentId: internalEmploymentId as string,
     options: {
@@ -1518,6 +1519,7 @@ export const useContractorOnboarding = ({
             scheduleId: existingInvoiceSchedule.id,
             values: parsedValues,
           });
+          await refetchInvoiceSchedule();
           return response;
         }
 
@@ -1531,6 +1533,7 @@ export const useContractorOnboarding = ({
           throw createStructuredError('Failed to create invoice schedule');
         }
 
+        await refetchInvoiceSchedule();
         return response;
       }
 

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -33,10 +33,10 @@ import {
   useSetContractOrigin,
   useGetContractOriginSchema,
   useGetInvoiceScheduleSchema,
-  useGetLastInvoiceSchedule,
   useGetCreateInvoiceScheduleSchema,
   useCreateInvoiceSchedule,
   useUpdateInvoiceSchedule,
+  useGetExistingInvoiceSchedule,
 } from '@/src/flows/ContractorOnboarding/api';
 import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
@@ -712,7 +712,7 @@ export const useContractorOnboarding = ({
     data: existingInvoiceSchedule,
     isLoading: isLoadingInvoiceSchedules,
     refetch: refetchInvoiceSchedule,
-  } = useGetLastInvoiceSchedule({
+  } = useGetExistingInvoiceSchedule({
     employmentId: internalEmploymentId as string,
     options: {
       queryOptions: {
@@ -893,14 +893,11 @@ export const useContractorOnboarding = ({
         nr_occurrences: existingInvoiceSchedule.nr_occurrences,
       };
 
-      // Map items array to form fields (item_1, item_2, etc.)
-      existingInvoiceSchedule.items?.forEach(
-        (item: $TSFixMe, index: number) => {
-          const itemNumber = index + 1;
-          formValues[`item_${itemNumber}_description`] = item.description;
-          formValues[`item_${itemNumber}_amount`] = item.amount;
-        },
-      );
+      existingInvoiceSchedule.items?.forEach((item, index: number) => {
+        const itemNumber = index + 1;
+        formValues[`item_${itemNumber}_description`] = item.description;
+        formValues[`item_${itemNumber}_amount`] = item.amount;
+      });
 
       return getInitialValues(stepFields.create_invoice_schedule, formValues);
     }
@@ -1842,7 +1839,8 @@ export const useContractorOnboarding = ({
       manageContractorCorSubscriptionMutation.isPending ||
       deleteContractorCorSubscriptionMutation.isPending ||
       setContractOriginMutation.isPending ||
-      createInvoiceScheduleMutation.isPending,
+      createInvoiceScheduleMutation.isPending ||
+      updateInvoiceScheduleMutation.isPending,
 
     /**
      * Document preview PDF data

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -33,9 +33,10 @@ import {
   useSetContractOrigin,
   useGetContractOriginSchema,
   useGetInvoiceScheduleSchema,
-  useGetInvoiceSchedules,
+  useGetLastInvoiceSchedule,
   useGetCreateInvoiceScheduleSchema,
   useCreateInvoiceSchedule,
+  useUpdateInvoiceSchedule,
 } from '@/src/flows/ContractorOnboarding/api';
 import { useContractorContractDetailsSchema } from '@/src/common/api/contractor-contract-details';
 import {
@@ -274,6 +275,7 @@ export const useContractorOnboarding = ({
     usePostManageContractorCorSubscription();
   const setContractOriginMutation = useSetContractOrigin();
   const createInvoiceScheduleMutation = useCreateInvoiceSchedule();
+  const updateInvoiceScheduleMutation = useUpdateInvoiceSchedule();
 
   const { mutateAsyncOrThrow: updateEmploymentMutationAsync } =
     mutationToPromise(updateEmploymentMutation);
@@ -309,6 +311,9 @@ export const useContractorOnboarding = ({
 
   const { mutateAsyncOrThrow: createInvoiceScheduleMutationAsync } =
     mutationToPromise(createInvoiceScheduleMutation);
+
+  const { mutateAsyncOrThrow: updateInvoiceScheduleMutationAsync } =
+    mutationToPromise(updateInvoiceScheduleMutation);
 
   // if the employment is loaded, country code has not been set yet
   // we set the internal country code with the employment country code
@@ -703,20 +708,17 @@ export const useContractorOnboarding = ({
     jsfModify: options?.jsfModify?.invoice_schedule,
   });
 
-  const { data: invoiceSchedules, isLoading: isLoadingInvoiceSchedules } =
-    useGetInvoiceSchedules({
-      employmentId: internalEmploymentId as string,
-      options: {
-        queryOptions: {
-          enabled:
-            includeInvoiceSchedule &&
-            stepState.currentStep.name === 'invoice_schedule' &&
-            Boolean(internalEmploymentId),
-        },
+  const {
+    data: existingInvoiceSchedule,
+    isLoading: isLoadingInvoiceSchedules,
+  } = useGetLastInvoiceSchedule({
+    employmentId: internalEmploymentId as string,
+    options: {
+      queryOptions: {
+        enabled: includeInvoiceSchedule && Boolean(internalEmploymentId),
       },
-    });
-
-  console.log('invoiceSchedules', invoiceSchedules);
+    },
+  });
 
   const {
     data: createInvoiceScheduleForm,
@@ -879,11 +881,38 @@ export const useContractorOnboarding = ({
   }, [stepFields.invoice_schedule, onboardingInitialValues]);
 
   const createInvoiceScheduleInitialValues = useMemo(() => {
+    // If an existing schedule exists, transform it to form values
+    if (existingInvoiceSchedule) {
+      const formValues: Record<string, unknown> = {
+        currency: existingInvoiceSchedule.currency,
+        periodicity: existingInvoiceSchedule.periodicity,
+        start_date: existingInvoiceSchedule.start_date,
+        number: existingInvoiceSchedule.number,
+        note: existingInvoiceSchedule.note,
+        nr_occurrences: existingInvoiceSchedule.nr_occurrences,
+      };
+
+      // Map items array to form fields (item_1, item_2, etc.)
+      existingInvoiceSchedule.items?.forEach(
+        (item: $TSFixMe, index: number) => {
+          const itemNumber = index + 1;
+          formValues[`item_${itemNumber}_description`] = item.description;
+          formValues[`item_${itemNumber}_amount`] = item.amount;
+        },
+      );
+
+      return formValues;
+    }
+
     const initialValues = {
       ...onboardingInitialValues,
     };
     return getInitialValues(stepFields.create_invoice_schedule, initialValues);
-  }, [stepFields.create_invoice_schedule, onboardingInitialValues]);
+  }, [
+    stepFields.create_invoice_schedule,
+    onboardingInitialValues,
+    existingInvoiceSchedule,
+  ]);
 
   const contractDetailsInitialValues = useMemo(() => {
     const hardcodedValues = {
@@ -1479,8 +1508,25 @@ export const useContractorOnboarding = ({
       }
 
       case 'create_invoice_schedule': {
+<<<<<<< HEAD
         const response = await createInvoiceScheduleMutationAsync({
           employmentId: internalEmploymentId as string,
+=======
+        if (!internalEmploymentId) {
+          throw createStructuredError('Employment ID is required');
+        }
+
+        // Use update if we have an existing schedule, otherwise create
+        if (existingInvoiceSchedule?.id) {
+          return updateInvoiceScheduleMutationAsync({
+            scheduleId: existingInvoiceSchedule.id,
+            values: parsedValues,
+          });
+        }
+
+        return createInvoiceScheduleMutationAsync({
+          employmentId: internalEmploymentId,
+>>>>>>> ee83ac7f (edit a scheduled invoice)
           values: parsedValues,
         });
 

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -33,6 +33,7 @@ import {
   useSetContractOrigin,
   useGetContractOriginSchema,
   useGetInvoiceScheduleSchema,
+  useGetInvoiceSchedules,
   useGetCreateInvoiceScheduleSchema,
   useCreateInvoiceSchedule,
 } from '@/src/flows/ContractorOnboarding/api';
@@ -702,6 +703,21 @@ export const useContractorOnboarding = ({
     jsfModify: options?.jsfModify?.invoice_schedule,
   });
 
+  const { data: invoiceSchedules, isLoading: isLoadingInvoiceSchedules } =
+    useGetInvoiceSchedules({
+      employmentId: internalEmploymentId as string,
+      options: {
+        queryOptions: {
+          enabled:
+            includeInvoiceSchedule &&
+            stepState.currentStep.name === 'invoice_schedule' &&
+            Boolean(internalEmploymentId),
+        },
+      },
+    });
+
+  console.log('invoiceSchedules', invoiceSchedules);
+
   const {
     data: createInvoiceScheduleForm,
     isLoading: isLoadingCreateInvoiceScheduleForm,
@@ -973,7 +989,8 @@ export const useContractorOnboarding = ({
     isLoadingIR35File ||
     isLoadingContractDocuments ||
     isLoadingEligibilityQuestionnaire ||
-    isLoadingCreateInvoiceScheduleForm;
+    isLoadingCreateInvoiceScheduleForm ||
+    isLoadingInvoiceSchedules;
 
   const isNavigatingToReview = useMemo(() => {
     const isCor = employment?.contractor_type === 'cor';

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1508,29 +1508,24 @@ export const useContractorOnboarding = ({
       }
 
       case 'create_invoice_schedule': {
-<<<<<<< HEAD
-        const response = await createInvoiceScheduleMutationAsync({
-          employmentId: internalEmploymentId as string,
-=======
         if (!internalEmploymentId) {
           throw createStructuredError('Employment ID is required');
         }
 
         // Use update if we have an existing schedule, otherwise create
         if (existingInvoiceSchedule?.id) {
-          return updateInvoiceScheduleMutationAsync({
+          const response = await updateInvoiceScheduleMutationAsync({
             scheduleId: existingInvoiceSchedule.id,
             values: parsedValues,
           });
+          return response;
         }
 
-        return createInvoiceScheduleMutationAsync({
+        const response = await createInvoiceScheduleMutationAsync({
           employmentId: internalEmploymentId,
->>>>>>> ee83ac7f (edit a scheduled invoice)
           values: parsedValues,
         });
 
-        // Check for failures in the bulk response
         const failures = response?.data?.failures;
         if (failures && failures.length > 0) {
           throw createStructuredError('Failed to create invoice schedule');

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -902,7 +902,7 @@ export const useContractorOnboarding = ({
         },
       );
 
-      return formValues;
+      return getInitialValues(stepFields.create_invoice_schedule, formValues);
     }
 
     const initialValues = {

--- a/src/flows/ContractorOnboarding/invoiceScheduleConstants.ts
+++ b/src/flows/ContractorOnboarding/invoiceScheduleConstants.ts
@@ -1,0 +1,14 @@
+/**
+ * Invoice schedule status values
+ * Based on ContractorInvoiceScheduleStatus from the API
+ */
+export const INVOICE_SCHEDULE_STATUS = {
+  PENDING_CONTRACTOR_ACTION: 'pending_contractor_action',
+  PROCESSING: 'processing',
+  PENDING_COMPANY_ACTION: 'pending_company_action',
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+  COMPLETED: 'completed',
+  GENERATION_FAILED_UNRELATED_TO_WITHDRAWAL_METHOD:
+    'generation_failed_unrelated_to_withdrawal_method',
+} as const;

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -221,3 +221,54 @@ export const getBasicInformationSchemaVersion = (options?: {
     options?.jsonSchemaVersion?.employment_basic_information || DEFAULT_VERSION
   );
 };
+
+/**
+ * Builds invoice items array from form values
+ * Collects up to 10 invoice items (item_1 through item_10)
+ * @param values - Form values containing item_N_description and item_N_amount fields
+ * @returns Array of invoice items with description and amount
+ */
+export function buildInvoiceItems(values: Record<string, unknown>) {
+  const items = [];
+  for (let i = 1; i <= 10; i++) {
+    const description = values[`item_${i}_description`];
+    const amount = values[`item_${i}_amount`];
+    if (description && amount != null) {
+      items.push({
+        description,
+        amount: Number(amount),
+      });
+    }
+  }
+  return items;
+}
+
+/**
+ * Builds the base invoice schedule payload from form values
+ * @param values - Form values containing invoice schedule data
+ * @returns Invoice schedule payload object
+ */
+export function buildInvoiceSchedulePayload(
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    currency: values.currency,
+    periodicity: values.periodicity,
+    start_date: values.start_date,
+    items: buildInvoiceItems(values),
+  };
+
+  if (values.number) {
+    payload.number = values.number;
+  }
+
+  if (values.note) {
+    payload.note = values.note;
+  }
+
+  if (values.nr_occurrences) {
+    payload.nr_occurrences = Number(values.nr_occurrences);
+  }
+
+  return payload;
+}

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -8,11 +8,6 @@ import {
   REMOTE_AI_SERVICES_AND_DELIVERABLES_COR_ERROR_MESSAGE,
 } from '@/src/flows/ContractorOnboarding/constants';
 import { Employment } from '@/src/flows/Onboarding/types';
-import type {
-  ContractorInvoiceScheduleItem,
-  CurrencyCode,
-  ContractorInvoiceSchedulePeriodicity,
-} from '@/src/client';
 
 export type StepKeys =
   | 'select_country'
@@ -228,35 +223,19 @@ export const getBasicInformationSchemaVersion = (options?: {
 };
 
 /**
- * Shared invoice schedule payload type
- * Represents the common structure for both create and update operations
- */
-export type InvoiceSchedulePayload = {
-  currency: CurrencyCode;
-  periodicity: ContractorInvoiceSchedulePeriodicity;
-  start_date: string;
-  items: ContractorInvoiceScheduleItem[];
-  number?: string;
-  note?: string;
-  nr_occurrences?: number;
-};
-
-/**
  * Builds invoice items array from form values
  * Collects up to 10 invoice items (item_1 through item_10)
  * @param values - Form values containing item_N_description and item_N_amount fields
  * @returns Array of invoice items with description and amount
  */
-export function buildInvoiceItems(
-  values: Record<string, unknown>,
-): ContractorInvoiceScheduleItem[] {
-  const items: ContractorInvoiceScheduleItem[] = [];
+export function buildInvoiceItems(values: Record<string, unknown>) {
+  const items = [];
   for (let i = 1; i <= 10; i++) {
     const description = values[`item_${i}_description`];
     const amount = values[`item_${i}_amount`];
     if (typeof description === 'string' && typeof amount === 'number') {
       items.push({
-        description: description,
+        description,
         amount: amount,
       });
     }
@@ -271,11 +250,11 @@ export function buildInvoiceItems(
  */
 export function buildInvoiceSchedulePayload(
   values: Record<string, unknown>,
-): InvoiceSchedulePayload {
-  const payload: InvoiceSchedulePayload = {
-    currency: values.currency as CurrencyCode,
-    periodicity: values.periodicity as ContractorInvoiceSchedulePeriodicity,
-    start_date: values.start_date as string,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    currency: values.currency,
+    periodicity: values.periodicity,
+    start_date: values.start_date,
     items: buildInvoiceItems(values),
   };
 
@@ -284,7 +263,7 @@ export function buildInvoiceSchedulePayload(
   }
 
   if (values.note) {
-    payload.note = String(values.note);
+    payload.note = values.note;
   }
 
   if (values.nr_occurrences) {

--- a/src/flows/ContractorOnboarding/utils.ts
+++ b/src/flows/ContractorOnboarding/utils.ts
@@ -8,6 +8,11 @@ import {
   REMOTE_AI_SERVICES_AND_DELIVERABLES_COR_ERROR_MESSAGE,
 } from '@/src/flows/ContractorOnboarding/constants';
 import { Employment } from '@/src/flows/Onboarding/types';
+import type {
+  ContractorInvoiceScheduleItem,
+  CurrencyCode,
+  ContractorInvoiceSchedulePeriodicity,
+} from '@/src/client';
 
 export type StepKeys =
   | 'select_country'
@@ -223,20 +228,36 @@ export const getBasicInformationSchemaVersion = (options?: {
 };
 
 /**
+ * Shared invoice schedule payload type
+ * Represents the common structure for both create and update operations
+ */
+export type InvoiceSchedulePayload = {
+  currency: CurrencyCode;
+  periodicity: ContractorInvoiceSchedulePeriodicity;
+  start_date: string;
+  items: ContractorInvoiceScheduleItem[];
+  number?: string;
+  note?: string;
+  nr_occurrences?: number;
+};
+
+/**
  * Builds invoice items array from form values
  * Collects up to 10 invoice items (item_1 through item_10)
  * @param values - Form values containing item_N_description and item_N_amount fields
  * @returns Array of invoice items with description and amount
  */
-export function buildInvoiceItems(values: Record<string, unknown>) {
-  const items = [];
+export function buildInvoiceItems(
+  values: Record<string, unknown>,
+): ContractorInvoiceScheduleItem[] {
+  const items: ContractorInvoiceScheduleItem[] = [];
   for (let i = 1; i <= 10; i++) {
     const description = values[`item_${i}_description`];
     const amount = values[`item_${i}_amount`];
-    if (description && amount != null) {
+    if (typeof description === 'string' && typeof amount === 'number') {
       items.push({
-        description,
-        amount: Number(amount),
+        description: description,
+        amount: amount,
       });
     }
   }
@@ -250,20 +271,20 @@ export function buildInvoiceItems(values: Record<string, unknown>) {
  */
 export function buildInvoiceSchedulePayload(
   values: Record<string, unknown>,
-): Record<string, unknown> {
-  const payload: Record<string, unknown> = {
-    currency: values.currency,
-    periodicity: values.periodicity,
-    start_date: values.start_date,
+): InvoiceSchedulePayload {
+  const payload: InvoiceSchedulePayload = {
+    currency: values.currency as CurrencyCode,
+    periodicity: values.periodicity as ContractorInvoiceSchedulePeriodicity,
+    start_date: values.start_date as string,
     items: buildInvoiceItems(values),
   };
 
   if (values.number) {
-    payload.number = values.number;
+    payload.number = String(values.number);
   }
 
   if (values.note) {
-    payload.note = values.note;
+    payload.note = String(values.note);
   }
 
   if (values.nr_occurrences) {


### PR DESCRIPTION
Add functionality to edit existing invoice, add rules to see if AI avoids missing essential stuff in isLoading and isSubmitting


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contractor onboarding billing/scheduling with create-vs-update branching and new API calls; mistakes in loading/submitting aggregation or status filtering could cause duplicate schedules or premature navigation.
> 
> **Overview**
> Adds **editing of an existing scheduled invoice** during contractor onboarding instead of always creating a new schedule when the user returns to the flow.
> 
> The flow **loads invoice schedules** for the employment and picks one in editable statuses (`pending_contractor_action`, `processing`, `pending_company_action`). The **create invoice schedule** step is **prefilled** from that record (currency, dates, line items). On submit it **PATCHes** via `useUpdateInvoiceSchedule` when an existing schedule id is present; otherwise it still **POSTs** create. Payload building is **centralized** in `buildInvoiceSchedulePayload` / `buildInvoiceItems` for create and update. After save, schedules are **refetched** so state stays aligned.
> 
> **Flow hook hygiene:** `isLoadingInvoiceSchedules` is included in `initialLoading`, and `updateInvoiceScheduleMutation.isPending` in `isSubmitting`.
> 
> Two **Cursor rules** document patterns for aggregating query `isLoading` into `initialLoading` and mutation `isPending` into `isSubmitting` in flow hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15fd4bf9c1b97ee027b93d4213514d304afca8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->