### PR TITLE
chore(ci) - change main e2e pipeline

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -183,9 +183,59 @@ jobs:
         working-directory: ./example
         run: npm ci --include=optional --ignore-scripts
 
-      - name: Install Playwright
+      - name: Get Playwright version
+        id: playwright-version
         working-directory: ./example
-        run: npx playwright install chromium --with-deps
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright system dependencies
+        working-directory: ./example
+        timeout-minutes: 5
+        run: |
+          # Install system dependencies using Playwright's built-in command
+          # This ensures all OS-specific and browser-specific deps are installed
+          # Retry with backoff in case apt-get has issues
+          for i in 1 2 3; do
+            echo "Installing system dependencies (attempt $i of 3)"
+            if npx playwright install-deps chromium; then
+              echo "Successfully installed system dependencies"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "System dependency installation failed, waiting $((i * 10)) seconds..."
+              sleep $((i * 10))
+            fi
+          done
+          echo "Failed to install system dependencies after 3 attempts"
+          exit 1
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./example
+        timeout-minutes: 5
+        run: |
+          # Install browser binaries only (deps already installed above)
+          # Retry up to 3 times with exponential backoff
+          for i in 1 2 3; do
+            echo "Attempt $i of 3"
+            if npx playwright install chromium; then
+              echo "Successfully installed Playwright browsers"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "Installation failed, waiting $((i * 10)) seconds before retry..."
+              sleep $((i * 10))
+            fi
+          done
+          echo "Failed to install Playwright browsers after 3 attempts"
+          exit 1
 
       - name: Download remote-flows URL
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application code, secrets handling, or runtime behavior changes beyond more reliable Playwright setup on GitHub Actions.
> 
> **Overview**
> The main branch **e2e-tests** job no longer runs a single `playwright install chromium --with-deps` step. It now resolves the `@playwright/test` version from `example/package.json`, caches browser binaries under `~/.cache/ms-playwright` keyed by OS and that version, and always installs OS deps via `playwright install-deps chromium`.
> 
> Browser binaries are installed only on a cache miss, using `playwright install chromium` (deps assumed already installed). Both the deps and browser install steps use **5-minute timeouts** and **three attempts** with increasing sleep between failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75eb19b5deddd6f6669163212f0dfb87ed14eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->