### PR TITLE
fix(deu) - fix contract details validation by using the new way to render fields

### DIFF
--- a/src/flows/Onboarding/utils.ts
+++ b/src/flows/Onboarding/utils.ts
@@ -141,7 +141,7 @@ export const DEFAULT_VERSION = 1;
  * useContractDetailsSchema instead of useJSONSchemaForm.
  * FRA = wage portage, ITA = APL.
  */
-const JSF_V1_CONTRACT_DETAILS_COUNTRIES = ['FRA', 'ITA'];
+const JSF_V1_CONTRACT_DETAILS_COUNTRIES = ['FRA', 'ITA', 'DEU'];
 
 /**
  * Checks if a country's contract details schema is served as jsfVersion 1


### PR DESCRIPTION
I believe some of the fields weren't appering, I was try to fix with other ways but at the moment the correct fix seems this one

https://www.loom.com/share/657587c57341414db91b2be04bd23581?focus_title=1&muted=1&from_recorder=1

I have the loom rambling about it, showing what was happening etc

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-country onboarding routing change with no auth or data-layer impact; behavior mirrors existing FRA/ITA handling.
> 
> **Overview**
> **Germany (DEU)** is now treated like FRA and ITA for onboarding **contract details**, so those steps use the **jsfVersion 1** path (`useContractDetailsSchema` with per-field state) instead of **`useJSONSchemaForm`**.
> 
> This aligns DEU with how wage portage and APL countries already render and validate contract details, addressing incorrect validation when DEU was on the generic JSON Schema form path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cd85c9abb9daa6d6f34ecbd1256e34ca7cd4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->