### PR TITLE
1.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @remoteoss/remote-flows
 
+## 1.49.1
+
+### Patch Changes
+
+- fix contract details validation by using the new way to validate/render fields (#1268) [#1268](https://github.com/remoteoss/remote-flows/pull/1268)
+- set multiple to false explicitely to avoid multiple files (#1267) [#1267](https://github.com/remoteoss/remote-flows/pull/1267)
+
 ## 1.49.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Patch Changes
 
+#### Fixes
+
 - fix contract details validation by using the new way to validate/render fields (#1268) [#1268](https://github.com/remoteoss/remote-flows/pull/1268)
 - set multiple to false explicitely to avoid multiple files (#1267) [#1267](https://github.com/remoteoss/remote-flows/pull/1267)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-flows",
-      "version": "1.49.0",
+      "version": "1.49.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-checkbox": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/remote-flows",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/remoteoss/remote-flows.git"


### PR DESCRIPTION
## 1.49.1

### Patch Changes

#### Fixes

- fix contract details validation by using the new way to validate/render fields (#1268) [#1268](https://github.com/remoteoss/remote-flows/pull/1268)
- set multiple to false explicitely to avoid multiple files (#1267) [#1267](https://github.com/remoteoss/remote-flows/pull/1267)

---

This release was automatically generated from conventional commits.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release bump with no code changes in the diff; risk is limited to publishing the documented fixes from prior merges.
> 
> **Overview**
> **This PR publishes patch release 1.49.1** by bumping the package version from `1.49.0` to `1.49.1` in `package.json` and `package-lock.json`, and adding the corresponding **1.49.1** section to `CHANGELOG.md`.
> 
> The changelog records two bug fixes already merged elsewhere: **contract details validation** aligned with the newer field validate/render path (#1268), and **file upload fields** defaulting `multiple` to `false` so users cannot accidentally select multiple files (#1267). There are **no application source changes** in this diff—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8987f84df04f121a5f52901f7c83be13843f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->