### PR TITLE
fix(files) - set multiple to false explicitely to avoid multiple files

### DIFF
--- a/src/components/form/fields/FileUploadField.tsx
+++ b/src/components/form/fields/FileUploadField.tsx
@@ -41,7 +41,7 @@ export function FileUploadField({
   name,
   description,
   label,
-  multiple,
+  multiple = false,
   onChange,
   component,
   accept,

--- a/src/components/form/fields/tests/FileUploadField.test.tsx
+++ b/src/components/form/fields/tests/FileUploadField.test.tsx
@@ -222,7 +222,11 @@ describe('FileUploadField Component', () => {
       const methods = useForm();
       return (
         <FormProvider {...methods}>
-          <FileUploadField {...defaultProps} onChange={mockOnChange} />
+          <FileUploadField
+            multiple={true}
+            {...defaultProps}
+            onChange={mockOnChange}
+          />
         </FormProvider>
       );
     };

--- a/src/components/ui/file-uploader.tsx
+++ b/src/components/ui/file-uploader.tsx
@@ -51,10 +51,7 @@ export function FileUploader({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       const newFiles = Array.from(e.target.files);
-      // `multiple` unset keeps the historical accumulate-across-selections behavior. Only an
-      // explicit `multiple={false}` (as opposed to just not passing the prop) opts a field out
-      // of that and replaces its selection instead — see the discussion on why this can't be
-      // `!multiple` without reverting the field's own past "preserve existing files" fix.
+      // now the multiple is always a boolean, before multiple could be undefined and it would accumulate files
       const updatedFiles =
         multiple === false ? newFiles : [...files, ...newFiles];
 


### PR DESCRIPTION
Fixes the problem when multiple is undefined and we were accumulating files...

[loom](loom.com/share/95b3e5c0288549f5b35e3c62a7ee58e0?focus_title=1&muted=1&from_recorder=1)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default file-upload behavior for any field that omitted `multiple` (accumulate → replace), which may surprise existing forms until they opt in with `multiple={true}`.
> 
> **Overview**
> **File upload fields now default to single-file behavior** by setting `multiple = false` on `FileUploadField` instead of leaving `multiple` undefined.
> 
> That aligns the form field with `FileUploader`, where only `multiple === false` replaces the current selection; any other value (including `undefined` before this change) kept accumulating files across picker opens. Fields that should allow adding more files must pass **`multiple={true}`** explicitly.
> 
> The multi-file test was updated to set `multiple={true}` so it still exercises accumulation. The uploader comment was shortened to reflect that `multiple` is now always a boolean from the field layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fd84ff634f7e5ae26503671807eaf7834b4164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->