### PR TITLE
1.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @remoteoss/remote-flows
 
+## 1.49.0
+
+### Minor Changes
+
+- setup for cloud agents (#1247) [#1247](https://github.com/remoteoss/remote-flows/pull/1247)
+- extract contract details schema hook to common/api (#1245) [#1245](https://github.com/remoteoss/remote-flows/pull/1245)
+- add cursor rules (#1250) [#1250](https://github.com/remoteoss/remote-flows/pull/1250)
+- build intermeddiate step (#1249) [#1249](https://github.com/remoteoss/remote-flows/pull/1249)
+- tentative flaky fix (#1248) [#1248](https://github.com/remoteoss/remote-flows/pull/1248)
+- build next step to put the form in (#1252) [#1252](https://github.com/remoteoss/remote-flows/pull/1252)
+- render form (#1253) [#1253](https://github.com/remoteoss/remote-flows/pull/1253)
+- change e2e config to avoid flaky installs (#1256) [#1256](https://github.com/remoteoss/remote-flows/pull/1256)
+- edit a previous scheduled invoice (#1254) [#1254](https://github.com/remoteoss/remote-flows/pull/1254)
+- prefill selection (#1257) [#1257](https://github.com/remoteoss/remote-flows/pull/1257)
+- fix prefill contract origin (#1258) [#1258](https://github.com/remoteoss/remote-flows/pull/1258)
+- change main e2e pipeline (#1259) [#1259](https://github.com/remoteoss/remote-flows/pull/1259)
+- more options example (#1260) [#1260](https://github.com/remoteoss/remote-flows/pull/1260)
+- add tests about scheduling an invoice (#1261) [#1261](https://github.com/remoteoss/remote-flows/pull/1261)
+- Add Cursor hooks for auto-format and validation (#1263) [#1263](https://github.com/remoteoss/remote-flows/pull/1263)
+- add cursor rules for component customization patterns (#1264) [#1264](https://github.com/remoteoss/remote-flows/pull/1264)
+- Add customization support for ZendeskTriggerButton component (#1262) [#1262](https://github.com/remoteoss/remote-flows/pull/1262)
+
 ## 1.48.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,34 @@
 
 ### Minor Changes
 
-- setup for cloud agents (#1247) [#1247](https://github.com/remoteoss/remote-flows/pull/1247)
-- extract contract details schema hook to common/api (#1245) [#1245](https://github.com/remoteoss/remote-flows/pull/1245)
-- add cursor rules (#1250) [#1250](https://github.com/remoteoss/remote-flows/pull/1250)
+#### Features
+
 - build intermeddiate step (#1249) [#1249](https://github.com/remoteoss/remote-flows/pull/1249)
-- tentative flaky fix (#1248) [#1248](https://github.com/remoteoss/remote-flows/pull/1248)
 - build next step to put the form in (#1252) [#1252](https://github.com/remoteoss/remote-flows/pull/1252)
 - render form (#1253) [#1253](https://github.com/remoteoss/remote-flows/pull/1253)
-- change e2e config to avoid flaky installs (#1256) [#1256](https://github.com/remoteoss/remote-flows/pull/1256)
 - edit a previous scheduled invoice (#1254) [#1254](https://github.com/remoteoss/remote-flows/pull/1254)
 - prefill selection (#1257) [#1257](https://github.com/remoteoss/remote-flows/pull/1257)
-- fix prefill contract origin (#1258) [#1258](https://github.com/remoteoss/remote-flows/pull/1258)
-- change main e2e pipeline (#1259) [#1259](https://github.com/remoteoss/remote-flows/pull/1259)
-- more options example (#1260) [#1260](https://github.com/remoteoss/remote-flows/pull/1260)
 - add tests about scheduling an invoice (#1261) [#1261](https://github.com/remoteoss/remote-flows/pull/1261)
+- Add customization support for ZendeskTriggerButton component (#1262) [#1262](https://github.com/remoteoss/remote-flows/pull/1262)
+
+#### Fixes
+
+- fix prefill contract origin (#1258) [#1258](https://github.com/remoteoss/remote-flows/pull/1258)
+
+#### Docs
+
+- extract contract details schema hook to common/api (#1245) [#1245](https://github.com/remoteoss/remote-flows/pull/1245)
+- tentative flaky fix (#1248) [#1248](https://github.com/remoteoss/remote-flows/pull/1248)
+- change e2e config to avoid flaky installs (#1256) [#1256](https://github.com/remoteoss/remote-flows/pull/1256)
+- change main e2e pipeline (#1259) [#1259](https://github.com/remoteoss/remote-flows/pull/1259)
+
+#### Chores
+
+- setup for cloud agents (#1247) [#1247](https://github.com/remoteoss/remote-flows/pull/1247)
+- add cursor rules (#1250) [#1250](https://github.com/remoteoss/remote-flows/pull/1250)
+- more options example (#1260) [#1260](https://github.com/remoteoss/remote-flows/pull/1260)
 - Add Cursor hooks for auto-format and validation (#1263) [#1263](https://github.com/remoteoss/remote-flows/pull/1263)
 - add cursor rules for component customization patterns (#1264) [#1264](https://github.com/remoteoss/remote-flows/pull/1264)
-- Add customization support for ZendeskTriggerButton component (#1262) [#1262](https://github.com/remoteoss/remote-flows/pull/1262)
 
 ## 1.48.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.48.0",
+      "version": "1.49.0",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.49.0

### Minor Changes

#### Features

- build intermeddiate step (#1249) [#1249](https://github.com/remoteoss/remote-flows/pull/1249)
- build next step to put the form in (#1252) [#1252](https://github.com/remoteoss/remote-flows/pull/1252)
- render form (#1253) [#1253](https://github.com/remoteoss/remote-flows/pull/1253)
- edit a previous scheduled invoice (#1254) [#1254](https://github.com/remoteoss/remote-flows/pull/1254)
- prefill selection (#1257) [#1257](https://github.com/remoteoss/remote-flows/pull/1257)
- add tests about scheduling an invoice (#1261) [#1261](https://github.com/remoteoss/remote-flows/pull/1261)
- Add customization support for ZendeskTriggerButton component (#1262) [#1262](https://github.com/remoteoss/remote-flows/pull/1262)

#### Fixes

- fix prefill contract origin (#1258) [#1258](https://github.com/remoteoss/remote-flows/pull/1258)

#### Docs

- extract contract details schema hook to common/api (#1245) [#1245](https://github.com/remoteoss/remote-flows/pull/1245)
- tentative flaky fix (#1248) [#1248](https://github.com/remoteoss/remote-flows/pull/1248)
- change e2e config to avoid flaky installs (#1256) [#1256](https://github.com/remoteoss/remote-flows/pull/1256)
- change main e2e pipeline (#1259) [#1259](https://github.com/remoteoss/remote-flows/pull/1259)

#### Chores

- setup for cloud agents (#1247) [#1247](https://github.com/remoteoss/remote-flows/pull/1247)
- add cursor rules (#1250) [#1250](https://github.com/remoteoss/remote-flows/pull/1250)
- more options example (#1260) [#1260](https://github.com/remoteoss/remote-flows/pull/1260)
- Add Cursor hooks for auto-format and validation (#1263) [#1263](https://github.com/remoteoss/remote-flows/pull/1263)
- add cursor rules for component customization patterns (#1264) [#1264](https://github.com/remoteoss/remote-flows/pull/1264)

---

This release was automatically generated from conventional commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The published 1.49.0 artifact includes new invoice-scheduling flow behavior and prefill fixes, which affect user-facing onboarding paths even though this PR only bumps the version and changelog.
> 
> **Overview**
> This PR **releases `@remoteoss/remote-flows` 1.49.0** by bumping `package.json` / `package-lock.json` and adding the **1.49.0** section to `CHANGELOG.md`. There is no additional source change in the diff beyond versioning and release notes.
> 
> The changelog records the bundled work since 1.48.0, mainly **contractor invoice scheduling**: intermediate and follow-on steps, form rendering, editing an existing scheduled invoice, selection prefill, and a fix for contract-origin prefill, plus tests. **ZendeskTriggerButton** gains partner **customization** support. Other entries cover moving the contract-details schema hook to `common/api`, e2e pipeline and flaky-install tweaks, and Cursor/agent tooling chores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4593241ff9dc6964198efb368eb62b525ddb354d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->