### PR TITLE
fix(contractor-origin) - fix prefill contract origin

### DIFF
--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -769,24 +769,17 @@ export const ContractorOnboardingWithProps = ({
                 contract_origin: {
                   fields: {
                     contract_origin: (field: JSFModifyField) => {
-                      const labelOverrides: Record<string, string> = {
+                      const titleOverrides: Record<string, string> = {
                         provided_by_customer: 'Continue without an agreement',
                       };
                       return {
+                        oneOf: field?.oneOf?.map((option) => ({
+                          ...option,
+                          title: titleOverrides[option.const] ?? option.title,
+                        })),
                         'x-jsf-presentation': {
                           description:
                             "Managing your relationship with contractors is easy: your contract is fully editable in Remote with legally reviewed contract templates specific to France. After all parties sign in Remote, you're ready to go.",
-                          oneOf: field['x-jsf-presentation']?.oneOf?.map(
-                            (option: {
-                              value: string;
-                              label?: string;
-                              description?: string;
-                            }) => ({
-                              ...option,
-                              label:
-                                labelOverrides[option.value] ?? option.label,
-                            }),
-                          ),
                         },
                       };
                     },

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -768,23 +768,27 @@ export const ContractorOnboardingWithProps = ({
                 },
                 contract_origin: {
                   fields: {
-                    contract_origin: {
-                      title: 'Contract options',
-                      description:
-                        "Managing your relationship with contractors is easy: your contract is fully editable in Remote with legally reviewed contract templates specific to France. After all parties sign in Remote, you're ready to go.",
-                      oneOf: [
-                        {
-                          const: 'provided_by_remote',
-                          title: 'Contractor services agreement',
+                    contract_origin: (field: JSFModifyField) => {
+                      const labelOverrides: Record<string, string> = {
+                        provided_by_customer: 'Continue without an agreement',
+                      };
+                      return {
+                        'x-jsf-presentation': {
                           description:
-                            'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
+                            "Managing your relationship with contractors is easy: your contract is fully editable in Remote with legally reviewed contract templates specific to France. After all parties sign in Remote, you're ready to go.",
+                          oneOf: field['x-jsf-presentation']?.oneOf?.map(
+                            (option: {
+                              value: string;
+                              label?: string;
+                              description?: string;
+                            }) => ({
+                              ...option,
+                              label:
+                                labelOverrides[option.value] ?? option.label,
+                            }),
+                          ),
                         },
-                        {
-                          const: 'provided_by_customer',
-                          title: 'Continue without an agreement',
-                          description: 'Use your own agreement outside Remote.',
-                        },
-                      ],
+                      };
                     },
                   },
                 },

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -774,7 +774,7 @@ export const ContractorOnboardingWithProps = ({
                         "Managing your relationship with contractors is easy: your contract is fully editable in Remote with legally reviewed contract templates specific to France. After all parties sign in Remote, you're ready to go.",
                       oneOf: [
                         {
-                          const: 'remote_contract',
+                          const: 'provided_by_remote',
                           title: 'Contractor services agreement',
                           description:
                             'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',

--- a/example/src/ContractorOnboarding.tsx
+++ b/example/src/ContractorOnboarding.tsx
@@ -774,7 +774,7 @@ export const ContractorOnboardingWithProps = ({
                         "Managing your relationship with contractors is easy: your contract is fully editable in Remote with legally reviewed contract templates specific to France. After all parties sign in Remote, you're ready to go.",
                       oneOf: [
                         {
-                          const: 'provided_by_remote',
+                          const: 'remote_contract',
                           title: 'Contractor services agreement',
                           description:
                             'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',

--- a/src/common/api/employment.ts
+++ b/src/common/api/employment.ts
@@ -1,6 +1,8 @@
 import {
   getV1EmploymentsEmploymentId,
   GetV1EmploymentsEmploymentIdResponse,
+  getV2EmploymentsEmploymentIdBasicInformation,
+  GetV2EmploymentsEmploymentIdBasicInformationResponse,
   postV1CancelOnboardingEmploymentId,
 } from '@/src/client';
 import { useClient } from '@/src/context';
@@ -40,6 +42,45 @@ export const useEmploymentQuery = ({
         },
         path: { employment_id: employmentId },
         query: queryParams,
+      });
+    },
+    enabled: !!employmentId && enabled,
+    select: ({ data }) => data?.data?.employment,
+  });
+};
+
+/**
+ * Hook to retrieve basic information for a specific employment ID from the v2 endpoint.
+ *
+ * This endpoint returns a subset of employment data including contract_origin,
+ * which is not available in the v1 full employment endpoint.
+ *
+ * @param {Object} params - The parameters for the query.
+ * @param {string} params.employmentId - The ID of the employment to fetch basic information for.
+ * @param {boolean} params.enabled - Optional. Set to `false` to skip the query.
+ * @returns {UseQueryResult<any, unknown>} - The result of the query, including the basic information.
+ */
+export const useBasicInformationQuery = ({
+  employmentId,
+  enabled = true,
+}: {
+  employmentId: string;
+  enabled?: boolean;
+}): UseQueryResult<
+  GetV2EmploymentsEmploymentIdBasicInformationResponse['data']['employment'],
+  unknown
+> => {
+  const { client } = useClient();
+  return useQuery({
+    queryKey: ['employment', employmentId, 'basic-information'],
+    retry: false,
+    queryFn: () => {
+      return getV2EmploymentsEmploymentIdBasicInformation({
+        client: client as Client,
+        headers: {
+          Authorization: ``,
+        },
+        path: { employment_id: employmentId },
       });
     },
     enabled: !!employmentId && enabled,

--- a/src/common/api/fixtures/employments.ts
+++ b/src/common/api/fixtures/employments.ts
@@ -1,3 +1,30 @@
+export const mockBasicInformationResponse = {
+  data: {
+    employment: {
+      id: 'fb33c6c7-941c-4316-a9ba-e12dfef05daa',
+      status: 'created',
+      type: 'contractor',
+      updated_at: '2026-08-19T10:46:17',
+      basic_information: {
+        name: 'Gabriel',
+        manager: null,
+        email: 'john.doe@example.com',
+        job_title: 'pm',
+        login_email: 'personal',
+        provisional_start_date: '2025-11-26',
+        tax_servicing_countries: ['Turkey'],
+        personal_email: 'john.doe@example.com',
+        work_email: 'john.doe@remote.com',
+        seniority_date: null,
+        tax_job_category: 'operations',
+        has_seniority_date: 'no',
+      },
+      user_status: 'created',
+      contract_origin: null,
+    },
+  },
+};
+
 export const mockOnboardingReservesStatusResponse = {
   data: {
     data: {

--- a/src/flows/ContractorOnboarding/api.ts
+++ b/src/flows/ContractorOnboarding/api.ts
@@ -21,9 +21,11 @@ import {
   SubmitEligibilityQuestionnaireRequest,
   postV1ContractorsEligibilityQuestionnaire,
   postV1ContractorsEmploymentsEmploymentIdContractorCorSubscription,
+  postV1EmploymentsEmploymentIdContractOrigin,
   deleteV1ContractorsEmploymentsEmploymentIdContractorCorSubscription,
   Country,
   ContractorInvoiceScheduleCreateParams,
+  PostV1EmploymentsEmploymentIdContractOriginData,
 } from '@/src/client';
 import { useClient } from '@/src/context';
 import { signatureSchema } from '@/src/flows/ContractorOnboarding/json-schemas/signature';
@@ -728,20 +730,18 @@ export const useSetContractOrigin = () => {
       templateType,
     }: {
       employmentId: string;
-      contractOrigin: string;
-      templateType: string;
+      contractOrigin: PostV1EmploymentsEmploymentIdContractOriginData['body']['contract_origin'];
+      templateType: PostV1EmploymentsEmploymentIdContractOriginData['body']['template_type'];
     }) => {
-      return (client as Client).post({
-        url: '/v1/employments/{employment_id}/contract-origin',
-        path: { employment_id: employmentId },
+      return postV1EmploymentsEmploymentIdContractOrigin({
+        client: client as Client,
+        path: {
+          employment_id: employmentId,
+        },
         body: {
           contract_origin: contractOrigin,
           template_type: templateType,
         },
-        security: [
-          { scheme: 'bearer', type: 'http' },
-          { scheme: 'bearer', type: 'http' },
-        ],
       });
     },
   });

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -387,9 +387,11 @@ export const useContractorOnboarding = ({
   const shouldIncludeContractPreview = employment?.contractor_type !== 'cor';
 
   const selectedContractOrigin =
-    (stepState.values?.contract_origin?.contract_origin as
-      | string
-      | undefined) ?? basicInformation?.contract_origin;
+    (stepState.currentStep.name === 'contract_origin'
+      ? fieldValues.contract_origin
+      : undefined) ??
+    stepState.values?.contract_origin?.contract_origin ??
+    basicInformation?.contract_origin;
 
   const isContractProvidedByCustomer =
     selectedProduct === contractorStandardProductIdentifier &&

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -109,6 +109,11 @@ const jsonSchemaToEmployment: Partial<
   employment_basic_information: 'basic_information',
 };
 
+const contractOriginMapping: Record<string, string> = {
+  remote_contract: 'provided_by_remote',
+  // Add other mappings as needed
+};
+
 export const useContractorOnboarding = ({
   countryCode,
   externalId,
@@ -386,12 +391,15 @@ export const useContractorOnboarding = ({
 
   const shouldIncludeContractPreview = employment?.contractor_type !== 'cor';
 
-  const selectedContractOrigin =
+  const rawContractOrigin =
     (stepState.currentStep.name === 'contract_origin'
       ? fieldValues.contract_origin
       : undefined) ??
     stepState.values?.contract_origin?.contract_origin ??
     basicInformation?.contract_origin;
+
+  const selectedContractOrigin =
+    contractOriginMapping[rawContractOrigin] ?? rawContractOrigin;
 
   const isContractProvidedByCustomer =
     selectedProduct === contractorStandardProductIdentifier &&
@@ -874,7 +882,9 @@ export const useContractorOnboarding = ({
   const contractOriginInitialValues = useMemo(() => {
     const initialValues = {
       ...onboardingInitialValues,
-      contract_origin: basicInformation?.contract_origin,
+      contract_origin:
+        contractOriginMapping[basicInformation?.contract_origin as string] ??
+        basicInformation?.contract_origin,
     };
     return getInitialValues(stepFields.contract_origin, initialValues);
   }, [
@@ -1484,13 +1494,20 @@ export const useContractorOnboarding = ({
       }
 
       case 'contract_origin': {
+        // provided_by_remote -> remote_contract why to mantain retrocompatibility with the backend
+        // provided_by_remote doesn't exist in the backend, so we need to map it to remote_contract
+        const contractOrigin =
+          parsedValues.contract_origin === 'provided_by_remote'
+            ? 'remote_contract'
+            : parsedValues.contract_origin;
+        const templateType =
+          parsedValues.contract_origin === 'provided_by_customer'
+            ? 'contractor_agreement'
+            : 'contractor_services_agreement';
         await setContractOriginMutationAsync({
           employmentId: internalEmploymentId as string,
-          contractOrigin: parsedValues.contract_origin,
-          templateType:
-            parsedValues.contract_origin === 'provided_by_customer'
-              ? 'contractor_agreement'
-              : 'contractor_services_agreement',
+          contractOrigin,
+          templateType,
         });
         // Refetch basic information to get the updated contract_origin from server
         await refetchBasicInformation();

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -77,7 +77,10 @@ import { transformAiErrorResponse } from '@/src/flows/ContractorOnboarding/utils
 import { AiValidationError } from '@/src/flows/ContractorOnboarding/types';
 import { useUploadFile } from '@/src/common/api/files';
 import { dataURLtoFile } from '@/src/lib/files';
-import { useEmploymentQuery } from '@/src/common/api/employment';
+import {
+  useEmploymentQuery,
+  useBasicInformationQuery,
+} from '@/src/common/api/employment';
 import { useDefaultLegalEntity } from '@/src/common/api/legal-entities';
 
 type useContractorOnboardingProps = Omit<
@@ -226,6 +229,12 @@ export const useContractorOnboarding = ({
     employmentId: internalEmploymentId as string,
     queryParams: { exclude_files: true },
   });
+
+  const { data: basicInformation, refetch: refetchBasicInformation } =
+    useBasicInformationQuery({
+      employmentId: internalEmploymentId as string,
+      enabled: !!internalEmploymentId,
+    });
 
   const defaultLegalEntity = useDefaultLegalEntity();
 
@@ -378,11 +387,12 @@ export const useContractorOnboarding = ({
   const shouldIncludeContractPreview = employment?.contractor_type !== 'cor';
 
   const selectedContractOrigin =
-    (fieldValues.contract_origin as string | undefined) ??
     (stepState.values?.contract_origin?.contract_origin as
       | string
-      | undefined) ??
-    employment?.contract_details?.contract_origin;
+      | undefined) ?? basicInformation?.contract_origin;
+
+  console.log('selectedContractOrigin', selectedContractOrigin);
+  console.log('basicInformation', basicInformation);
 
   const isContractProvidedByCustomer =
     selectedProduct === contractorStandardProductIdentifier &&
@@ -865,13 +875,13 @@ export const useContractorOnboarding = ({
   const contractOriginInitialValues = useMemo(() => {
     const initialValues = {
       ...onboardingInitialValues,
-      contract_origin: employment?.contract_details?.contract_origin,
+      contract_origin: basicInformation?.contract_origin,
     };
     return getInitialValues(stepFields.contract_origin, initialValues);
   }, [
     stepFields.contract_origin,
     onboardingInitialValues,
-    employment?.contract_details?.contract_origin,
+    basicInformation?.contract_origin,
   ]);
 
   const invoiceScheduleInitialValues = useMemo(() => {
@@ -1478,14 +1488,16 @@ export const useContractorOnboarding = ({
         // Step visibility is already reconciled reactively from the selected
         // value, so a plain next() lands on the right step (review when the
         // customer provides their own contract, otherwise eligibility /
-        // contract_details). We only persist the choice server-side here.
-        if (values.contract_origin === 'provided_by_customer') {
-          await setContractOriginMutationAsync({
-            employmentId: internalEmploymentId as string,
-            contractOrigin: 'provided_by_customer',
-            templateType: 'contractor_agreement',
-          });
-        }
+        await setContractOriginMutationAsync({
+          employmentId: internalEmploymentId as string,
+          contractOrigin: parsedValues.contract_origin,
+          templateType:
+            parsedValues.contract_origin === 'provided_by_customer'
+              ? 'contractor_agreement'
+              : 'contractor_services_agreement',
+        });
+        // Refetch basic information to get the updated contract_origin from server
+        await refetchBasicInformation();
 
         return {
           data: { contractOrigin: values.contract_origin },

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -391,9 +391,6 @@ export const useContractorOnboarding = ({
       | string
       | undefined) ?? basicInformation?.contract_origin;
 
-  console.log('selectedContractOrigin', selectedContractOrigin);
-  console.log('basicInformation', basicInformation);
-
   const isContractProvidedByCustomer =
     selectedProduct === contractorStandardProductIdentifier &&
     selectedContractOrigin === 'provided_by_customer';

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -1482,9 +1482,6 @@ export const useContractorOnboarding = ({
       }
 
       case 'contract_origin': {
-        // Step visibility is already reconciled reactively from the selected
-        // value, so a plain next() lands on the right step (review when the
-        // customer provides their own contract, otherwise eligibility /
         await setContractOriginMutationAsync({
           employmentId: internalEmploymentId as string,
           contractOrigin: parsedValues.contract_origin,

--- a/src/flows/ContractorOnboarding/hooks.tsx
+++ b/src/flows/ContractorOnboarding/hooks.tsx
@@ -114,6 +114,12 @@ const contractOriginMapping: Record<string, string> = {
   // Add other mappings as needed
 };
 
+// Inverse mapping: frontend -> backend
+const contractOriginToBackend: Record<string, string> = {
+  provided_by_remote: 'remote_contract',
+  // Add other mappings as needed
+};
+
 export const useContractorOnboarding = ({
   countryCode,
   externalId,
@@ -1494,12 +1500,11 @@ export const useContractorOnboarding = ({
       }
 
       case 'contract_origin': {
-        // provided_by_remote -> remote_contract why to mantain retrocompatibility with the backend
+        // provided_by_remote -> remote_contract to maintain retrocompatibility with the backend
         // provided_by_remote doesn't exist in the backend, so we need to map it to remote_contract
-        const contractOrigin =
-          parsedValues.contract_origin === 'provided_by_remote'
-            ? 'remote_contract'
-            : parsedValues.contract_origin;
+        const contractOrigin: $TSFixMe =
+          contractOriginToBackend[parsedValues.contract_origin] ??
+          parsedValues.contract_origin;
         const templateType =
           parsedValues.contract_origin === 'provided_by_customer'
             ? 'contractor_agreement'

--- a/src/flows/ContractorOnboarding/json-schemas/contractOrigin.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/contractOrigin.ts
@@ -5,7 +5,7 @@ export const contractOriginSchema = {
       description: '',
       oneOf: [
         {
-          const: 'remote_contract',
+          const: 'provided_by_remote',
           description:
             'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
           title: 'Contractor services agreement',

--- a/src/flows/ContractorOnboarding/json-schemas/contractOrigin.ts
+++ b/src/flows/ContractorOnboarding/json-schemas/contractOrigin.ts
@@ -5,7 +5,7 @@ export const contractOriginSchema = {
       description: '',
       oneOf: [
         {
-          const: 'provided_by_remote',
+          const: 'remote_contract',
           description:
             'Create a new terms and conditions and statement of work. This should only be used if you do not have an agreement in place with a contractor or want to renegotiate an agreement.',
           title: 'Contractor services agreement',

--- a/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
+++ b/src/flows/ContractorOnboarding/tests/ContractorOnboarding.test.tsx
@@ -52,6 +52,7 @@ import {
 import { mockBlockedEligibilityQuestionnaireResponse } from '@/src/common/api/fixtures/eligibility-questionnaire';
 import { mockContractorBasicInformationSchema } from '@/src/common/api/fixtures/contractors';
 import { PrettifiedValuesRenderer } from '@/src/tests/components/PrettifiedValuesRenderer';
+import { mockBasicInformationResponse } from '@/src/common/api/fixtures/employments';
 
 const mockOnSubmit = vi.fn();
 const mockOnSuccess = vi.fn();
@@ -1297,6 +1298,68 @@ describe('ContractorOnboardingFlow', () => {
     await waitFor(() => {
       expect(screen.getByText(customTitle)).toBeInTheDocument();
       expect(screen.queryByText('Contract options')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should preselect contract_origin when defined in basic information response', async () => {
+    const employmentId = generateUniqueEmploymentId();
+
+    server.use(
+      http.get(`*/v2/employments/${employmentId}/basic-information`, () => {
+        return HttpResponse.json({
+          ...mockBasicInformationResponse,
+          data: {
+            ...mockBasicInformationResponse.data,
+            employment: {
+              ...mockBasicInformationResponse.data.employment,
+              contract_origin: 'remote_contract',
+            },
+          },
+        });
+      }),
+    );
+
+    mockRender.mockImplementation(
+      createMockRenderImplementation(MultiStepFormWithoutCountry),
+    );
+
+    render(
+      <ContractorOnboardingFlow
+        employmentId={employmentId}
+        skipSteps={['select_country']}
+        {...defaultProps}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await screen.findByText(/Step: Basic Information/i);
+
+    await fillBasicInformation();
+
+    let nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Pricing Plan/i);
+
+    await fillContractorSubscription('Contractor Management');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('visible-steps')).toHaveTextContent(
+        'contract_origin',
+      );
+    });
+
+    nextButton = screen.getByText(/Next Step/i);
+    nextButton.click();
+
+    await screen.findByText(/Step: Contract Origin/i);
+
+    // Verify the "Contractor services agreement" option is pre-selected
+    await waitFor(() => {
+      const remoteContractRadio = screen.getByRole('radio', {
+        name: /Contractor services agreement/i,
+      });
+      expect(remoteContractRadio).toBeChecked();
     });
   });
 

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -140,5 +140,10 @@ export type JSFModifyField = {
       label?: string;
       description?: string;
     }>;
+    oneOf?: Array<{
+      value: string;
+      label?: string;
+      description?: string;
+    }>;
   };
 };

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -133,14 +133,14 @@ export type JSFModifyField = {
   description?: string;
   enum?: string[];
   type?: string;
+  oneOf?: Array<{
+    const: string;
+    title?: string;
+    description?: string;
+  }>;
   'x-jsf-presentation'?: {
     inputType?: string;
     options?: Array<{
-      value: string;
-      label?: string;
-      description?: string;
-    }>;
-    oneOf?: Array<{
       value: string;
       label?: string;
       description?: string;

--- a/src/tests/handlers.ts
+++ b/src/tests/handlers.ts
@@ -20,6 +20,7 @@ import {
 } from '@/src/common/api/fixtures/companies';
 import { mockBaseResponse } from '@/src/common/api/fixtures/base';
 import {
+  mockBasicInformationResponse,
   mockBenefitOffersResponse,
   mockBenefitOffersSchema,
   mockOnboardingReservesStatusResponse,
@@ -192,6 +193,35 @@ const createEmploymentHandler = http.post('*/v1/employments', () => {
   return HttpResponse.json(employmentCreatedResponse);
 });
 
+const basicInformationHandler = http.get(
+  '*/v2/employments/:id/basic-information',
+  ({ params }) => {
+    const employmentId = params?.id;
+
+    return HttpResponse.json({
+      ...mockBasicInformationResponse,
+      data: {
+        ...mockBasicInformationResponse.data,
+        employment: {
+          ...mockBasicInformationResponse.data.employment,
+          id: employmentId,
+        },
+      },
+    });
+  },
+);
+
+const setContractOriginHandler = http.post(
+  '*/v1/employments/*/contract-origin',
+  async ({ request }) => {
+    const body = (await request.json()) as { contract_origin: string };
+
+    return HttpResponse.json({
+      data: { contract_origin: body.contract_origin },
+    });
+  },
+);
+
 const updateEmploymentHandler = http.patch('*/v1/employments/*', () => {
   return HttpResponse.json(employmentUpdatedResponse);
 });
@@ -233,6 +263,8 @@ export const defaultHandlers = [
   contractEligibilityHandler,
   employmentHandler,
   createEmploymentHandler,
+  basicInformationHandler,
+  setContractOriginHandler,
   updateEmploymentHandler,
   updateBenefitOffersHandler,
   currencyConverterHandler,


### PR DESCRIPTION
Fix preselection of the contract_origin

Had to the next:

- Fix preselection by reading from employment v2 basic information
- Write remote_contract when provided_by_remote is selected (bidirectional mapping)
- Kept provided_by_remote in the frontend (didn't refactor) due to example usage
- Built tests for functionality
- Refactored example to avoid leaking business values
- Refactored useSetContractOrigin to use SDK function instead of Client directly


<img width="947" height="648" alt="image" src="https://github.com/user-attachments/assets/f657ad99-8a8b-40d4-a229-35b5cd392ce2" />




<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes contractor onboarding step logic and backend contract-origin persistence/mapping; incorrect mapping could mis-route users past contract details or preview, but scope is limited and covered by new tests.
> 
> **Overview**
> Fixes **contract origin** not pre-selecting when returning to contractor onboarding by loading `contract_origin` from the **v2 basic-information** employment endpoint instead of v1 employment `contract_details`.
> 
> The UI still uses `provided_by_remote` / `provided_by_customer`, while the API uses values like `remote_contract`; the flow now **maps** between those on read and write. Submitting the contract origin step **always** persists the choice (with the correct `template_type`), then refetches basic information so the form stays aligned with the server.
> 
> `setContractOrigin` uses the generated client helper instead of a manual POST. Tests and MSW handlers cover the new basic-information fetch and contract-origin preselection when the API returns `remote_contract`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd05f9af7d3648a70508808d51d4cc7648e547d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->