### PR TITLE
docs(cursor): Add new cursor rules to avoid diverging when writing PRs

### DIFF
--- a/.cursor/rules/component-documentation.mdc
+++ b/.cursor/rules/component-documentation.mdc
@@ -1,0 +1,75 @@
+# Component Documentation Rule
+
+## Philosophy: Keep Documentation in Sync
+
+When adding a new customizable component to the `Components` type, documentation must be updated immediately. This ensures library consumers can discover and use new customization options.
+
+## Required Updates
+
+When adding a new customizable component:
+
+### 1. Update docs/COMPONENT_CUSTOMIZATION.md
+
+Add the component type to the **"Available component types"** list (around line 92-113):
+
+```markdown
+- `componentName` - Component description
+```
+
+Add the TypeScript type to the **"and their typescript definitions"** list (around line 115-130):
+
+```markdown
+- `ComponentNameComponentProps`: For custom componentName components
+```
+
+If the component has unique props or usage patterns, add an example section similar to the existing `ZendeskTriggerButtonComponentProps` example (lines 398-467).
+
+### 2. Verify Exports
+
+Ensure the component props type is exported from:
+- `src/types/remoteFlows.ts` - Type definition
+- `src/index.tsx` - Public API export
+
+### 3. When to Update
+
+**Always check and update this documentation when:**
+- Adding a new field to `Components` type in `src/types/remoteFlows.ts`
+- Creating a new customizable component
+- Exporting a new component props type from `src/index.tsx`
+- Adding a new field type that consumers can override
+
+## Example Pattern
+
+For a new `CustomWidget` component:
+
+1. **docs/COMPONENT_CUSTOMIZATION.md** (line ~113):
+```markdown
+- `customWidget` - Custom widget component
+```
+
+2. **docs/COMPONENT_CUSTOMIZATION.md** (line ~130):
+```markdown
+- `CustomWidgetComponentProps`: For custom widget components
+```
+
+3. **Verify exports**:
+```typescript
+// src/types/remoteFlows.ts
+export type CustomWidgetComponentProps = { /* ... */ };
+
+// src/index.tsx
+export type { CustomWidgetComponentProps } from '@/src/types/remoteFlows';
+```
+
+## Red Flags
+
+If you find yourself:
+- Adding a type to `Components` without updating docs
+- Exporting a new `*ComponentProps` type without documenting it
+- Implementing a custom component without checking the docs
+
+**STOP** and update the documentation first.
+
+## Remember
+
+The documentation is the contract with library consumers. Missing documentation means features that are undiscoverable and unused.

--- a/.cursor/rules/component-pattern.mdc
+++ b/.cursor/rules/component-pattern.mdc
@@ -1,0 +1,191 @@
+# Component Pattern Rule
+
+## Philosophy: Separation of Concerns
+
+All customizable components in Remote Flows follow a consistent pattern: **main component** (logic) + **default component** (presentation). This separation enables lazy loading, reduces bundle size, and maintains consistency.
+
+## The Pattern
+
+### Structure
+
+```
+src/
+├── components/
+│   ├── form/fields/
+│   │   ├── ComponentName.tsx          # Main component with logic
+│   │   └── default/
+│   │       └── ComponentNameDefault.tsx  # Default implementation
+│   └── shared/
+│       └── feature-name/
+│           ├── ComponentName.tsx
+│           └── default/
+│               └── ComponentNameDefault.tsx
+```
+
+### Main Component (Logic)
+
+**Example**: `ForcedValueField.tsx`
+
+```typescript
+import { useFormFields } from '@/src/context';
+
+export function ComponentName(props) {
+  const { components } = useFormFields();
+  
+  // Business logic here
+  const processedData = /* ... */;
+  
+  const Component = components?.componentName;
+  
+  if (!Component) {
+    throw new Error(`Component not found for field ${name}`);
+  }
+  
+  return <Component fieldData={processedData} />;
+}
+```
+
+**Responsibilities:**
+- Business logic and data processing
+- Context consumption
+- Component resolution via `useFormFields()`
+- Error handling (throw if component not found)
+- **NO inline rendering** of default UI
+
+### Default Component (Presentation)
+
+**Example**: `ForcedValueFieldDefault.tsx`
+
+```typescript
+import { ComponentNameComponentProps } from '@/src/types/remoteFlows';
+
+export function ComponentNameDefault({ fieldData }: ComponentNameComponentProps) {
+  return (
+    <div>
+      {/* Pure presentation - no business logic */}
+    </div>
+  );
+}
+```
+
+**Responsibilities:**
+- Pure presentation component
+- Receives props from main component
+- No context consumption
+- No business logic
+- Lives in `default/` subdirectory
+
+### Lazy Loading Registration
+
+**Always add to** `src/lazy-default-components.ts`:
+
+```typescript
+export const lazyDefaultComponents: Components = {
+  componentName: lazy(() =>
+    import('./components/path/to/default/ComponentNameDefault').then((m) => ({
+      default: m.ComponentNameDefault,
+    })),
+  ),
+  // ... other components
+};
+```
+
+## Complete Implementation Checklist
+
+When adding a new customizable component:
+
+### 1. Component Files
+- [ ] Create `ComponentName.tsx` with business logic
+- [ ] Create `default/ComponentNameDefault.tsx` with presentation
+- [ ] Main component uses `useFormFields()` to get custom component
+- [ ] Main component throws error if component not found
+- [ ] No inline default rendering in main component
+
+### 2. Type Definitions
+- [ ] Export `ComponentNameComponentProps` in `src/types/remoteFlows.ts`
+- [ ] Add `componentName?: React.ComponentType<ComponentNameComponentProps>` to `Components` type
+- [ ] Export props type from `src/index.tsx`
+
+### 3. Lazy Loading
+- [ ] Add to `src/lazy-default-components.ts` using `React.lazy()`
+- [ ] Import path points to Default component file
+- [ ] Test that import path is correct
+
+### 4. Documentation
+- [ ] Update `docs/COMPONENT_CUSTOMIZATION.md` (see component-documentation.mdc)
+
+### 5. Tests
+- [ ] Create test file in `tests/` subdirectory
+- [ ] Test default rendering
+- [ ] Test custom component override
+- [ ] Test props are passed correctly
+- [ ] Use `TestProviders` with custom components prop
+
+### 6. Validation
+- [ ] Run `npm run format`
+- [ ] Run `npm run lint`
+- [ ] Run `npm run type-check`
+- [ ] Run `npm test`
+
+## Examples from Codebase
+
+### Good Examples
+
+**ForcedValueField** (lines 1-67):
+- Main component: `src/components/form/fields/ForcedValueField.tsx`
+- Default: `src/components/form/fields/default/ForcedValueFieldDefault.tsx`
+- Lazy: `src/lazy-default-components.ts` (lines 63-69)
+
+**ZendeskDrawer** (lines 1-47):
+- Main component: `src/components/shared/zendesk-drawer/ZendeskDrawer.tsx`
+- Default: `src/components/shared/zendesk-drawer/ZendeskDrawerDefault.tsx`
+- Follows pattern correctly
+
+### Anti-Pattern (What NOT to Do)
+
+```typescript
+// ❌ BAD: Inline default rendering in main component
+export function ComponentName(props) {
+  const { components } = useFormFields();
+  const CustomComponent = components?.componentName;
+  
+  if (CustomComponent) {
+    return <CustomComponent {...props} />;
+  }
+  
+  // ❌ Don't do this - create a Default component instead
+  return (
+    <div>
+      Default rendering here
+    </div>
+  );
+}
+```
+
+**Why this is bad:**
+- No lazy loading (default always included in bundle)
+- Violates separation of concerns
+- Inconsistent with codebase patterns
+- Makes testing harder
+
+## Why This Matters
+
+1. **Bundle size**: Defaults are lazy-loaded only when needed
+2. **Consistency**: All components follow the same pattern
+3. **Maintenance**: Changes to default styling happen in one place
+4. **Testing**: Easier to test logic separately from presentation
+5. **Type safety**: Props are explicitly typed and exported
+
+## Red Flags
+
+Stop and refactor if you find yourself:
+- Writing inline JSX in the main component for default case
+- Not creating a Default component file
+- Skipping the lazy-default-components.ts registration
+- Creating a component that doesn't follow this structure
+
+## Remember
+
+**Every customizable component = Main (logic) + Default (presentation) + Lazy loading**
+
+No exceptions. This pattern is enforced by the codebase architecture and bundle size limits.


### PR DESCRIPTION
## Summary

Adds two Cursor rules that enforce consistent patterns when adding customizable components to the library.

One rule to make agents not diverge from the architecture when writing new components and the other one to make docs consistent


---

> [!NOTE]
> **Low Risk**
> Documentation-only Cursor rules; no runtime, auth, or data-handling code is changed.
> 
> **Overview**
> Adds two Cursor agent rules so new customizable components follow the existing main + default + lazy-load pattern and stay documented.
> 
> `component-pattern.mdc` requires a logic component that resolves via `useFormFields()`, a presentation `*Default` file, registration in `lazy-default-components.ts`, types/exports, tests, and no inline default UI.
> 
> `component-documentation.mdc` requires updating `docs/COMPONENT_CUSTOMIZATION.md` (available types, TS props, examples) whenever a field is added to `Components`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b52c2fc507ca3fd462230b724b923b45d0cf8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->