### PR TITLE
feat(invoice-schedule) - prefill selection

### DIFF
--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -716,7 +716,10 @@ export const useContractorOnboarding = ({
     employmentId: internalEmploymentId as string,
     options: {
       queryOptions: {
-        enabled: includeInvoiceSchedule && Boolean(internalEmploymentId),
+        enabled:
+          includeInvoiceSchedule &&
+          Boolean(internalEmploymentId) &&
+          stepState.currentStep.name === 'invoice_schedule',
       },
     },
   });

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -877,9 +877,17 @@ export const useContractorOnboarding = ({
   const invoiceScheduleInitialValues = useMemo(() => {
     const initialValues = {
       ...onboardingInitialValues,
+      // If an existing schedule exists, default to 'schedule' preference
+      ...(existingInvoiceSchedule && {
+        invoice_schedule_preference: 'schedule',
+      }),
     };
     return getInitialValues(stepFields.invoice_schedule, initialValues);
-  }, [stepFields.invoice_schedule, onboardingInitialValues]);
+  }, [
+    stepFields.invoice_schedule,
+    onboardingInitialValues,
+    existingInvoiceSchedule,
+  ]);
 
   const createInvoiceScheduleInitialValues = useMemo(() => {
     // If an existing schedule exists, transform it to form values


### PR DESCRIPTION
Prefill selection when there is selected a preexisting invoice

<img width="1080" height="642" alt="image" src="https://github.com/user-attachments/assets/c222c57e-aa1c-4a0e-8527-498fbbf299e7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and query timing only; no auth, payments, or persistence logic changes beyond initial form defaults.
> 
> **Overview**
> When contractor onboarding includes invoice schedules and the employment already has one, the **invoice schedule** step now defaults `invoice_schedule_preference` to **Create invoice schedule now** (`schedule`) instead of leaving the radio unset.
> 
> The existing-schedule API call is also gated so it runs only on the `invoice_schedule` step (not for the whole flow whenever invoice schedules are enabled), which aligns fetch timing with when that default is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a36cf997d875428f1e221265e3abcd56dac46af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->