### PR TITLE
chore(e2e) - change e2e config to avoid flaky installs

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -79,22 +79,34 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
 
-      - name: Install Playwright system dependencies first
+      - name: Install Playwright system dependencies
         working-directory: ./example
         timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-            libdrm2 libdbus-1-3 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
-            libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 \
-            libcairo2 libasound2 libwayland-client0
+          # Install system dependencies using Playwright's built-in command
+          # This ensures all OS-specific and browser-specific deps are installed
+          # Works correctly for both chromium and firefox
+          # Retry with backoff in case apt-get has issues
+          for i in 1 2 3; do
+            echo "Installing system dependencies for ${{ matrix.browser }} (attempt $i of 3)"
+            if npx playwright install-deps ${{ matrix.browser }}; then
+              echo "Successfully installed system dependencies"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "System dependency installation failed, waiting $((i * 10)) seconds..."
+              sleep $((i * 10))
+            fi
+          done
+          echo "Failed to install system dependencies after 3 attempts"
+          exit 1
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./example
         timeout-minutes: 5
         run: |
+          # Install browser binaries only (deps already installed above)
           # Retry up to 3 times with exponential backoff
           for i in 1 2 3; do
             echo "Attempt $i of 3"

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -41,6 +41,7 @@ jobs:
   e2e-tests-production:
     name: E2E Tests (Production)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: deploy-nightly
     permissions:
       contents: read
@@ -66,9 +67,48 @@ jobs:
         working-directory: ./example
         run: npm ci --include=optional --ignore-scripts
 
-      - name: Install Playwright browsers
+      - name: Get Playwright version
+        id: playwright-version
         working-directory: ./example
-        run: npx playwright install ${{ matrix.browser }} --with-deps
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright system dependencies first
+        working-directory: ./example
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+            libdrm2 libdbus-1-3 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
+            libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 \
+            libcairo2 libasound2 libwayland-client0
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./example
+        timeout-minutes: 5
+        run: |
+          # Retry up to 3 times with exponential backoff
+          for i in 1 2 3; do
+            echo "Attempt $i of 3"
+            if npx playwright install ${{ matrix.browser }}; then
+              echo "Successfully installed Playwright browsers"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "Installation failed, waiting $((i * 10)) seconds before retry..."
+              sleep $((i * 10))
+            fi
+          done
+          echo "Failed to install Playwright browsers after 3 attempts"
+          exit 1
 
       - name: Download remote-flows URL
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -376,22 +376,33 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
-      - name: Install Playwright system dependencies first
+      - name: Install Playwright system dependencies
         working-directory: ./example
         timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-            libdrm2 libdbus-1-3 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
-            libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 \
-            libcairo2 libasound2 libwayland-client0
+          # Install system dependencies using Playwright's built-in command
+          # This ensures all OS-specific and browser-specific deps are installed
+          # Retry with backoff in case apt-get has issues
+          for i in 1 2 3; do
+            echo "Installing system dependencies (attempt $i of 3)"
+            if npx playwright install-deps chromium; then
+              echo "Successfully installed system dependencies"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "System dependency installation failed, waiting $((i * 10)) seconds..."
+              sleep $((i * 10))
+            fi
+          done
+          echo "Failed to install system dependencies after 3 attempts"
+          exit 1
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./example
         timeout-minutes: 5
         run: |
+          # Install browser binaries only (deps already installed above)
           # Retry up to 3 times with exponential backoff
           for i in 1 2 3; do
             echo "Attempt $i of 3"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -338,6 +338,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       [
         lint-and-format,
@@ -363,9 +364,48 @@ jobs:
         working-directory: ./example
         run: npm ci --include=optional --ignore-scripts
 
-      - name: Install Playwright
+      - name: Get Playwright version
+        id: playwright-version
         working-directory: ./example
-        run: npx playwright install chromium --with-deps
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright system dependencies first
+        working-directory: ./example
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+            libdrm2 libdbus-1-3 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
+            libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 \
+            libcairo2 libasound2 libwayland-client0
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./example
+        timeout-minutes: 5
+        run: |
+          # Retry up to 3 times with exponential backoff
+          for i in 1 2 3; do
+            echo "Attempt $i of 3"
+            if npx playwright install chromium; then
+              echo "Successfully installed Playwright browsers"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "Installation failed, waiting $((i * 10)) seconds before retry..."
+              sleep $((i * 10))
+            fi
+          done
+          echo "Failed to install Playwright browsers after 3 attempts"
+          exit 1
 
       - name: Download remote-flows URL
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
It seems with the next setup we avoid playwright from hanging, add timeouts in case it happens, retries, we cache browser installation which saves up minutes

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow configuration for Playwright setup; no application or test logic is modified, though cache key differences between PR and nightly jobs are worth a quick sanity check on first runs.
> 
> **Overview**
> Updates **PR** and **nightly E2E** GitHub Actions jobs so Playwright setup is faster and less flaky.
> 
> Both `e2e-tests` and `e2e-tests-production` now have a **30-minute job timeout**. Playwright browser binaries are **cached** under `~/.cache/ms-playwright` using a key derived from the runner OS and the `@playwright/test` version from `example/package.json` (nightly also includes the matrix **browser** in the cache key).
> 
> Installation is split: **`playwright install-deps`** runs every time (with up to three retries and backoff), while **`playwright install`** for browser binaries runs only when the cache misses, also with retries. This replaces the previous single `playwright install … --with-deps` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49d639553487eb33266240df3845c08b4bd7e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->